### PR TITLE
Fix root cause of HomePage removeChild error

### DIFF
--- a/src/client/pages/HomePage.tsx
+++ b/src/client/pages/HomePage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Layout, Typography, Card, Grid, Spin } from '@arco-design/web-react';
-import { ErrorBoundary } from '../components/ErrorBoundary';
+import { Layout, Card, Grid } from '@arco-design/web-react';
 import TradingPairList from '../components/TradingPairList';
 import KLineChart from '../components/KLineChart';
 import TradingOrder from '../components/TradingOrder';
@@ -9,19 +8,6 @@ import ConditionalOrdersPanel from '../components/ConditionalOrdersPanel';
 
 const { Content } = Layout;
 const { Row, Col } = Grid;
-
-// Fallback component for ErrorBoundary to prevent rapid mount/unmount
-const HomePageFallback: React.FC = () => (
-  <div style={{ 
-    display: 'flex', 
-    justifyContent: 'center', 
-    alignItems: 'center', 
-    height: '100%',
-    minHeight: 400,
-  }}>
-    <Spin size="large" />
-  </div>
-);
 
 const HomePage: React.FC = () => {
   const [selectedSymbol, setSelectedSymbol] = useState('BTC/USD');
@@ -59,10 +45,9 @@ const HomePage: React.FC = () => {
   };
 
   return (
-    <ErrorBoundary fallback={<HomePageFallback />}>
-      <Content key={`content-${isMobile ? 'mobile' : 'desktop'}`} style={{ padding: isMobile ? 8 : 24 }}>
-        {/* Mobile: Stack vertically */}
-        {isMobile ? (
+    <Content style={{ padding: isMobile ? 8 : 24 }}>
+      {/* Mobile: Stack vertically */}
+      {isMobile ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {/* Trading Pair List - Full width at top */}
           <Card
@@ -122,8 +107,7 @@ const HomePage: React.FC = () => {
           </Col>
         </Row>
       )}
-      </Content>
-    </ErrorBoundary>
+    </Content>
   );
 };
 


### PR DESCRIPTION
## Summary

- Remove the dynamic `key` prop from Arco Design `<Content>` that forced full component tree unmount/remount on window resize
- This was the root cause of 23+ failed fix attempts — the key change caused React cleanup, Arco DOM management, Realtime unsubscribe, and lightweight-charts canvas removal to race on the same DOM nodes
- Remove unnecessary ErrorBoundary wrapper and HomePageFallback (added as symptom workarounds)

## Root Cause

`<Content key={content-${isMobile ? 'mobile' : 'desktop'}}>` changed key on resize, forcing React to destroy and recreate the entire subtree. Without the key, React diffs in place — child components stay mounted, no cleanup race condition.

## Test plan

- [ ] Resize browser window between mobile/desktop widths — no console errors
- [ ] Navigate away from HomePage and back — no removeChild errors
- [ ] Verify mobile layout still renders correctly (stacked vertically)
- [ ] Verify desktop layout still renders correctly (grid columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HomePage rendering lifecycle by removing the dynamic `key` and page-level `ErrorBoundary`, which could alter component mount/unmount behavior and error handling during resizes.
> 
> **Overview**
> Prevents `HomePage` from forcibly unmounting/remounting on mobile/desktop breakpoint changes by removing the dynamic `key` on Arco `Content`, so resize updates re-render in place instead of tearing down the subtree.
> 
> Removes the page-scoped `ErrorBoundary` wrapper and its spinner fallback/workaround, simplifying the render tree while keeping the existing mobile vs desktop layout logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5414d9eb3a150fbbd9e4d846b68aeea3910427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->