### PR TITLE
Fix #133: Add proper cleanup to useOrderBook hook to prevent DOM errors

### DIFF
--- a/src/client/hooks/useData.ts
+++ b/src/client/hooks/useData.ts
@@ -292,21 +292,31 @@ export const useOrderBook = (symbol: string, levels: number = 20) => {
   const [error, setError] = useState<string | null>(null);
   const realtimeClientRef = useRef<ReturnType<typeof getRealtimeClient> | null>(null);
   const unsubscribeRef = useRef<(() => void)[]>([]);
+  const isMountedRef = useRef<boolean>(false);
 
   const fetchOrderBook = useCallback(async () => {
     try {
       const data = await api.getOrderBook(symbol, levels);
-      setOrderBook(data);
-      setError(null);
+      if (isMountedRef.current) {
+        setOrderBook(data);
+        setError(null);
+        setLoading(false);
+      }
     } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
+      if (isMountedRef.current) {
+        setError(err.message);
+        setLoading(false);
+      }
     }
   }, [symbol, levels]);
 
   useEffect(() => {
+    isMountedRef.current = true;
     fetchOrderBook();
+    
+    return () => {
+      isMountedRef.current = false;
+    };
   }, [fetchOrderBook]);
 
   useEffect(() => {
@@ -322,15 +332,19 @@ export const useOrderBook = (symbol: string, levels: number = 20) => {
 
     // Listen for snapshot and delta events
     const unsubscribeSnapshot = client.onOrderBookSnapshot(symbol, (data: OrderBookSnapshot) => {
-      setOrderBook(data);
-      setLoading(false);
+      if (isMountedRef.current) {
+        setOrderBook(data);
+        setLoading(false);
+      }
     });
 
     const unsubscribeDelta = client.onOrderBookDelta(symbol, (delta: OrderBookSnapshot) => {
-      setOrderBook(prev => {
-        if (!prev || !delta) return prev;
-        return { ...delta };
-      });
+      if (isMountedRef.current) {
+        setOrderBook(prev => {
+          if (!prev || !delta) return prev;
+          return { ...delta };
+        });
+      }
     });
 
     unsubscribeRef.current = [unsubscribeSnapshot, unsubscribeDelta];


### PR DESCRIPTION
## Problem
OrderBook component was causing 'removeChild' DOM error: `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

## Root Cause
The `useOrderBook` hook had improper useEffect cleanup:
- Async callbacks (`onOrderBookSnapshot`, `onOrderBookDelta`) could call `setOrderBook` after component unmount
- No mounted state tracking to prevent state updates on unmounted components
- React tried to reconcile DOM nodes that no longer existed

## Solution
- Add `isMountedRef` to track component mount state
- Guard all state updates (`setOrderBook`, `setLoading`, `setError`) with `isMountedRef.current` check
- Properly cleanup subscriptions on unmount

## Testing
- Component should mount/unmount without DOM errors
- OrderBook data should still update correctly via realtime subscriptions
- No memory leaks from dangling subscriptions

Fixes #133

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to a client-side React hook and adds mount guards to avoid updating state after unmount; main risk is subtle changes to loading/error timing during fast mount/unmount cycles.
> 
> **Overview**
> Fixes `useOrderBook` cleanup by tracking mount state with `isMountedRef` and guarding all `setOrderBook`/`setLoading`/`setError` calls (API fetch + realtime snapshot/delta handlers) to prevent state updates after unmount.
> 
> Adds an effect to set/clear the mounted flag on mount/unmount, reducing DOM reconciliation errors during rapid component teardown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9fef1b419e6a04816d67eb9cb30b96df4d79c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->