### PR TITLE
fix: K线图表渲染失败 - 等待图表初始化后再设置数据

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -65,6 +65,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
   const [timeframe, setTimeframe] = useState<TimeFrame>('1h');
   const [isMobile, setIsMobile] = useState(false);
   const [chartError, setChartError] = useState<string | null>(null);
+  const [chartReady, setChartReady] = useState(false); // Track when chart is ready for data
   const { klineData, loading, error } = useKLineData(symbol, timeframe);
 
   // Mount state tracking to prevent DOM operations after unmount
@@ -107,6 +108,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
    */
   const cleanupChart = useCallback(() => {
     console.log('[KLineChart] Cleaning up chart resources...');
+    setChartReady(false); // Mark chart as not ready
 
     // Cancel any pending animation frame
     if (initRafRef.current) {
@@ -259,6 +261,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
 
         console.log('[KLineChart] ✅ Chart initialized successfully');
         setChartError(null); // Clear any previous errors
+        setChartReady(true); // Mark chart as ready for data
         return true;
       } catch (err: any) {
         console.error('[KLineChart] ❌ Failed to initialize chart:', err);
@@ -321,8 +324,14 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
     };
   }, [height, showVolume, loading, cleanupChart]);
 
-  // Update data when timeframe or symbol changes
+  // Update data when chart is ready or data changes
   useEffect(() => {
+    // Wait for chart to be ready before setting data
+    if (!chartReady) {
+      console.log('[KLineChart] Chart not ready yet, waiting...');
+      return;
+    }
+
     if (!candleSeriesRef.current) {
       console.warn('[KLineChart] Candle series not ready, skipping data update');
       return;
@@ -411,7 +420,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
         setChartError(`图表数据更新失败：${err.message}`);
       }
     }
-  }, [klineData, showVolume, symbol]);
+  }, [chartReady, klineData, showVolume, symbol]);
 
   // Handle timeframe change
   const handleTimeframeChange = useCallback((value: TimeFrame) => {


### PR DESCRIPTION
## 问题

Issue #161: K线图表渲染失败 - 黑色矩形框无数据

### 根本原因

PR #160 使用  延迟图表初始化，以避免 DOM 操作冲突。但是，数据更新的  没有相应延迟：

1.  hook 获取数据完成，, 
2.  创建 RAF，延迟到下一帧初始化图表
3. **数据更新的  立即执行**：
   - 检查  → （因为 RAF 还没执行）
   - 打印警告并返回，**数据更新被跳过！**
4. RAF 回调执行：
   - 初始化图表成功
   - **但没有数据！**

### 症状

- 图表区域显示为黑色矩形框
- 只有左下角 "TV" (TradingView) 标志
- 没有蜡烛图、时间轴、价格轴

## 修复

添加  state 来追踪图表初始化状态：

1. **新增 state**: 
2. **初始化成功后**:  标记图表已准备好
3. **数据更新时**: 等待  后再设置数据
4. **清理时**: 重置 

### 代码变更

```tsx
// 数据更新的 useEffect 现在会等待图表初始化完成
useEffect(() => {
  // 等待图表准备好再设置数据
  if (!chartReady) {
    console.log('[KLineChart] Chart not ready yet, waiting...');
    return;
  }
  // ... 设置数据
}, [chartReady, klineData, showVolume, symbol]);
```

## 测试

- [ ] 首页 K 线图表正常渲染蜡烛图
- [ ] 切换交易对，图表数据正确更新
- [ ] 切换时间周期，图表正常刷新
- [ ] 浏览器控制台无错误

## 关联

- Fixes #161
- Related to #159, #160

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI fix that changes effect timing so series data is only applied after the chart is initialized; main risk is potential missed/extra renders if the readiness flag isn’t toggled correctly.
> 
> **Overview**
> Fixes a race where K-line data could be fetched before the lightweight-charts instance/series finished initializing, causing the data update effect to no-op and the chart to render empty.
> 
> Adds a `chartReady` flag that is reset during cleanup, set after successful chart initialization, and used to gate the data-setting `useEffect` (including updating its dependency list) so data is applied only once the chart is ready.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 461a141258bbd09d47d486067ae46c6f778487b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->