### PR TITLE
Fix #125: Improve K-line chart error handling and fix URL encoding

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -43,6 +43,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
   const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
   const [timeframe, setTimeframe] = useState<TimeFrame>('1h');
   const [isMobile, setIsMobile] = useState(false);
+  const [chartError, setChartError] = useState<string | null>(null);
   const { klineData, loading, error } = useKLineData(symbol, timeframe);
 
   // Detect mobile on mount and resize
@@ -129,6 +130,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
           volumeSeriesRef.current = volumeSeries;
         }
 
+        setChartError(null); // Clear any previous errors
         return true;
       } catch (err: any) {
         console.error('[KLineChart] Failed to initialize chart:', err);
@@ -137,7 +139,8 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
           stack: err.stack,
           name: err.name,
         });
-        throw err; // Re-throw to be caught by ErrorBoundary
+        setChartError(`图表初始化失败：${err.message}`);
+        return false;
       }
     };
 
@@ -212,9 +215,11 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
         }));
         volumeSeriesRef.current.setData(volumeData);
       }
+      
+      setChartError(null); // Clear errors on successful update
     } catch (err: any) {
       console.error('[KLineChart] Failed to update chart data:', err);
-      throw err; // Re-throw to be caught by ErrorBoundary
+      setChartError(`图表数据更新失败：${err.message}`);
     }
   }, [klineData, showVolume]);
 
@@ -223,11 +228,11 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
     setTimeframe(value);
   }, []);
 
-  if (error) {
+  if (error || chartError) {
     return (
       <Card>
         <div style={{ padding: '40px', textAlign: 'center' }}>
-          <Text type="danger">加载失败：{error}</Text>
+          <Text type="danger">加载失败：{error || chartError}</Text>
         </div>
       </Card>
     );

--- a/src/client/utils/api.ts
+++ b/src/client/utils/api.ts
@@ -394,8 +394,9 @@ export const api = {
   async getKLineData(symbol: string, timeframe: string, limit?: number): Promise<KLineData[]> {
     const params = new URLSearchParams();
     params.append('timeframe', timeframe);
+    params.append('symbol', symbol); // Pass symbol as query param instead of path
     if (limit) params.append('limit', limit.toString());
-    const res = await apiFetch(`/api/market/kline/${symbol}?${params}`);
+    const res = await apiFetch(`/api/market/kline?${params}`);
     const data: ApiResponse<KLineData[]> = await res.json();
     return data.success ? data.data : [];
   },

--- a/supabase/functions/get-market-kline/index.ts
+++ b/supabase/functions/get-market-kline/index.ts
@@ -84,10 +84,8 @@ serve(async (req) => {
 
     // Parse URL to extract symbol, timeframe, and limit
     const url = new URL(req.url);
-    const pathParts = url.pathname.split('/');
-    // Path is like /functions/v1/get-market-kline or /functions/v1/get-market-kline/BTC/USD
-    // pathParts: ['', 'functions', 'v1', 'get-market-kline'] or ['', 'functions', 'v1', 'get-market-kline', 'BTC/USD']
-    const symbol = pathParts.length > 4 ? pathParts[4] : 'BTC/USD';
+    // Symbol is now passed as query parameter to avoid URL encoding issues with slashes
+    const symbol = url.searchParams.get('symbol') || 'BTC/USD';
     
     // Get query parameters
     const timeframe = url.searchParams.get('timeframe') || '1h';


### PR DESCRIPTION
## Summary

Fixes the '组件加载失败' error when clicking on stocks from the list.

## Root Cause

Two issues were identified:

1. **URL Encoding Problem**: Symbols with slashes (like 'BTC/USD') were being passed in the URL path, causing parsing issues in the Supabase function. The symbol was being truncated to just 'BTC' instead of 'BTC/USD'.

2. **Error Handling in useEffect**: Errors thrown in useEffect callbacks were not being caught properly by the ErrorBoundary, causing unhandled exceptions.

## Changes

### Frontend (src/client/utils/api.ts)
- Changed getKLineData to pass symbol as a query parameter instead of in the URL path
- This avoids URL encoding issues with slash characters

### Backend (supabase/functions/get-market-kline/index.ts)
- Updated to read symbol from query parameters instead of URL path

### Component (src/client/components/KLineChart.tsx)
- Added internal error state (chartError) for chart-specific errors
- Replaced error throwing in useEffect callbacks with error state updates
- Improved error messages to show actual error details
- Chart initialization and data update errors are now displayed gracefully

## Testing

- Build passes successfully
- Fixes the URL encoding issue for symbols with slashes
- Provides better error messages for debugging

Fixes #125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the K-line API contract from path params to query params, which can break non-Supabase backends or any callers still hitting `/api/market/kline/:symbol`. Frontend chart failures are now handled more safely (no thrown `useEffect` errors), reducing crash risk.
> 
> **Overview**
> Fixes K-line loading failures for symbols containing `/` by **moving `symbol` from the URL path to a `symbol` query parameter** in both the frontend `api.getKLineData` call and the `get-market-kline` Supabase edge function.
> 
> Updates `KLineChart` to **stop throwing from `useEffect`** during chart init/data updates; it now captures those failures in a local `chartError` state and renders the error message alongside existing data-fetch errors instead of crashing the component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 172c3245a58dc36907ca683dbaf96f517fa6938f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->