### PR TITLE
fix: correct currentPrice calculation in TradingOrder

### DIFF
--- a/src/client/components/TradingOrder.tsx
+++ b/src/client/components/TradingOrder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import {
   Card,
   Tabs,
@@ -87,10 +87,34 @@ const TradingOrder: React.FC<TradingOrderProps> = ({
   const baseBalance = portfolio?.positions.find(p => p.symbol === baseCurrency)?.quantity || 0;
   const totalPortfolioValue = portfolio?.totalValue || availableBalance;
 
-  // Get current market price
-  const currentPrice = orderBook ? 
-    ((orderBook.bids[0]?.price + orderBook.asks[0]?.price) / 2) : 0;
+  // Get current market price - must find best bid/ask (highest bid, lowest ask)
+  // because API returns unsorted arrays
+  const currentPrice = useMemo(() => {
+    if (!orderBook?.bids?.length || !orderBook?.asks?.length) {
+      return 0;
+    }
 
+    // Find best bid (highest price) and best ask (lowest price)
+    let bestBid = -Infinity;
+    let bestAsk = Infinity;
+
+    for (let i = 0; i < orderBook.bids.length; i++) {
+      const price = orderBook.bids[i].price;
+      if (price > bestBid) bestBid = price;
+    }
+
+    for (let i = 0; i < orderBook.asks.length; i++) {
+      const price = orderBook.asks[i].price;
+      if (price < bestAsk) bestAsk = price;
+    }
+
+    // Validate we found valid prices
+    if (bestBid === -Infinity || bestAsk === Infinity) {
+      return 0;
+    }
+
+    return (bestBid + bestAsk) / 2;
+  }, [orderBook]);
   // Real-time validation function
   const validateField = useCallback((field: 'price' | 'quantity' | 'triggerPrice', value: number | undefined): ValidationError | null => {
     const formData = formRef.current?.getFieldsValue();


### PR DESCRIPTION
## Summary

Fixes #168 - K线图与订单簿价格不一致，交易面板显示undefined

### Problem
1. **TradingOrder 直接使用 `bids[0]` 和 `asks[0]`**：假设它们是最佳价格，但 API 返回的订单簿数据是乱序的
2. **价格计算错误**：当数组乱序时，中间价计算不正确
3. **undefined 显示**：如果订单簿为空或加载失败，`bids[0]?.price` 返回 undefined

### Solution
修改 `currentPrice` 的计算逻辑：
- 遍历整个订单簿数组找到真正的最佳买价（最高价）和最佳卖价（最低价）
- 与 `OrderBook.tsx` 中 `spreadInfo` 的计算逻辑保持一致
- 添加空值检查，避免 undefined 显示

### Testing
- 构建成功：`npm run build` ✅
- 本地测试：价格计算正确，不再显示 undefined

### Root Cause Analysis
`get-orderbook` Edge Function 生成的 bids 和 asks 数组没有按价格排序，而前端组件假设数组已排序。正确的做法是在前端找到最佳价格，而不是依赖数组顺序。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `currentPrice` is derived for order validation and order totals, which can affect what users see and submit. Scope is limited to the `TradingOrder` UI and adds guards for empty/invalid order books.
> 
> **Overview**
> Fixes `TradingOrder` mid-price calculation by no longer assuming `orderBook.bids[0]`/`asks[0]` are the best prices (the API can return unsorted arrays).
> 
> `currentPrice` is now memoized and computed by scanning for the highest bid and lowest ask with null/empty checks, preventing incorrect/undefined prices from propagating into validation and order total calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd4fedc66ae1dbb08b4ae484b27cd5dc86bcc049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->