### PR TITLE
Fix #156: ErrorBoundary retry properly remounts children

### DIFF
--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -15,6 +15,7 @@ interface State {
   error: Error | null;
   errorInfo: ErrorInfo | null;
   retryCount: number;
+  remountKey: number; // Key to force remount on retry
 }
 
 /**
@@ -58,6 +59,7 @@ export class ErrorBoundary extends Component<Props, State> {
       error: null, 
       errorInfo: null,
       retryCount: 0,
+      remountKey: 0,
     };
     
     // Validate configuration on mount
@@ -76,7 +78,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error, errorInfo: null, retryCount: 0 };
+    return { hasError: true, error, errorInfo: null, retryCount: 0, remountKey: 0 };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -117,7 +119,14 @@ export class ErrorBoundary extends Component<Props, State> {
       if (this.state.retryCount < 3) {
         this.retryTimeout = setTimeout(() => {
           console.log('[ErrorBoundary] Attempting auto-retry...');
-          this.setState({ hasError: false, error: null, errorInfo: null, retryCount: this.state.retryCount + 1 });
+          // Increment remountKey to force full remount of children
+          this.setState({ 
+            hasError: false, 
+            error: null, 
+            errorInfo: null, 
+            retryCount: this.state.retryCount + 1,
+            remountKey: this.state.remountKey + 1,
+          });
         }, 500);
         return; // Don't show error UI yet, wait for retry
       }
@@ -128,7 +137,15 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   handleReset = () => {
-    this.setState({ hasError: false, error: null, errorInfo: null, retryCount: 0 });
+    // CRITICAL: Increment remountKey to force React to fully unmount and remount children
+    // Simply clearing error state with setState doesn't trigger remount - children stay in error state
+    this.setState({ 
+      hasError: false, 
+      error: null, 
+      errorInfo: null, 
+      retryCount: 0,
+      remountKey: this.state.remountKey + 1,
+    });
   };
 
   handleReload = () => {
@@ -281,7 +298,9 @@ export class ErrorBoundary extends Component<Props, State> {
       );
     }
 
-    return this.props.children;
+    // CRITICAL: Use remountKey to force full remount when retry is triggered
+    // This ensures children components are properly unmounted and remounted fresh
+    return <React.Fragment key={this.state.remountKey}>{this.props.children}</React.Fragment>;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes P0 bug #156 where the trading pair detail page gets stuck on loading indefinitely.

## Root Cause
ErrorBoundary's retry mechanism used setState to clear error state, but this doesn't trigger a full component remount. Child components remained in error state, causing the loading spinner to persist forever.

## Solution
- Added `remountKey` state variable to track remount cycles
- Modified `handleReset` to increment `remountKey` on retry
- Updated auto-retry logic to also increment `remountKey`
- Wrapped children with `React.Fragment` using `remountKey` as the key prop

This forces React to fully unmount and remount child components when retry is triggered, ensuring they start fresh.

## Testing
- Verified that clicking retry button now properly remounts children
- Loading completes successfully after retry
- No more infinite loading spinner

Closes #156

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `ErrorBoundary` retry behavior to force unmount/remount, which can reset child component state and trigger additional effects on recovery paths.
> 
> **Overview**
> Fixes `ErrorBoundary` retry behavior so that both manual retry and auto-retry after transient third‑party DOM errors fully **remount** the child tree.
> 
> Adds a `remountKey` state counter, increments it on retry, and wraps `children` in a keyed `React.Fragment` so clearing the error state actually recreates the subtree instead of leaving components stuck in a bad/loading state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e80b340dfbceb9a3dbfaca23e3210d8e837a23bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->