### PR TITLE
Sprint 6: Implement stop-loss and take-profit order types

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1006,12 +1006,30 @@ export class APIServer extends EventEmitter {
     this.priceMonitoring.on('order-triggered', async (data: any) => {
       console.log(`[PriceMonitoring] Order triggered: ${data.orderType} ${data.symbol} @ ${data.executedPrice}`);
       
-      // In production, send notification via Feishu, email, etc.
-      // For now, just log it
+      // Send Feishu notification for triggered orders
+      const orderTypeText = data.orderType === 'stop_loss' ? '止损单' : '止盈单';
+      const sideText = data.side === 'buy' ? '买入' : '卖出';
+      
       if (data.orderType === 'stop_loss') {
-        console.warn(`⚠️ Stop-loss triggered for ${data.symbol}: Sold ${data.quantity} @ ${data.executedPrice}`);
+        console.warn(`⚠️ Stop-loss triggered for ${data.symbol}: ${sideText} ${data.quantity} @ ${data.executedPrice}`);
       } else {
-        console.log(`✅ Take-profit triggered for ${data.symbol}: Sold ${data.quantity} @ ${data.executedPrice}`);
+        console.log(`✅ Take-profit triggered for ${data.symbol}: ${sideText} ${data.quantity} @ ${data.executedPrice}`);
+      }
+
+      // Send Feishu notification
+      try {
+        await this.feishuAlert.sendAlert({
+          type: data.orderType === 'stop_loss' ? 'warning' : 'info',
+          title: `条件单已触发 - ${orderTypeText}`,
+          content: `交易对：${data.symbol}\n` +
+                   `类型：${orderTypeText} (${sideText})\n` +
+                   `触发价格：$${data.triggerPrice}\n` +
+                   `执行价格：$${data.executedPrice}\n` +
+                   `数量：${data.quantity}\n` +
+                   `交易 ID: ${data.tradeId}`,
+        });
+      } catch (error: any) {
+        console.error('[PriceMonitoring] Failed to send Feishu notification:', error);
       }
 
       // Broadcast to frontend via realtime

--- a/src/client/utils/api.ts
+++ b/src/client/utils/api.ts
@@ -34,6 +34,7 @@ const FUNCTION_MAP: Record<string, string> = {
   '/api/orderbook': 'get-orderbook',
   '/api/market/tickers': 'get-market-tickers',
   '/api/market/kline': 'get-market-kline',
+  '/api/conditional-orders': 'conditional-orders',
 };
 
 // Helper to map API paths to Supabase function names

--- a/supabase/functions/cancel-conditional-order/index.ts
+++ b/supabase/functions/cancel-conditional-order/index.ts
@@ -1,0 +1,115 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.99.0';
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+    // Only allow POST
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Method not allowed' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 405 }
+      );
+    }
+
+    // Extract order ID from URL path
+    const url = new URL(req.url);
+    const pathParts = url.pathname.split('/');
+    const orderId = pathParts[pathParts.length - 2]; // Get the ID from /conditional-orders/{id}/cancel
+
+    if (!orderId) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order ID is required' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Get the current order to check status
+    const { data: existingOrder, error: fetchError } = await supabase
+      .from('conditional_orders')
+      .select('status')
+      .eq('id', orderId)
+      .single();
+
+    if (fetchError) {
+      if (fetchError.code === 'PGRST116') {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Conditional order not found' }),
+          { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 404 }
+        );
+      }
+      throw fetchError;
+    }
+
+    // Check if order can be cancelled
+    if (existingOrder.status !== 'active') {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: `Cannot cancel order with status: ${existingOrder.status}` 
+        }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Update order status to cancelled
+    const { data: updatedOrder, error: updateError } = await supabase
+      .from('conditional_orders')
+      .update({
+        status: 'cancelled',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', orderId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Error cancelling conditional order:', updateError);
+      throw updateError;
+    }
+
+    // Format response
+    const formattedOrder = {
+      id: updatedOrder.id,
+      strategyId: updatedOrder.strategy_id,
+      symbol: updatedOrder.symbol,
+      side: updatedOrder.side,
+      orderType: updatedOrder.order_type,
+      triggerPrice: parseFloat(updatedOrder.trigger_price),
+      quantity: parseFloat(updatedOrder.quantity),
+      status: updatedOrder.status,
+      triggeredAt: updatedOrder.triggered_at,
+      triggeredOrderId: updatedOrder.triggered_order_id,
+      expiresAt: updatedOrder.expires_at,
+      createdAt: updatedOrder.created_at,
+      updatedAt: updatedOrder.updated_at,
+    };
+
+    return new Response(
+      JSON.stringify({ success: true, data: formattedOrder }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200,
+      }
+    );
+  } catch (error) {
+    console.error('Error in cancel-conditional-order:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 }
+    );
+  }
+});

--- a/supabase/functions/conditional-orders/index.ts
+++ b/supabase/functions/conditional-orders/index.ts
@@ -66,19 +66,18 @@ serve(async (req) => {
     // Transform data to match expected format
     const formattedOrders = orders.map((o) => ({
       id: o.id,
-      userId: o.user_id,
+      strategyId: o.strategy_id,
       symbol: o.symbol,
+      side: o.side,
       orderType: o.order_type,
-      triggerType: o.trigger_type,
       triggerPrice: o.trigger_price ? parseFloat(o.trigger_price.toString()) : null,
-      orderSide: o.order_side,
-      orderPrice: o.order_price ? parseFloat(o.order_price.toString()) : null,
-      orderQuantity: o.order_quantity ? parseFloat(o.order_quantity.toString()) : null,
+      quantity: o.quantity ? parseFloat(o.quantity.toString()) : null,
       status: o.status,
+      triggeredAt: o.triggered_at,
+      triggeredOrderId: o.triggered_order_id,
       createdAt: o.created_at,
       updatedAt: o.updated_at,
-      triggeredAt: o.triggered_at,
-      expiresAt: o.expires_at
+      expiresAt: o.expires_at,
     }));
 
     return new Response(JSON.stringify({

--- a/supabase/functions/create-conditional-order/index.ts
+++ b/supabase/functions/create-conditional-order/index.ts
@@ -1,0 +1,156 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.99.0';
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+    // Only allow POST
+    if (req.method !== 'POST') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Method not allowed' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 405 }
+      );
+    }
+
+    // Parse request body
+    const body = await req.json();
+    const { symbol, side, orderType, triggerPrice, quantity, expiresAt, strategyId } = body;
+
+    // Validate required fields
+    if (!symbol || !side || !orderType || !triggerPrice || !quantity) {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Missing required fields: symbol, side, orderType, triggerPrice, quantity' 
+        }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Validate side
+    if (!['buy', 'sell'].includes(side)) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid side. Must be "buy" or "sell"' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Validate order type
+    if (!['stop_loss', 'take_profit'].includes(orderType)) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid orderType. Must be "stop_loss" or "take_profit"' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Validate trigger price
+    if (typeof triggerPrice !== 'number' || triggerPrice <= 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid triggerPrice. Must be a positive number' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Validate quantity
+    if (typeof quantity !== 'number' || quantity <= 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid quantity. Must be a positive number' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 400 }
+      );
+    }
+
+    // Validate trigger price logic
+    // Stop-loss: should trigger when price falls below trigger price (typically for sell orders)
+    // Take-profit: should trigger when price rises above trigger price (typically for sell orders)
+    // Note: We allow flexibility but warn about unusual combinations
+
+    // Get current market price for validation
+    const { data: priceData } = await supabase
+      .from('price_history')
+      .select('price')
+      .eq('symbol', symbol)
+      .order('timestamp', { ascending: false })
+      .limit(1)
+      .single();
+    
+    let currentPrice = null;
+    if (priceData) {
+      currentPrice = parseFloat(priceData.price.toString());
+    }
+
+    // Optional validation warnings (not blocking)
+    if (currentPrice) {
+      if (orderType === 'stop_loss' && side === 'buy' && triggerPrice > currentPrice) {
+        console.warn('Stop-loss buy order with trigger above current price - unusual combination');
+      }
+      if (orderType === 'take_profit' && side === 'buy' && triggerPrice < currentPrice) {
+        console.warn('Take-profit buy order with trigger below current price - unusual combination');
+      }
+    }
+
+    // Create conditional order record
+    const { data: order, error } = await supabase
+      .from('conditional_orders')
+      .insert([
+        {
+          strategy_id: strategyId || null,
+          symbol,
+          side,
+          order_type: orderType,
+          trigger_price: triggerPrice.toString(),
+          quantity: quantity.toString(),
+          expires_at: expiresAt || null,
+          status: 'active',
+        },
+      ])
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error creating conditional order:', error);
+      throw error;
+    }
+
+    // Format response
+    const formattedOrder = {
+      id: order.id,
+      strategyId: order.strategy_id,
+      symbol: order.symbol,
+      side: order.side,
+      orderType: order.order_type,
+      triggerPrice: parseFloat(order.trigger_price),
+      quantity: parseFloat(order.quantity),
+      status: order.status,
+      expiresAt: order.expires_at,
+      createdAt: order.created_at,
+      updatedAt: order.updated_at,
+    };
+
+    return new Response(
+      JSON.stringify({ success: true, data: formattedOrder }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 201,
+      }
+    );
+  } catch (error) {
+    console.error('Error in create-conditional-order:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
This PR implements stop-loss and take-profit conditional order functionality for Sprint 6.

## Changes
### Backend
- **create-conditional-order edge function**: Creates stop-loss and take-profit orders in Supabase
- **cancel-conditional-order edge function**: Cancels active conditional orders
- **Updated conditional-orders GET endpoint**: Returns data in the correct format for the UI
- **Feishu notification integration**: Sends alerts when conditional orders are triggered

### Frontend
- **API client updates**: Added mapping for conditional-orders endpoints to Supabase functions
- **UI components**: Already implemented (ConditionalOrdersPanel, TradingOrder with conditional order support)

### Infrastructure
- **Price monitoring service**: Automatically monitors prices and triggers orders when conditions are met (already implemented)
- **Real-time notifications**: Broadcasts order trigger events to frontend via Supabase Realtime

## Testing
- All conditional-orders DAO tests pass (8/8)
- Build successful
- UI components already integrated in HomePage

## Acceptance Criteria
- [x] Users can create stop-loss orders for their positions
- [x] Users can create take-profit orders for their positions
- [x] Conditional orders are visible in the UI with clear status indicators
- [x] Orders trigger correctly when price conditions are met
- [x] Triggered orders execute as market orders
- [x] Notification system alerts users when orders trigger (Feishu + UI)

Fixes: #95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Supabase Edge Functions that create/cancel conditional orders and changes how conditional-order data is shaped, which can break UI expectations or order lifecycle handling if mismatched. Also introduces external Feishu alert calls on order triggers, increasing operational/dependency risk.
> 
> **Overview**
> Implements stop-loss/take-profit conditional order support via Supabase Edge Functions: new `create-conditional-order` (validates input, inserts `conditional_orders`) and `cancel-conditional-order` (validates status, updates to `cancelled`).
> 
> Updates the `conditional-orders` function response shape (e.g., `strategyId`, `side`, `quantity`, `triggeredAt/triggeredOrderId`) to match the UI, and maps `/api/conditional-orders` to the Supabase function in the frontend API client.
> 
> When the price-monitoring service emits `order-triggered`, the API server now sends a Feishu alert (warning/info) with order details in addition to the existing realtime broadcast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0826b379d700c26b33a4dda5878fff3bccb8ae91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->