### PR TITLE
fix: add missing useRef import in TradingOrder component (#150)

### DIFF
--- a/src/client/components/TradingOrder.tsx
+++ b/src/client/components/TradingOrder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
   Card,
   Tabs,


### PR DESCRIPTION
## Problem

TradingOrder component uses `React.useRef` but was missing the `useRef` import from React. This caused a runtime error when the component tried to initialize, resulting in the "组件加载失败" (Component load failure) error on the homepage.

## Root Cause

The import statement was:
```tsx
import React, { useState, useCallback, useEffect } from 'react';
```

But the component uses:
```tsx
const formRef = React.useRef<FormInstance>(null);
```

This is the same issue that was fixed in PR #149 for useKLineData hook.

## Fix

Added `useRef` to the import statement:
```tsx
import React, { useState, useCallback, useEffect, useRef } from 'react';
```

## Testing

- Build succeeds without errors
- Component should now render without runtime errors

## Related

- Issue #150: P0 bug - component load failure persists
- PR #149: Fixed same issue in useKLineData hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line import fix with no behavior changes beyond preventing the component from failing to load at runtime.
> 
> **Overview**
> Prevents `TradingOrder` from crashing on initialization by adding the missing React `useRef` import required for the component’s `formRef` (`React.useRef<FormInstance>(null)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 077fe675a4ebc4be1c47104b76f4baad8ca1e0bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->