### PR TITLE
fix: wrap Arco Design Layout components with ErrorBoundary (#141)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,6 +14,7 @@ import {
 import BalanceDisplay from './components/BalanceDisplay';
 import ThemeToggle from './components/ThemeToggle';
 import OfflineIndicator from './components/OfflineIndicator';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { ThemeProvider } from './hooks/useTheme';
 import { ConnectionProvider } from './store/connectionStore';
 import { useRealtimeConnection } from './hooks/useRealtimeConnection';
@@ -112,10 +113,11 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      {/* Desktop Sider */}
-      {!isMobile && (
-        <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed}>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        {/* Desktop Sider */}
+        {!isMobile && (
+          <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed}>
           <div
             style={{
               height: 32,
@@ -205,6 +207,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         />
       </Drawer>
     </Layout>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/DashboardPage.tsx
+++ b/src/client/pages/DashboardPage.tsx
@@ -19,6 +19,7 @@ import {
 import { useStats, useStrategies, useTrades } from '../hooks/useData';
 import TradeHistoryPanel from '../components/TradeHistoryPanel';
 import OrdersPanel from '../components/OrdersPanel';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import type { TableProps } from '@arco-design/web-react';
 import type { Trade, Strategy } from '../utils/api';
 
@@ -170,13 +171,14 @@ const DashboardPage: React.FC = () => {
   ];
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Header>
-        <Title heading={2} style={{ color: 'white', margin: 0 }}>
-          AlphaArena - Dashboard
-        </Title>
-      </Header>
-      <Content style={{ padding: isMobile ? 12 : 24 }}>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        <Header>
+          <Title heading={2} style={{ color: 'white', margin: 0 }}>
+            AlphaArena - Dashboard
+          </Title>
+        </Header>
+        <Content style={{ padding: isMobile ? 12 : 24 }}>
         {/* Stats Overview */}
         <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
           <Col xs={12} sm={12} md={6}>
@@ -322,6 +324,7 @@ const DashboardPage: React.FC = () => {
         </Row>
       </Content>
     </Layout>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/HoldingsPage.tsx
+++ b/src/client/pages/HoldingsPage.tsx
@@ -17,6 +17,7 @@ import {
 } from 'recharts';
 import { useStrategies, useTrades, usePortfolioHistory } from '../hooks/useData';
 import { usePortfolioRealtime } from '../hooks/usePortfolioRealtime';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import type { TableProps } from '@arco-design/web-react';
 import type { PortfolioWithPnL } from '../hooks/usePortfolioRealtime';
 
@@ -249,13 +250,14 @@ const HoldingsPage: React.FC = () => {
   const loading = strategiesLoading || portfolioLoading || tradesLoading;
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Header>
-        <Title heading={2} style={{ color: 'white', margin: 0 }}>
-          AlphaArena - Holdings
-        </Title>
-      </Header>
-      <Content style={{ padding: isMobile ? 12 : 24 }}>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        <Header>
+          <Title heading={2} style={{ color: 'white', margin: 0 }}>
+            AlphaArena - Holdings
+          </Title>
+        </Header>
+        <Content style={{ padding: isMobile ? 12 : 24 }}>
         {/* Strategy Selector */}
         <Card style={{ marginBottom: isMobile ? 16 : 24 }}>
           <Select
@@ -573,6 +575,7 @@ const HoldingsPage: React.FC = () => {
         </Card>
       </Content>
     </Layout>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/HomePage.tsx
+++ b/src/client/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Layout, Typography, Card, Grid } from '@arco-design/web-react';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import TradingPairList from '../components/TradingPairList';
 import KLineChart from '../components/KLineChart';
 import TradingOrder from '../components/TradingOrder';
@@ -42,9 +43,10 @@ const HomePage: React.FC = () => {
   };
 
   return (
-    <Content style={{ padding: isMobile ? 8 : 24 }}>
-      {/* Mobile: Stack vertically */}
-      {isMobile ? (
+    <ErrorBoundary>
+      <Content style={{ padding: isMobile ? 8 : 24 }}>
+        {/* Mobile: Stack vertically */}
+        {isMobile ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {/* Trading Pair List - Full width at top */}
           <Card
@@ -104,7 +106,8 @@ const HomePage: React.FC = () => {
           </Col>
         </Row>
       )}
-    </Content>
+      </Content>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/LeaderboardPage.tsx
+++ b/src/client/pages/LeaderboardPage.tsx
@@ -22,6 +22,7 @@ import {
 } from 'recharts';
 import { useStrategies, useTrades } from '../hooks/useData';
 import { api, LeaderboardEntry, StrategyMetrics } from '../utils/api';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import type { TableProps, TableColumnProps } from '@arco-design/web-react';
 import { IconRefresh, IconTrophy, IconArrowRise, IconArrowFall } from '@arco-design/web-react/icon';
 
@@ -314,20 +315,21 @@ const LeaderboardPage: React.FC = () => {
   ];
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Header
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          flexWrap: 'wrap',
-          gap: isMobile ? 8 : 0,
-        }}
-      >
-        <Title heading={2} style={{ color: 'white', margin: 0, fontSize: isMobile ? 18 : 20 }}>
-          <IconTrophy style={{ marginRight: 8 }} />
-          Strategy Leaderboard
-        </Title>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        <Header
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: isMobile ? 8 : 0,
+          }}
+        >
+          <Title heading={2} style={{ color: 'white', margin: 0, fontSize: isMobile ? 18 : 20 }}>
+            <IconTrophy style={{ marginRight: 8 }} />
+            Strategy Leaderboard
+          </Title>
         <Space wrap direction={isMobile ? 'vertical' : 'horizontal'}>
           <Text style={{ color: 'rgba(255,255,255,0.8)', fontSize: isMobile ? 12 : 14 }}>
             {lastUpdated ? `Updated: ${lastUpdated.toLocaleTimeString()}` : 'Loading...'}
@@ -526,6 +528,7 @@ const LeaderboardPage: React.FC = () => {
         </div>
       </Content>
     </Layout>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/StrategiesPage.tsx
+++ b/src/client/pages/StrategiesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Layout, Typography, Card, Table, Tag, Space, Button, Modal, Form, Input, Select, Switch, Drawer } from '@arco-design/web-react';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import { useStrategies } from '../hooks/useData';
 import type { TableProps } from '@arco-design/web-react';
 import type { Strategy } from '../utils/api';
@@ -146,13 +147,14 @@ const StrategiesPage: React.FC = () => {
   ];
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Header>
-        <Title heading={2} style={{ color: 'white', margin: 0 }}>
-          AlphaArena - Strategies
-        </Title>
-      </Header>
-      <Content style={{ padding: isMobile ? 12 : 24 }}>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        <Header>
+          <Title heading={2} style={{ color: 'white', margin: 0 }}>
+            AlphaArena - Strategies
+          </Title>
+        </Header>
+        <Content style={{ padding: isMobile ? 12 : 24 }}>
         <Card
           title="Strategy Management"
           extra={
@@ -272,6 +274,7 @@ const StrategiesPage: React.FC = () => {
         </Form>
       </Modal>
     </Layout>
+    </ErrorBoundary>
   );
 };
 

--- a/src/client/pages/TradesPage.tsx
+++ b/src/client/pages/TradesPage.tsx
@@ -17,6 +17,7 @@ import {
 } from 'recharts';
 import { useTrades } from '../hooks/useData';
 import { api } from '../utils/api';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import type { TableProps } from '@arco-design/web-react';
 import type { Trade } from '../utils/api';
 
@@ -184,13 +185,14 @@ const TradesPage: React.FC = () => {
   ];
 
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Header>
-        <Title heading={2} style={{ color: 'white', margin: 0 }}>
-          AlphaArena - Trades
-        </Title>
-      </Header>
-      <Content style={{ padding: isMobile ? 12 : 24 }}>
+    <ErrorBoundary>
+      <Layout style={{ minHeight: '100vh' }}>
+        <Header>
+          <Title heading={2} style={{ color: 'white', margin: 0 }}>
+            AlphaArena - Trades
+          </Title>
+        </Header>
+        <Content style={{ padding: isMobile ? 12 : 24 }}>
         {/* Filters */}
         <Card style={{ marginBottom: isMobile ? 16 : 24 }}>
           <Space wrap direction={isMobile ? 'vertical' : 'horizontal'}>
@@ -305,6 +307,7 @@ const TradesPage: React.FC = () => {
         </Card>
       </Content>
     </Layout>
+    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
## Problem
The application crashes with 'Failed to execute 'removeChild' on 'Node' DOM errors when Arco Design Layout components unmount.

## Solution
Wrap all Arco Design Layout components with ErrorBoundary to gracefully handle these DOM race condition errors.

## Changes
- Added ErrorBoundary wrapper in HomePage.tsx, DashboardPage.tsx, LeaderboardPage.tsx, StrategiesPage.tsx, TradesPage.tsx, HoldingsPage.tsx, and App.tsx
- Prevents application crashes from Arco Design unmount errors
- Provides user-friendly error UI instead of white screen

## Testing
- Verified build passes
- ErrorBoundary catches and displays errors gracefully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a UI-only change that adds error boundaries around existing page/layout trees without altering data fetching or business logic; main risk is masking unexpected errors behind fallback UI.
> 
> **Overview**
> Adds `ErrorBoundary` wrappers around the top-level Arco `Layout`/page render trees in `App.tsx` and all main pages (`HomePage`, `DashboardPage`, `HoldingsPage`, `TradesPage`, `StrategiesPage`, `LeaderboardPage`).
> 
> This makes DOM/unmount-related runtime errors render a fallback error UI instead of crashing the entire app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 109e3ed90e346217a6ab5f3cdde1c118af2f1386. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->