### PR TITLE
fix: enhance ErrorBoundary logging for production debugging (#150)

### DIFF
--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -38,14 +38,30 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('[ErrorBoundary] Caught error:', error);
-    console.error('[ErrorBoundary] Component stack:', errorInfo.componentStack);
-    console.error('[ErrorBoundary] Full error details:', {
-      message: error.message,
-      stack: error.stack,
-      name: error.name,
-    });
+    // CRITICAL: Log errors prominently to help debugging production issues
+    console.error('========================================');
+    console.error('🚨 ERRORBOUNDARY CAUGHT ERROR 🚨');
+    console.error('========================================');
+    console.error('Error name:', error.name);
+    console.error('Error message:', error.message);
+    console.error('Error stack:', error.stack);
+    console.error('Component stack:', errorInfo.componentStack);
+    console.error('Full error object:', error);
+    console.error('========================================');
     
+    // Store error globally for easy access from console
+    (window as any).__LAST_ERROR__ = {
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      },
+      componentStack: errorInfo.componentStack,
+      timestamp: Date.now(),
+      url: window.location.href,
+    };
+    
+    // Auto-expand error details in UI for better visibility
     this.setState({ errorInfo });
     
     // Log to error reporting service if configured
@@ -75,7 +91,7 @@ export class ErrorBoundary extends Component<Props, State> {
         (this.state.error?.message?.includes('environment') || 
          this.state.error?.message?.includes('configuration'));
 
-      // Default error UI
+      // Default error UI - auto-expand error details for visibility
       return (
         <Result
           status="error"
@@ -103,31 +119,34 @@ export class ErrorBoundary extends Component<Props, State> {
               )}
               
               {this.state.error && (
-                <details style={{ marginTop: 16, fontSize: 12, color: '#86909c' }}>
-                  <summary>错误详情（点击展开）</summary>
+                <details open style={{ marginTop: 16, fontSize: 12, color: '#86909c' }}>
+                  <summary style={{ cursor: 'pointer', fontWeight: 'bold' }}>错误详情（已自动展开）</summary>
                   <div style={{ 
                     marginTop: 8, 
                     padding: 12, 
-                    background: '#f5f5f5', 
+                    background: '#fff1f0', 
                     borderRadius: 4,
                     overflow: 'auto',
                     maxWidth: '100%',
                     fontFamily: 'monospace',
                     fontSize: 11,
+                    border: '1px solid #ffa39e',
                   }}>
                     <div style={{ marginBottom: 8 }}>
-                      <Text strong>错误类型：</Text> {this.state.error.name || 'Error'}
+                      <Text strong style={{ color: '#f5222d' }}>错误类型：</Text> {this.state.error.name || 'Error'}
                     </div>
                     <div style={{ marginBottom: 8 }}>
-                      <Text strong>错误信息：</Text> {this.state.error.message}
+                      <Text strong style={{ color: '#f5222d' }}>错误信息：</Text> {this.state.error.message}
                     </div>
                     {this.state.error.stack && (
                       <div>
-                        <Text strong>堆栈跟踪：</Text>
+                        <Text strong style={{ color: '#f5222d' }}>堆栈跟踪：</Text>
                         <pre style={{ 
                           marginTop: 4,
                           whiteSpace: 'pre-wrap',
                           wordBreak: 'break-word',
+                          background: '#f5f5f5',
+                          padding: 8,
                         }}>
                           {this.state.error.stack}
                         </pre>
@@ -135,16 +154,24 @@ export class ErrorBoundary extends Component<Props, State> {
                     )}
                     {this.state.errorInfo?.componentStack && (
                       <div style={{ marginTop: 12 }}>
-                        <Text strong>组件堆栈：</Text>
+                        <Text strong style={{ color: '#f5222d' }}>组件堆栈：</Text>
                         <pre style={{ 
                           marginTop: 4,
                           whiteSpace: 'pre-wrap',
                           wordBreak: 'break-word',
+                          background: '#f5f5f5',
+                          padding: 8,
                         }}>
                           {this.state.errorInfo.componentStack}
                         </pre>
                       </div>
                     )}
+                    <div style={{ marginTop: 12, padding: 8, background: '#e6f7ff', borderRadius: 4 }}>
+                      <Text strong>💡 调试提示：</Text>
+                      <p style={{ margin: '4px 0 0 0', fontSize: 10 }}>
+                        打开浏览器控制台（F12），输入 <code style={{ background: '#f0f0f0', padding: '2px 4px' }}>window.__LAST_ERROR__</code> 查看完整错误对象
+                      </p>
+                    </div>
                   </div>
                 </details>
               )}


### PR DESCRIPTION
## Purpose
This PR enhances error visibility to help debug the persistent '组件加载失败' issue (#150).

## Changes
- **Auto-expand error details**: Error details are now visible by default (no clicking required)
- **Prominent console logging**: Added visual separators and emoji for easy spotting in console
- **Global error storage**: Errors stored in `window.__LAST_ERROR__` for easy access
- **Visual improvements**: Red highlighting and borders for better error visibility
- **Debugging tips**: Added inline instructions for accessing error details

## Testing
After deployment:
1. Open https://alphaarena-eight.vercel.app
2. Open browser DevTools console (F12)
3. Look for 🚨 ERRORBOUNDARY CAUGHT ERROR 🚨 messages
4. Or check `window.__LAST_ERROR__` in console
5. Error details will be auto-expanded on the page

## Related
- Fixes #150 (needs error details to be captured first)
- Builds on PR #147, #149, #151

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-expanding and enhancing error detail display/logging can expose stack traces and URLs to end users in production, and the new global `window.__LAST_ERROR__` increases the surface for leaking error context. Functional impact is otherwise limited to the error/fallback path.
> 
> **Overview**
> **Improves production debugging for the error fallback path.** `ErrorBoundary` now logs a much more prominent, structured error dump to the console (including component stack) and stores the latest error context on `window.__LAST_ERROR__` for quick inspection.
> 
> **Makes error details visible by default in the UI.** The fallback `details` section is now auto-expanded and restyled with stronger red emphasis, and includes an inline tip pointing developers to `window.__LAST_ERROR__` for full context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2555aa63d7d2a6418dd3f120fca2ff8461dfb28c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->