### PR TITLE
fix: 交易面板/订单簿数据未跟随交易对切换

### DIFF
--- a/supabase/functions/get-orderbook/index.ts
+++ b/supabase/functions/get-orderbook/index.ts
@@ -6,6 +6,17 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+// Initial prices for simulation - must match get-market-kline function
+const INITIAL_PRICES: Record<string, number> = {
+  'BTC/USD': 67500.00,
+  'ETH/USD': 3450.00,
+  'AAPL': 175.50,
+  'GOOGL': 140.25,
+  'TSLA': 245.00,
+  'MSFT': 415.75,
+  'NVDA': 875.30,
+};
+
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
@@ -43,10 +54,13 @@ serve(async (req) => {
       throw error;
     }
 
-    // Use latest price or default to simulated price
-    let midPrice = 50000; // Default BTC-like price
+    // Use latest price from database, or fallback to INITIAL_PRICES mapping
+    let midPrice: number;
     if (priceData) {
       midPrice = parseFloat(priceData.price.toString());
+    } else {
+      // Fallback to initial prices mapping (same as K-line function)
+      midPrice = INITIAL_PRICES[symbol] || 100; // Default to 100 if symbol not found
     }
     
     const spread = midPrice * 0.001; // 0.1% spread


### PR DESCRIPTION
## 问题
Fixes #166

切换交易对后，K线图数据正确，但交易面板和订单簿数据未切换，一直显示 BTC/USD 的价格数据。

## 根因分析

**问题根源**：`get-orderbook` Supabase Edge Function 在获取订单簿数据时：

1. 尝试从 `price_history` 表查询实时价格
2. **如果找不到数据，默认回退到 `midPrice = 50000`**（硬编码的 BTC 价格）

而 K线图使用的 `get-market-kline` 函数有正确的初始价格映射：
```typescript
const INITIAL_PRICES: Record<string, number> = {
  'BTC/USD': 67500.00,
  'ETH/USD': 3450.00,
  'AAPL': 175.50,
  // ...
};
```

这导致：
- AAPL 的 K线图显示 ~$175.50（正确）
- AAPL 的订单簿/交易面板显示 ~$50,000（错误的回退值）

## 修复方案

将 `INITIAL_PRICES` 映射添加到 `get-orderbook` 函数中，与 K线图数据源保持一致。

## 修改文件

- `supabase/functions/get-orderbook/index.ts`：添加 `INITIAL_PRICES` 映射

## 验证

切换交易对后，订单簿和交易面板价格应与 K线图一致。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the fallback pricing logic in `get-orderbook` when the latest `price_history` row is missing, aligning it with existing K-line defaults.
> 
> **Overview**
> Fixes orderbook/quote generation for non-`BTC/USD` symbols by replacing the hardcoded fallback `midPrice` with a shared `INITIAL_PRICES` mapping (matching `get-market-kline`). When no `price_history` data exists for a symbol, the orderbook now seeds prices from this per-symbol default (or `100` as a last resort) so switching trading pairs produces consistent orderbook prices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da1e813896076c7c12e220d6f6a5807f755520dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->