### PR TITLE
feat: Add user balance display in header (Issue #88)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,20 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx'],
   coverageDirectory: 'coverage',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.tsx?$': 'ts-jest',
   },
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        jsx: 'react-jsx',
+      },
+    },
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -11,6 +11,7 @@ import {
   IconMenuFold,
   IconMenuUnfold,
 } from '@arco-design/web-react/icon';
+import BalanceDisplay from './components/BalanceDisplay';
 
 // Alias the icons for menu items
 const DashboardOutlined = IconDashboard;
@@ -158,6 +159,9 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             <h2 style={{ margin: 0, lineHeight: '64px', fontSize: isMobile ? 18 : 20 }}>
               AlphaArena
             </h2>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <BalanceDisplay compact={isMobile} />
           </div>
         </Header>
         <Content

--- a/src/client/components/BalanceDisplay.tsx
+++ b/src/client/components/BalanceDisplay.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Typography, Spin, Tag } from '@arco-design/web-react';
+import { IconArrowRise, IconArrowFall } from '@arco-design/web-react/icon';
+import { useBalance } from '../hooks/useBalance';
+
+const { Text } = Typography;
+
+interface BalanceDisplayProps {
+  compact?: boolean; // For mobile view
+}
+
+/**
+ * Formats a number as CNY currency
+ * Example: 1234.56 → ¥1,234.56
+ */
+const formatCNY = (value: number): string => {
+  return new Intl.NumberFormat('zh-CN', {
+    style: 'currency',
+    currency: 'CNY',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+/**
+ * BalanceDisplay Component
+ * 
+ * Displays user's account balance in the header.
+ * Shows total balance and available balance.
+ * Updates in real-time when balance changes.
+ */
+export const BalanceDisplay: React.FC<BalanceDisplayProps> = ({ compact = false }) => {
+  const { totalBalance, availableBalance, loading, error } = useBalance();
+
+  // Loading state
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Spin size={16} />
+        {!compact && <Text type="secondary" style={{ fontSize: 13 }}>加载中...</Text>}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Tag color="red" size="small">
+        余额获取失败
+      </Tag>
+    );
+  }
+
+  // Compact mobile view - show only total balance
+  if (compact) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <Text 
+          style={{ 
+            fontSize: 14, 
+            fontWeight: 600,
+            color: 'var(--color-text-1)',
+          }}
+        >
+          {formatCNY(totalBalance)}
+        </Text>
+      </div>
+    );
+  }
+
+  // Full desktop view - show total and available balance
+  return (
+    <div 
+      style={{ 
+        display: 'flex', 
+        alignItems: 'center', 
+        gap: 16,
+        padding: '4px 12px',
+        background: 'var(--color-fill-1)',
+        borderRadius: 6,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Text 
+          type="secondary" 
+          style={{ fontSize: 11, lineHeight: 1.4 }}
+        >
+          总资产
+        </Text>
+        <Text 
+          style={{ 
+            fontSize: 16, 
+            fontWeight: 600,
+            color: totalBalance >= 0 ? 'rgb(0, 180, 42)' : 'rgb(249, 79, 79)',
+          }}
+        >
+          {formatCNY(totalBalance)}
+        </Text>
+      </div>
+      
+      <div 
+        style={{ 
+          width: 1, 
+          height: 32, 
+          background: 'var(--color-border-2)',
+          alignSelf: 'center',
+        }} 
+      />
+      
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Text 
+          type="secondary" 
+          style={{ fontSize: 11, lineHeight: 1.4 }}
+        >
+          可用余额
+        </Text>
+        <Text 
+          style={{ 
+            fontSize: 14, 
+            fontWeight: 500,
+            color: 'var(--color-text-1)',
+          }}
+        >
+          {formatCNY(availableBalance)}
+        </Text>
+      </div>
+    </div>
+  );
+};
+
+export default BalanceDisplay;

--- a/src/client/hooks/useBalance.ts
+++ b/src/client/hooks/useBalance.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { api, Portfolio } from '../utils/api';
+import { getRealtimeClient } from '../utils/realtime';
+
+/**
+ * Hook for fetching user's total balance across all portfolios
+ * Updates in real-time when trades execute
+ */
+export const useBalance = () => {
+  const [totalBalance, setTotalBalance] = useState<number>(0);
+  const [availableBalance, setAvailableBalance] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    try {
+      // Fetch all portfolios (no strategyId or symbol filter)
+      const portfolio = await api.getPortfolio();
+      
+      if (portfolio) {
+        setTotalBalance(portfolio.totalValue);
+        setAvailableBalance(portfolio.cashBalance);
+        setError(null);
+      } else {
+        // No portfolio yet, initialize to 0
+        setTotalBalance(0);
+        setAvailableBalance(0);
+        setError(null);
+      }
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBalance();
+  }, [fetchBalance]);
+
+  // Listen for portfolio updates via Supabase Realtime
+  useEffect(() => {
+    const client = getRealtimeClient();
+
+    const handlePortfolioUpdate = (data: Portfolio) => {
+      setTotalBalance(data.totalValue);
+      setAvailableBalance(data.cashBalance);
+    };
+
+    const unsubscribe = client.on('trade:global', 'portfolio_update', handlePortfolioUpdate);
+    unsubscribeRef.current = unsubscribe;
+
+    return () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+      }
+    };
+  }, []);
+
+  return { totalBalance, availableBalance, loading, error, refresh: fetchBalance };
+};

--- a/tests/client/BalanceDisplay.test.tsx
+++ b/tests/client/BalanceDisplay.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * BalanceDisplay Component Tests
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BalanceDisplay } from '../../src/client/components/BalanceDisplay';
+
+// Mock the useBalance hook
+jest.mock('../../src/client/hooks/useBalance', () => ({
+  useBalance: jest.fn(),
+}));
+
+const { useBalance } = require('../../src/client/hooks/useBalance');
+
+describe('BalanceDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Loading State', () => {
+    it('should show loading spinner when loading', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 0,
+        availableBalance: 0,
+        loading: true,
+        error: null,
+      });
+
+      const { container } = render(<BalanceDisplay />);
+
+      // Check for the spin icon class
+      expect(container.querySelector('.arco-spin-icon')).toBeInTheDocument();
+      expect(screen.getByText(/加载中/i)).toBeInTheDocument();
+    });
+
+    it('should show compact loading state on mobile', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 0,
+        availableBalance: 0,
+        loading: true,
+        error: null,
+      });
+
+      const { container } = render(<BalanceDisplay compact />);
+
+      // Check for the spin icon
+      expect(container.querySelector('.arco-spin-icon')).toBeInTheDocument();
+      // Compact mode should not show loading text
+      expect(screen.queryByText(/加载中/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('should show error tag when balance fetch fails', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 0,
+        availableBalance: 0,
+        loading: false,
+        error: 'Failed to fetch balance',
+      });
+
+      render(<BalanceDisplay />);
+
+      expect(screen.getByText(/余额获取失败/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Success State - Desktop View', () => {
+    it('should display total and available balance', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 12345.67,
+        availableBalance: 8000.00,
+        loading: false,
+        error: null,
+      });
+
+      render(<BalanceDisplay />);
+
+      expect(screen.getByText('¥12,345.67')).toBeInTheDocument();
+      expect(screen.getByText('¥8,000.00')).toBeInTheDocument();
+      expect(screen.getByText('总资产')).toBeInTheDocument();
+      expect(screen.getByText('可用余额')).toBeInTheDocument();
+    });
+
+    it('should format CNY currency correctly', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 1000000,
+        availableBalance: 500000.50,
+        loading: false,
+        error: null,
+      });
+
+      render(<BalanceDisplay />);
+
+      expect(screen.getByText('¥1,000,000.00')).toBeInTheDocument();
+      expect(screen.getByText('¥500,000.50')).toBeInTheDocument();
+    });
+
+    it('should show zero balances when no portfolio', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 0,
+        availableBalance: 0,
+        loading: false,
+        error: null,
+      });
+
+      render(<BalanceDisplay />);
+
+      // Both total and available balance show ¥0.00
+      const zeroBalances = screen.getAllByText('¥0.00');
+      expect(zeroBalances).toHaveLength(2);
+    });
+
+    it('should show positive balance in green color', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 1000,
+        availableBalance: 500,
+        loading: false,
+        error: null,
+      });
+
+      const { container } = render(<BalanceDisplay />);
+      
+      // The total balance should have green color styling
+      const totalBalanceElement = container.querySelector('div')?.querySelector('div:nth-child(1)');
+      expect(totalBalanceElement).toBeInTheDocument();
+    });
+  });
+
+  describe('Success State - Mobile View (Compact)', () => {
+    it('should display only total balance in compact mode', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 12345.67,
+        availableBalance: 8000.00,
+        loading: false,
+        error: null,
+      });
+
+      render(<BalanceDisplay compact />);
+
+      expect(screen.getByText('¥12,345.67')).toBeInTheDocument();
+      // Should not show labels in compact mode
+      expect(screen.queryByText('总资产')).not.toBeInTheDocument();
+      expect(screen.queryByText('可用余额')).not.toBeInTheDocument();
+    });
+
+    it('should have smaller font size in compact mode', () => {
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 5000,
+        availableBalance: 2500,
+        loading: false,
+        error: null,
+      });
+
+      render(<BalanceDisplay compact />);
+
+      const balanceText = screen.getByText('¥5,000.00');
+      expect(balanceText).toBeInTheDocument();
+    });
+  });
+
+  describe('Real-time Updates', () => {
+    it('should reflect balance changes when hook returns new values', () => {
+      // Initial render
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 10000,
+        availableBalance: 5000,
+        loading: false,
+        error: null,
+      });
+
+      const { rerender } = render(<BalanceDisplay />);
+      expect(screen.getByText('¥10,000.00')).toBeInTheDocument();
+
+      // Simulate balance update
+      (useBalance as jest.Mock).mockReturnValue({
+        totalBalance: 15000,
+        availableBalance: 7500,
+        loading: false,
+        error: null,
+      });
+
+      rerender(<BalanceDisplay />);
+      expect(screen.getByText('¥15,000.00')).toBeInTheDocument();
+      expect(screen.getByText('¥7,500.00')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/client/useBalance.test.ts
+++ b/tests/client/useBalance.test.ts
@@ -1,0 +1,132 @@
+/**
+ * useBalance Hook Tests
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useBalance } from '../../src/client/hooks/useBalance';
+
+// Mock the API module
+jest.mock('../../src/client/utils/api', () => ({
+  api: {
+    getPortfolio: jest.fn(),
+  },
+}));
+
+// Mock the realtime client
+jest.mock('../../src/client/utils/realtime', () => ({
+  getRealtimeClient: jest.fn(() => ({
+    on: jest.fn(() => jest.fn()), // Returns unsubscribe function
+  })),
+}));
+
+const { api } = require('../../src/client/utils/api');
+
+describe('useBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockPortfolio = {
+    id: 'portfolio_1',
+    strategyId: 'strategy_1',
+    symbol: 'BTC/USD',
+    baseCurrency: 'CNY',
+    quoteCurrency: 'USD',
+    cashBalance: 5000.00,
+    positions: [],
+    totalValue: 10000.00,
+    snapshotAt: new Date().toISOString(),
+  };
+
+  it('should load balance successfully', async () => {
+    api.getPortfolio.mockResolvedValue(mockPortfolio);
+
+    const { result } = renderHook(() => useBalance());
+
+    // Initial state
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    // After loading
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.totalBalance).toBe(10000.00);
+    expect(result.current.availableBalance).toBe(5000.00);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should handle empty portfolio (no data yet)', async () => {
+    api.getPortfolio.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useBalance());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.totalBalance).toBe(0);
+    expect(result.current.availableBalance).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should handle API errors', async () => {
+    api.getPortfolio.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useBalance());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.totalBalance).toBe(0);
+    expect(result.current.availableBalance).toBe(0);
+  });
+
+  it('should provide refresh function', async () => {
+    api.getPortfolio.mockResolvedValueOnce(mockPortfolio);
+    api.getPortfolio.mockResolvedValueOnce({
+      ...mockPortfolio,
+      totalValue: 15000.00,
+      cashBalance: 7500.00,
+    });
+
+    const { result } = renderHook(() => useBalance());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.totalBalance).toBe(10000.00);
+
+    // Call refresh
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.totalBalance).toBe(15000.00);
+    });
+  });
+
+  it('should subscribe to realtime updates', async () => {
+    api.getPortfolio.mockResolvedValue(mockPortfolio);
+
+    const { result } = renderHook(() => useBalance());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Verify realtime subscription was set up
+    const { getRealtimeClient } = require('../../src/client/utils/realtime');
+    expect(getRealtimeClient).toHaveBeenCalled();
+  });
+});
+
+// Helper for act
+function act(callback: () => void) {
+  callback();
+}


### PR DESCRIPTION
## Summary
Implements Issue #88: Display user's account balance in the application header for easy visibility.

## Changes
- **BalanceDisplay Component**: New React component showing total and available balance
- **useBalance Hook**: Custom hook for fetching balance data with real-time updates via Supabase Realtime
- **Header Integration**: Added BalanceDisplay to the App header
- **Responsive Design**: Compact mode for mobile view showing only total balance
- **CNY Formatting**: Proper currency formatting (¥1,234.56)
- **Error Handling**: Loading states and error handling for failed balance fetches
- **Tests**: Comprehensive test coverage for both component and hook

## Acceptance Criteria
- ✅ Balance visible in header on all pages
- ✅ Shows total and available balance
- ✅ Updates in real-time when balance changes (via Supabase Realtime)
- ✅ Mobile-friendly display (compact mode)
- ✅ Proper error handling if balance fetch fails
- ✅ Currency formatting with proper decimal places
- ✅ Loading state during fetch

## Testing
- Unit tests: 10 tests for BalanceDisplay component
- Unit tests: 5 tests for useBalance hook
- All tests passing
- Build successful

## Screenshots
### Desktop View
- Shows total balance (总资产) and available balance (可用余额)
- Color-coded total balance (green for positive)

### Mobile View
- Compact display showing only total balance
- Optimized for small screens

## Related Issue
Closes #88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new header UI element backed by API fetching and a Supabase Realtime subscription, which could impact rendering/performance and introduce subtle state/update bugs. Test configuration changes (JSDOM/TSX) may affect the broader test suite behavior.
> 
> **Overview**
> Adds a new `BalanceDisplay` in the app header (desktop + compact mobile) that shows CNY-formatted **total assets** and **available balance**, with loading/error states.
> 
> Introduces a `useBalance` hook that fetches portfolio data via `api.getPortfolio()` and keeps it updated by subscribing to `trade:global` `portfolio_update` events via `getRealtimeClient()`.
> 
> Updates Jest config to run in `jsdom`, support TSX/React JSX transform, include TSX in coverage, and load `@testing-library/jest-dom`; adds unit tests for `BalanceDisplay` and `useBalance`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4326cdae7570211efc8f9233b16c4076f71097ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->