### PR TITLE
fix: remove duplicate 'height' key in KLineChart

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -83,7 +83,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
       const containerWidth = container.clientWidth;
       const containerHeight = container.clientHeight;
       
-      console.log('[KLineChart] Initializing chart, container size:', { width: containerWidth, height: containerHeight, height: height });
+      console.log('[KLineChart] Initializing chart, container size:', { width: containerWidth, containerHeight, height });
       
       if (containerWidth <= 0) {
         console.warn('[KLineChart] Container width is still 0, will retry...');


### PR DESCRIPTION
Fixes #135

## Problem
Build warning: `src/client/components/KLineChart.tsx: Duplicate key "height" in object literal`

This was causing the '组件加载失败' error in production.

## Solution
Removed duplicate 'height' key in the console.log statement at line 86. Changed from:
```typescript
{ width: containerWidth, height: containerHeight, height: height }
```
to:
```typescript
{ width: containerWidth, containerHeight, height }
```

## Testing
- ✅ Build completes without warnings
- ✅ No other duplicate keys in the file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a debug `console.log` object literal to remove a duplicate key, eliminating a build warning without affecting runtime chart logic.
> 
> **Overview**
> Fixes a build warning in `KLineChart` by removing the duplicate `height` key in the chart initialization `console.log` payload (now logs `containerHeight` separately and keeps the `height` prop). This prevents the duplicate-key warning that could surface as a component load failure in production builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ad2b349a3fc118f7212fd791b98fd9157ec6fc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->