### PR TITLE
fix: Add class names and test identifiers to K-line chart container

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -201,6 +201,8 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
       <Spin loading={loading} style={{ width: '100%' }}>
         <div
           ref={chartContainerRef}
+          className="kline-chart-container"
+          data-testid="kline-chart"
           style={{ height: `${adjustedHeight}px`, position: 'relative', width: '100%' }}
         >
           {klineData && klineData.length === 0 && (


### PR DESCRIPTION
## Summary

Fixes the K-line chart display issue identified in Sprint 2 retrospective where UI acceptance tests could not locate chart elements.

## Changes

- Added `kline-chart-container` class to the chart container div
- Added `data-testid="kline-chart"` attribute for automated testing
- Chart component already uses correct lightweight-charts v5.x API

## Root Cause

The acceptance test selectors were looking for classes like `chart`, `kline`, `candlestick` but the chart container had no identifying class names. The lightweight-charts library creates canvas elements dynamically without those class names.

## Testing

- Chart renders correctly with existing functionality unchanged
- UI acceptance tests should now detect chart elements via the new class name

## Related

- Fixes Issue #108
- Sprint 2 Milestone #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only a `className` and `data-testid` to the chart container with no changes to rendering logic or data flow.
> 
> **Overview**
> Adds stable DOM selectors to the K-line chart container in `KLineChart.tsx` by introducing `className="kline-chart-container"` and `data-testid="kline-chart"` so automated UI tests can reliably locate the chart element.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d813eeea28eca96cdbb4ea7491db892bd2d67117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->