### PR TITLE
fix: add timeout handling to prevent app stuck on connecting

### DIFF
--- a/src/client/hooks/useData.ts
+++ b/src/client/hooks/useData.ts
@@ -319,6 +319,22 @@ export const usePortfolioHistory = (
   return { history, loading, error, refresh: fetchHistory };
 };
 
+/**
+ * Wrapper function to add timeout to fetch operations
+ */
+const fetchWithTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number = 10000,
+  timeoutMessage: string = 'Request timed out'
+): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)
+    ),
+  ]);
+};
+
 export const useOrderBook = (symbol: string, levels: number = 20) => {
   const [orderBook, setOrderBook] = useState<OrderBookSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
@@ -329,7 +345,11 @@ export const useOrderBook = (symbol: string, levels: number = 20) => {
 
   const fetchOrderBook = useCallback(async () => {
     try {
-      const data = await api.getOrderBook(symbol, levels);
+      const data = await fetchWithTimeout(
+        api.getOrderBook(symbol, levels),
+        10000, // 10 second timeout
+        '获取订单簿数据超时'
+      );
       if (isMountedRef.current) {
         setOrderBook(data);
         setError(null);

--- a/src/client/utils/realtime.ts
+++ b/src/client/utils/realtime.ts
@@ -211,7 +211,7 @@ export class RealtimeClient {
   }
 
   /**
-   * Subscribe to a channel with automatic reconnection
+   * Subscribe to a channel with automatic reconnection and timeout handling
    */
   public async subscribe(topic: string): Promise<RealtimeChannel> {
     if (this.channels.has(topic)) {
@@ -231,8 +231,11 @@ export class RealtimeClient {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         console.error(`[RealtimeClient] Subscription timeout for ${topic}`);
+        // Update connection status to disconnected on timeout
+        this.connectionStatus = 'disconnected';
+        this.notifyConnectionListeners();
         this.handleReconnect(topic);
-        reject(new Error(`Subscription timeout for ${topic}`));
+        reject(new Error(`订阅超时：${topic}`));
       }, CONNECTION_TIMEOUT);
 
       channel.subscribe((status) => {
@@ -252,8 +255,11 @@ export class RealtimeClient {
         } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
           clearTimeout(timeout);
           console.error(`[RealtimeClient] Subscription error for ${topic}:`, status);
+          // Update connection status on error
+          this.connectionStatus = 'disconnected';
+          this.notifyConnectionListeners();
           this.handleReconnect(topic);
-          reject(new Error(`Subscription failed: ${status}`));
+          reject(new Error(`订阅失败：${status}`));
         }
       });
     });


### PR DESCRIPTION
## Summary

Fixes the issue where the app would hang indefinitely showing '正在连接服务器...' when Supabase realtime connections or order book API calls timeout.

## Changes

### src/client/hooks/useData.ts
- Added `fetchWithTimeout` wrapper function with 10-second timeout
- Wrapped `api.getOrderBook()` call with timeout protection
- Ensures loading state is set to false even on timeout/failure
- Added Chinese error message for timeout scenarios

### src/client/utils/realtime.ts
- Enhanced `subscribe()` method with proper timeout error handling
- Updates connection status to 'disconnected' on timeout (was staying in 'connecting' state)
- Added Chinese error messages for timeout and subscription failures
- Notifies connection listeners when status changes to disconnected

## Testing

- Build succeeds without TypeScript errors
- Dev server starts successfully
- Timeout handling prevents infinite loading states

## Related

Fixes issue reported in Sprint 2 where app gets stuck on connecting screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime subscription error/timeout handling and connection state transitions, which can affect app connectivity and reconnection behavior. Logic is straightforward but could change user-visible connection status and retry patterns if misfired.
> 
> **Overview**
> Prevents the UI from hanging in a perpetual *connecting* state by adding explicit timeout handling to key client-side network paths.
> 
> `useOrderBook` now wraps `api.getOrderBook()` with a 10s `fetchWithTimeout`, surfacing a clear timeout error and ensuring `loading` is cleared on failure.
> 
> `RealtimeClient.subscribe()` now marks the connection as `disconnected` (and notifies listeners) when a subscription times out or errors, and returns localized (Chinese) timeout/failure errors before triggering reconnection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d161c77b389f2d69980857997d9eb9e90a801c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->