### PR TITLE
Fix: K-line chart component loading error

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -61,11 +61,22 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
 
   // Initialize chart
   useEffect(() => {
-    if (!chartContainerRef.current) return;
+    if (!chartContainerRef.current) {
+      console.error('[KLineChart] Chart container ref is null');
+      return;
+    }
+
+    const container = chartContainerRef.current;
+    const containerWidth = container.clientWidth;
+    
+    if (containerWidth <= 0) {
+      console.warn('[KLineChart] Container width is 0, waiting for next render');
+      return;
+    }
 
     try {
-      const chart = createChart(chartContainerRef.current, {
-        width: chartContainerRef.current.clientWidth,
+      const chart = createChart(container, {
+        width: containerWidth,
         height: height,
         layout: {
           background: { type: 'solid', color: '#1a1a1a' },
@@ -128,10 +139,18 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
 
       return () => {
         window.removeEventListener('resize', handleResize);
-        chart.remove();
+        if (chartRef.current) {
+          chartRef.current.remove();
+          chartRef.current = null;
+        }
       };
     } catch (err: any) {
       console.error('[KLineChart] Failed to initialize chart:', err);
+      console.error('[KLineChart] Error details:', {
+        message: err.message,
+        stack: err.stack,
+        name: err.name,
+      });
       throw err; // Re-throw to be caught by ErrorBoundary
     }
   }, [height, showVolume]);


### PR DESCRIPTION
## Summary

This PR fixes the K-line chart component failing to load with '组件加载失败' error.

## Changes

- Added container ref validation before chart initialization
- Check container width is greater than 0 before creating chart
- Added detailed error logging to help debug future issues
- Properly cleanup chart instance on component unmount
- Fix potential null reference errors in chart cleanup

## Testing

- Build succeeds without errors
- Chart should now load correctly when clicking on a stock

Fixes #114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized UI robustness changes that add defensive checks and better teardown; main risk is the chart not initializing if the container briefly reports zero width.
> 
> **Overview**
> Prevents `KLineChart` from failing to mount by validating the chart container ref and skipping initialization when the container width is `0` (with targeted console logging).
> 
> Improves lifecycle safety by removing the chart via `chartRef.current.remove()` during cleanup and adding richer error diagnostics when chart initialization fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d6402b0c395bf854fb23044f85bae5306c25159. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->