### PR TITLE
fix: add VITE_* variables to build.env for Vite bundling (#119)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -43,7 +43,11 @@
   },
   "build": {
     "env": {
-      "NODE_ENV": "production"
+      "NODE_ENV": "production",
+      "VITE_API_URL": "https://plnylmnckssnfpwznpwf.supabase.co/functions/v1",
+      "VITE_WS_URL": "wss://alphaarena-production.up.railway.app",
+      "VITE_SUPABASE_URL": "https://plnylmnckssnfpwznpwf.supabase.co",
+      "VITE_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBsbnlsbW5ja3NzbmZwd3pucHdmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMyMTc5MDUsImV4cCI6MjA4ODc5MzkwNX0.BATHv0SbrOJC2MhitL_i-UyOhHRUv4HGycfecd4H4gg"
     }
   }
 }


### PR DESCRIPTION
## Root Cause

The K-line chart was failing to load because Vite environment variables were missing from the build configuration.

### Problem
- `vercel.json` had VITE_* variables in the `env` section (runtime)
- But the `build.env` section only had `NODE_ENV`
- Vite needs VITE_* variables at **build time** to bundle them into client-side code
- Without these variables in build.env, the production bundle was missing critical configuration

### Solution
Added all VITE_* variables to the `build.env` section:
- VITE_API_URL
- VITE_WS_URL  
- VITE_SUPABASE_URL
- VITE_SUPABASE_ANON_KEY

## Testing

After merge and deployment:
1. QA should run UI acceptance tests
2. Verify K-line chart loads correctly on https://alphaarena-eight.vercel.app
3. Check browser console for any remaining errors

Fixes #119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; main risk is misconfigured build-time env values causing incorrect client bundling or broken production connectivity.
> 
> **Overview**
> Fixes missing build-time configuration on Vercel by adding the required `VITE_*` variables (API, WS, Supabase URL, anon key) to `build.env` in `vercel.json`, ensuring Vite can inline them into the production bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d17faa6731019b9a328a6db62143931b40887cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->