### PR TITLE
fix: Add missing useRef import in useKLineData hook

### DIFF
--- a/src/client/hooks/useKLineData.ts
+++ b/src/client/hooks/useKLineData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { api } from '../utils/api';
 import type { KLineDataPoint, TimeFrame } from '../components/KLineChart';
 


### PR DESCRIPTION
## Summary

This PR fixes the P0 bug #148 where clicking on a trading pair causes the detail component to fail loading.

## Root Cause

The `useKLineData.ts` hook was using `useRef` without importing it from React. This caused a runtime error:
```
ReferenceError: useRef is not defined
```

## Changes

### useKLineData Hook
- Added `useRef` to the React imports

## Testing

- Build succeeds without errors
- The useRef hook is now properly available for tracking previous symbol state

## Related Issue

Fixes #148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line fix to restore a missing React hook import and prevent a runtime ReferenceError when the hook executes.
> 
> **Overview**
> Fixes a runtime crash in `useKLineData` by adding the missing React `useRef` import, allowing the hook’s `prevSymbolRef` tracking to work when switching trading pairs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12a46ac9e49a8d0d0c0384c6424f6e876f6b2c3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->