### PR TITLE
fix: prevent ErrorBoundary infinite retry loop

### DIFF
--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -51,6 +51,7 @@ function isThirdPartyDOMError(error: Error | null): boolean {
  */
 export class ErrorBoundary extends Component<Props, State> {
   private retryTimeout: NodeJS.Timeout | null = null;
+  private isInRetryCycle = false;
   
   constructor(props: Props) {
     super(props);
@@ -75,6 +76,7 @@ export class ErrorBoundary extends Component<Props, State> {
       clearTimeout(this.retryTimeout);
       this.retryTimeout = null;
     }
+    this.isInRetryCycle = false;
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -116,18 +118,17 @@ export class ErrorBoundary extends Component<Props, State> {
       console.warn('[ErrorBoundary] Detected third-party DOM error, will auto-retry...');
       
       // Auto-retry after a short delay (up to 3 attempts)
-      if (this.state.retryCount < 3) {
+      if (!this.isInRetryCycle && this.state.retryCount < 3) {
+        this.isInRetryCycle = true;
+        if (this.retryTimeout) clearTimeout(this.retryTimeout);
         this.retryTimeout = setTimeout(() => {
-          console.log('[ErrorBoundary] Attempting auto-retry...');
-          // Increment remountKey to force full remount of children
-          this.setState({ 
-            hasError: false, 
-            error: null, 
-            errorInfo: null, 
-            retryCount: this.state.retryCount + 1,
-            remountKey: this.state.remountKey + 1,
-          });
-        }, 500);
+          this.isInRetryCycle = false;
+          this.setState((prevState) => ({
+            hasError: false,
+            retryCount: prevState.retryCount + 1,
+            remountKey: prevState.remountKey + 1,
+          }));
+        }, 1000);
         return; // Don't show error UI yet, wait for retry
       }
     }


### PR DESCRIPTION
## Problem
The ErrorBoundary component had a potential infinite retry loop issue. When a third-party DOM error was caught, the retry logic could trigger multiple times without proper state tracking.

## Solution
- Added `isInRetryCycle` instance variable to track whether a retry is in progress
- Check the flag before initiating a retry to prevent overlapping retry cycles
- Reset the flag in `componentWillUnmount` and after the retry completes
- Changed retry delay from 500ms to 1000ms for better stability
- Updated setState to use prevState pattern for proper state updates

## Changes
1. Added `private isInRetryCycle = false;` instance variable
2. Updated retry logic in `componentDidCatch` to check and set the flag
3. Added `this.isInRetryCycle = false;` in `componentWillUnmount`
4. Improved setState to use functional update pattern

Fixes issue #158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to `ErrorBoundary` retry control flow; main impact is timing/behavior of auto-retry for third-party DOM errors.
> 
> **Overview**
> Prevents `ErrorBoundary` from entering overlapping/infinite auto-retry cycles when handling transient third-party DOM errors.
> 
> Adds an `isInRetryCycle` guard, clears/reset it on unmount and after retry, switches the retry `setState` to a functional update, and increases the retry delay from 500ms to 1000ms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567be4539ba22c105bf2ddb090c3645214cac2ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->