### PR TITLE
fix: resolve K-line data mismatch when switching trading pairs

### DIFF
--- a/src/client/components/KLineChart.tsx
+++ b/src/client/components/KLineChart.tsx
@@ -66,7 +66,10 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
   const [isMobile, setIsMobile] = useState(false);
   const [chartError, setChartError] = useState<string | null>(null);
   const [chartReady, setChartReady] = useState(false); // Track when chart is ready for data
-  const { klineData, loading, error } = useKLineData(symbol, timeframe);
+  const { klineData, loading, error, currentSymbol } = useKLineData(symbol, timeframe);
+
+  // Track the current symbol to detect changes and clear chart data
+  const prevSymbolRef = useRef<string>(symbol);
 
   // Mount state tracking to prevent DOM operations after unmount
   const isMountedRef = useRef(true);
@@ -132,6 +135,30 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
     candleSeriesRef.current = null;
     volumeSeriesRef.current = null;
   }, []);
+
+  // Clear chart data when symbol changes
+  useEffect(() => {
+    if (prevSymbolRef.current !== symbol) {
+      console.log('[KLineChart] Symbol changed from', prevSymbolRef.current, 'to', symbol, '- clearing chart data');
+      prevSymbolRef.current = symbol;
+      
+      // Clear chart data immediately
+      if (candleSeriesRef.current) {
+        try {
+          candleSeriesRef.current.setData([]);
+        } catch (err) {
+          console.warn('[KLineChart] Error clearing candlestick data:', err);
+        }
+      }
+      if (volumeSeriesRef.current) {
+        try {
+          volumeSeriesRef.current.setData([]);
+        } catch (err) {
+          console.warn('[KLineChart] Error clearing volume data:', err);
+        }
+      }
+    }
+  }, [symbol]);
 
   // Initialize chart - use useLayoutEffect for DOM operations
   // Wait for loading to complete before initializing to avoid DOM conflicts with Spin
@@ -342,6 +369,12 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
       return;
     }
 
+    // Verify data matches current symbol
+    if (currentSymbol !== symbol) {
+      console.warn('[KLineChart] Data symbol mismatch: got', currentSymbol, 'but expected', symbol, '- skipping update');
+      return;
+    }
+
     if (!Array.isArray(klineData)) {
       console.error('[KLineChart] Invalid klineData: not an array', typeof klineData);
       if (isMountedRef.current) {
@@ -374,6 +407,12 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
         }
         return;
       }
+
+      // Log price range for debugging
+      const prices = klineData.map(d => d.close);
+      const minPrice = Math.min(...prices);
+      const maxPrice = Math.max(...prices);
+      console.log('[KLineChart] Price range for', symbol, ':', { min: minPrice, max: maxPrice, first: firstPoint.close });
 
       const candleData: CandlestickData<Time>[] = klineData.map((point, idx) => {
         const time = point.time as UTCTimestamp;
@@ -420,7 +459,7 @@ const KLineChartInner: React.FC<KLineChartProps> = ({
         setChartError(`图表数据更新失败：${err.message}`);
       }
     }
-  }, [chartReady, klineData, showVolume, symbol]);
+  }, [chartReady, klineData, showVolume, symbol, currentSymbol]);
 
   // Handle timeframe change
   const handleTimeframeChange = useCallback((value: TimeFrame) => {

--- a/src/client/hooks/useKLineData.ts
+++ b/src/client/hooks/useKLineData.ts
@@ -2,6 +2,14 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { api } from '../utils/api';
 import type { KLineDataPoint, TimeFrame } from '../components/KLineChart';
 
+interface UseKLineDataResult {
+  klineData: KLineDataPoint[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+  currentSymbol: string; // 暴露当前 symbol 用于验证数据匹配
+}
+
 /**
  * Hook for fetching K-line (candlestick) data
  */
@@ -9,48 +17,97 @@ export const useKLineData = (
   symbol: string,
   timeframe: TimeFrame = '1h',
   limit: number = 1000
-) => {
+): UseKLineDataResult => {
   const [klineData, setKlineData] = useState<KLineDataPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const prevSymbolRef = useRef<string>('');
+  
+  // Track the current symbol to ensure data matches
+  const currentSymbolRef = useRef<string>(symbol);
+  // Track the current request to handle race conditions
+  const requestIdRef = useRef<number>(0);
 
   const fetchKLineData = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    const requestSymbol = symbol;
+    
     try {
       setLoading(true);
       setError(null);
       
-      console.log('[useKLineData] Fetching K-line data for:', { symbol, timeframe, limit });
+      console.log('[useKLineData] Fetching K-line data for:', { symbol, timeframe, limit, requestId });
       const data = await api.getKLineData(symbol, timeframe, limit);
-      console.log('[useKLineData] Received data:', data?.length, 'points');
+      
+      // Check if this is still the current request (no newer request has started)
+      if (requestId !== requestIdRef.current) {
+        console.log('[useKLineData] Stale response detected, ignoring data for:', requestSymbol);
+        return;
+      }
+      
+      // Verify symbol hasn't changed while fetching
+      if (requestSymbol !== currentSymbolRef.current) {
+        console.log('[useKLineData] Symbol changed during fetch, ignoring data for:', requestSymbol);
+        return;
+      }
+      
+      console.log('[useKLineData] Received data:', data?.length, 'points for symbol:', requestSymbol);
       
       if (!Array.isArray(data)) {
         console.error('[useKLineData] Invalid data format: not an array');
         setError('数据格式错误');
         setKlineData([]);
       } else {
+        // Log first data point for debugging
+        if (data.length > 0) {
+          console.log('[useKLineData] First data point for', requestSymbol, ':', {
+            time: data[0].time,
+            open: data[0].open,
+            close: data[0].close,
+          });
+        }
         setKlineData(data);
       }
     } catch (err: any) {
+      // Check if this is still the current request
+      if (requestId !== requestIdRef.current) {
+        console.log('[useKLineData] Stale error response, ignoring for:', requestSymbol);
+        return;
+      }
+      
       console.error('[useKLineData] Failed to fetch K-line data:', err.message);
       setError(err.message || '未知错误');
       setKlineData([]);
     } finally {
-      setLoading(false);
+      // Only update loading state if this is the current request
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [symbol, timeframe, limit]);
 
   useEffect(() => {
-    if (prevSymbolRef.current !== symbol) {
-      console.log('[useKLineData] Symbol changed, resetting data');
+    // Update the current symbol ref
+    const previousSymbol = currentSymbolRef.current;
+    currentSymbolRef.current = symbol;
+    
+    if (previousSymbol !== symbol) {
+      console.log('[useKLineData] Symbol changed from', previousSymbol, 'to', symbol, '- clearing data');
+      // Clear data immediately when symbol changes to prevent stale data
       setKlineData([]);
       setLoading(true);
-      prevSymbolRef.current = symbol;
+      setError(null);
     }
+    
     fetchKLineData();
   }, [fetchKLineData, symbol]);
 
-  return { klineData, loading, error, refresh: fetchKLineData };
+  return { 
+    klineData, 
+    loading, 
+    error, 
+    refresh: fetchKLineData,
+    currentSymbol: symbol 
+  };
 };
 
 export default useKLineData;


### PR DESCRIPTION
## Problem

When switching trading pairs, the K-line chart displayed incorrect data:
- UI showed trading pair as AAPL
- But K-line chart price range was 72,000-88,000 (BTC data)
- AAPL stock price should be around $150-200

## Root Cause Analysis

1. **Race condition in API responses**: When symbol changes, the hook fetches new data but old API responses could still arrive
2. **No stale response handling**: The useKLineData hook did not track request IDs to ignore stale responses
3. **Missing symbol verification**: Chart did not verify that incoming data matches the expected symbol

## Fix Implementation

### 1. useKLineData hook improvements:
- Added `requestIdRef` to track current request and ignore stale responses
- Added `currentSymbolRef` to verify data matches expected symbol
- Return `currentSymbol` for KLineChart validation
- Added detailed logging for debugging

### 2. KLineChart component improvements:
- Added `useEffect` to clear chart data immediately when symbol changes
- Added verification that `currentSymbol === symbol` before updating chart
- Added price range logging for debugging
- Improved error handling and state management

## Testing

- [x] Build passes successfully
- [x] Manual verification needed: switch between BTC/USD, AAPL, ETH/USD and verify chart data matches

## Verification Steps

1. Open the application
2. Select BTC/USD - chart should show prices around $65,000-$70,000
3. Switch to AAPL - chart should show prices around $150-$200
4. Switch to ETH/USD - chart should show prices around $3,000-$4,000
5. Verify no stale data is displayed during transitions

Fixes #163

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async data-fetching and chart update timing; mistakes could cause charts to fail to render or show empty data during rapid symbol changes, but changes are localized to the K-line hook/component.
> 
> **Overview**
> Fixes stale K-line rendering when switching trading pairs by adding request staleness protection in `useKLineData` (request IDs + symbol checks) and clearing cached data immediately on symbol change.
> 
> Updates `KLineChart` to proactively clear series data on symbol switches and to **skip chart updates** when the hook’s `currentSymbol` doesn’t match the displayed `symbol`, reducing race-condition driven mismatches; also adds additional debug logging around received data and price ranges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72327bfb224a8bf7ccfbabb7a0d950272e253974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->