### PR TITLE
fix: Use ResizeObserver to initialize K-line chart when container becomes available

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -67,92 +67,124 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
     }
 
     const container = chartContainerRef.current;
-    const containerWidth = container.clientWidth;
     
-    if (containerWidth <= 0) {
-      console.warn('[KLineChart] Container width is 0, waiting for next render');
-      return;
-    }
+    // Function to initialize chart with proper width
+    const initializeChart = () => {
+      const containerWidth = container.clientWidth;
+      
+      if (containerWidth <= 0) {
+        console.warn('[KLineChart] Container width is still 0, will retry...');
+        return false;
+      }
 
-    try {
-      const chart = createChart(container, {
-        width: containerWidth,
-        height: height,
-        layout: {
-          background: { type: 'solid', color: '#1a1a1a' },
-          textColor: '#d1d4dc',
-        },
-        grid: {
-          vertLines: { color: '#2B2B43' },
-          horzLines: { color: '#2B2B43' },
-        },
-        crosshair: {
-          mode: 1, // MagnetMode
-        },
-        timeScale: {
-          borderColor: '#2B2B43',
-          timeVisible: true,
-          secondsVisible: false,
-        },
-      });
-
-      chartRef.current = chart;
-
-      // Create candlestick series - lightweight-charts v5.x API
-      const candleSeries = chart.addSeries(CandlestickSeries, {
-        upColor: '#26a69a',
-        downColor: '#ef5350',
-        borderVisible: false,
-        wickUpColor: '#26a69a',
-        wickDownColor: '#ef5350',
-      });
-
-      candleSeriesRef.current = candleSeries;
-
-      // Create volume series (overlay at bottom)
-      if (showVolume) {
-        const volumeSeries = chart.addSeries(HistogramSeries, {
-          color: '#26a69a',
-          priceFormat: {
-            type: 'volume',
+      try {
+        const chart = createChart(container, {
+          width: containerWidth,
+          height: height,
+          layout: {
+            background: { type: 'solid', color: '#1a1a1a' },
+            textColor: '#d1d4dc',
           },
-          priceScaleId: '', // Overlay on main chart
-          scaleMargins: {
-            top: 0.8, // Push to bottom
-            bottom: 0,
+          grid: {
+            vertLines: { color: '#2B2B43' },
+            horzLines: { color: '#2B2B43' },
+          },
+          crosshair: {
+            mode: 1, // MagnetMode
+          },
+          timeScale: {
+            borderColor: '#2B2B43',
+            timeVisible: true,
+            secondsVisible: false,
           },
         });
 
-        volumeSeriesRef.current = volumeSeries;
-      }
+        chartRef.current = chart;
 
-      // Handle resize
-      const handleResize = () => {
-        if (chartContainerRef.current && chartRef.current) {
-          chartRef.current.applyOptions({
-            width: chartContainerRef.current.clientWidth,
+        // Create candlestick series - lightweight-charts v5.x API
+        const candleSeries = chart.addSeries(CandlestickSeries, {
+          upColor: '#26a69a',
+          downColor: '#ef5350',
+          borderVisible: false,
+          wickUpColor: '#26a69a',
+          wickDownColor: '#ef5350',
+        });
+
+        candleSeriesRef.current = candleSeries;
+
+        // Create volume series (overlay at bottom)
+        if (showVolume) {
+          const volumeSeries = chart.addSeries(HistogramSeries, {
+            color: '#26a69a',
+            priceFormat: {
+              type: 'volume',
+            },
+            priceScaleId: '', // Overlay on main chart
+            scaleMargins: {
+              top: 0.8, // Push to bottom
+              bottom: 0,
+            },
           });
+
+          volumeSeriesRef.current = volumeSeries;
         }
-      };
 
-      window.addEventListener('resize', handleResize);
+        return true;
+      } catch (err: any) {
+        console.error('[KLineChart] Failed to initialize chart:', err);
+        console.error('[KLineChart] Error details:', {
+          message: err.message,
+          stack: err.stack,
+          name: err.name,
+        });
+        throw err; // Re-throw to be caught by ErrorBoundary
+      }
+    };
 
+    // Try to initialize immediately
+    const initialized = initializeChart();
+    
+    // If not initialized (width was 0), set up a ResizeObserver to retry when container becomes available
+    if (!initialized) {
+      const resizeObserver = new ResizeObserver(() => {
+        // Only try to initialize if chart doesn't exist yet
+        if (!chartRef.current && chartContainerRef.current) {
+          const success = initializeChart();
+          if (success) {
+            resizeObserver.disconnect();
+          }
+        }
+      });
+      
+      resizeObserver.observe(container);
+      
       return () => {
-        window.removeEventListener('resize', handleResize);
+        resizeObserver.disconnect();
         if (chartRef.current) {
           chartRef.current.remove();
           chartRef.current = null;
         }
       };
-    } catch (err: any) {
-      console.error('[KLineChart] Failed to initialize chart:', err);
-      console.error('[KLineChart] Error details:', {
-        message: err.message,
-        stack: err.stack,
-        name: err.name,
-      });
-      throw err; // Re-throw to be caught by ErrorBoundary
     }
+
+    // Handle resize for already-initialized chart
+    const handleResize = () => {
+      if (chartContainerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({
+          width: chartContainerRef.current.clientWidth,
+        });
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (chartRef.current) {
+        chartRef.current.remove();
+        chartRef.current = null;
+      }
+    };
   }, [height, showVolume]);
 
   // Update data when timeframe or symbol changes


### PR DESCRIPTION
## Summary

This PR fixes the K-line chart loading issue by using ResizeObserver to detect when the container becomes available, instead of failing silently when the container width is 0.

## Root Cause

The previous implementation checked if the container width was > 0 during initialization, but if it was 0 (which can happen when the component mounts before the parent has completed layout), it would return early and never retry. This left the chart uninitialized with no error being thrown.

## Solution

- Refactored chart initialization into a separate function that returns success/failure
- When initialization fails due to container width being 0, set up a ResizeObserver
- The ResizeObserver watches the container and retries initialization when the size changes
- Once successfully initialized, disconnect the observer
- Properly cleanup the observer on component unmount

## Testing

- Build succeeds without errors
- Chart should now initialize correctly even when parent layout is delayed
- Fixes Issue #116

## Related

- Fixes #116
- Previous attempts: PR #111, PR #115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to chart initialization/cleanup; main concern is potential observer/listener lifecycle issues in edge cases.
> 
> **Overview**
> Fixes intermittent K-line chart non-rendering by refactoring initialization into a retryable `initializeChart()` and using `ResizeObserver` to re-attempt setup when the container’s width becomes non-zero.
> 
> Keeps the existing window `resize` handling for already-initialized charts, and adds explicit observer/listener cleanup paths to avoid leaking chart instances or observers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83766e084167aa8366bffe7d6b8392b92bfe89d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->