### PR TITLE
Fix #123: Move useRealtimeConnection into ConnectionProvider

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -221,12 +221,17 @@ const AppRoutes: React.FC = () => {
   );
 };
 
-function App() {
+// Wrapper component to use the hook inside ConnectionProvider
+function RealtimeConnectionSync() {
   useRealtimeConnection();
+  return null;
+}
 
+function App() {
   return (
     <ThemeProvider>
       <ConnectionProvider>
+        <RealtimeConnectionSync />
         <BrowserRouter>
           <OfflineIndicator />
           <MainLayout>


### PR DESCRIPTION
## Summary
Fixes the React context error where `useRealtimeConnection()` was called at the top level of App, outside the ConnectionProvider context.

## Changes
- Created a new wrapper component `RealtimeConnectionSync` that calls `useRealtimeConnection()`
- Moved the hook call inside the ConnectionProvider by rendering `<RealtimeConnectionSync />` within the provider
- Removed the direct `useRealtimeConnection()` call from the App function body

## Testing
- Build passes successfully
- This is a surgical fix that maintains the same functionality while respecting React context hierarchy

Fixes #123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small React component reorganization to ensure `useRealtimeConnection()` runs under its required context; no logic changes to connection state handling.
> 
> **Overview**
> Fixes a React context usage issue by moving the `useRealtimeConnection()` invocation under `ConnectionProvider`.
> 
> `App` now renders a small `RealtimeConnectionSync` component inside the provider, preserving existing realtime setup while avoiding calling the hook outside its context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc508bd456147b56b445b0bf5fbde7b94fee4897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->