### PR TITLE
fix: symbol 格式不一致导致 quoteCurrency 解析失败 (Issue #170)

### DIFF
--- a/src/client/components/TradingOrder.tsx
+++ b/src/client/components/TradingOrder.tsx
@@ -33,6 +33,16 @@ interface OrderFormData {
 }
 
 interface TradingOrderProps {
+  /**
+   * Optional base currency (e.g., "BTC", "AAPL")
+   * If not provided, will be parsed from symbol
+   */
+  baseCurrency?: string;
+  /**
+   * Optional quote currency (e.g., "USD", "USDT")
+   * If not provided, will be parsed from symbol or default to "USD"
+   */
+  quoteCurrency?: string;
   symbol?: string;
   onOrderPlaced?: (orderId: string) => void;
 }
@@ -48,6 +58,8 @@ const TRADING_FEE_RATE = 0.001; // 0.1% trading fee
 
 const TradingOrder: React.FC<TradingOrderProps> = ({
   symbol = 'BTC/USD',
+  baseCurrency: baseCurrencyProp,
+  quoteCurrency: quoteCurrencyProp,
   onOrderPlaced,
 }) => {
   const [activeTab, setActiveTab] = useState<OrderSide>('buy');
@@ -82,8 +94,14 @@ const TradingOrder: React.FC<TradingOrderProps> = ({
 
   // Calculate available balance
   const availableBalance = portfolio?.cashBalance || 0;
-  const baseCurrency = symbol.split('/')[0];
-  const quoteCurrency = symbol.split('/')[1];
+  
+  // Resolve baseCurrency and quoteCurrency:
+  // 1. Use props if provided (from parent with API data)
+  // 2. Fallback to parsing symbol (works for crypto pairs like "BTC/USD")
+  // 3. For stock symbols like "AAPL", default quoteCurrency to "USD"
+  const symbolParts = symbol.split('/');
+  const baseCurrency = baseCurrencyProp || symbolParts[0] || symbol;
+  const quoteCurrency = quoteCurrencyProp || symbolParts[1] || 'USD';
   const baseBalance = portfolio?.positions.find(p => p.symbol === baseCurrency)?.quantity || 0;
   const totalPortfolioValue = portfolio?.totalValue || availableBalance;
 

--- a/src/client/hooks/useMarketData.ts
+++ b/src/client/hooks/useMarketData.ts
@@ -96,16 +96,37 @@ export const useMarketData = (refreshInterval: number = 3000) => {
 
 /**
  * Transform MarketTick API response to TradingPair format
+ * 
+ * IMPORTANT: API now returns baseCurrency and quoteCurrency fields directly.
+ * We prioritize these fields over symbol parsing to handle both:
+ * - Crypto pairs like "BTC/USD" → baseCurrency="BTC", quoteCurrency="USD"
+ * - Stock symbols like "AAPL" → baseCurrency="AAPL", quoteCurrency="USD"
  */
 function transformMarketTickToTradingPair(tick: any): TradingPair {
   const symbol = tick.symbol || 'UNKNOWN';
-  const [baseCurrency, quoteCurrency] = symbol.split('/');
+  
+  // Prioritize API-provided baseCurrency and quoteCurrency fields
+  // Fallback to symbol parsing only if API doesn't provide these fields
+  let baseCurrency: string;
+  let quoteCurrency: string;
+  
+  if (tick.baseCurrency && tick.quoteCurrency) {
+    // API provided the currencies directly - use them
+    baseCurrency = tick.baseCurrency;
+    quoteCurrency = tick.quoteCurrency;
+  } else {
+    // Fallback: parse from symbol (works for crypto pairs like "BTC/USD")
+    // For stock symbols like "AAPL", split('/')[1] would be undefined
+    const [base, quote] = symbol.split('/');
+    baseCurrency = base || symbol || 'UNKNOWN';
+    quoteCurrency = quote || 'USD'; // Default to USD for stock symbols
+  }
 
   return {
     symbol,
-    baseCurrency: baseCurrency || 'UNKNOWN',
-    quoteCurrency: quoteCurrency || 'USD',
-    lastPrice: tick.price || 0,
+    baseCurrency,
+    quoteCurrency,
+    lastPrice: tick.lastPrice ?? tick.price ?? 0,
     priceChange24h: tick.priceChange24h || 0,
     priceChangePercent24h: tick.priceChangePercent24h || 0,
     high24h: tick.high24h || 0,

--- a/src/client/pages/HomePage.tsx
+++ b/src/client/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import TradingOrder from '../components/TradingOrder';
 import OrderBook from '../components/OrderBook';
 import ConditionalOrdersPanel from '../components/ConditionalOrdersPanel';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { useMarketData } from '../hooks/useMarketData';
 
 const { Content } = Layout;
 const { Row, Col } = Grid;
@@ -13,6 +14,10 @@ const { Row, Col } = Grid;
 const HomePage: React.FC = () => {
   const [selectedSymbol, setSelectedSymbol] = useState('BTC/USD');
   const [isMobile, setIsMobile] = useState(false);
+  
+  // Get market data to resolve baseCurrency/quoteCurrency for selected symbol
+  const { marketData } = useMarketData();
+  const selectedPair = marketData.find(p => p.symbol === selectedSymbol);
 
   // Stable callback for resize handler to prevent re-creation
   const checkMobile = useCallback(() => {
@@ -55,7 +60,7 @@ const HomePage: React.FC = () => {
           </Card>
           <ErrorBoundary><KLineChart symbol={selectedSymbol} height={300} /></ErrorBoundary>
           <ErrorBoundary><OrderBook symbol={selectedSymbol} levels={10} onPriceClick={handlePriceClick} /></ErrorBoundary>
-          <ErrorBoundary><TradingOrder symbol={selectedSymbol} onOrderPlaced={handleOrderPlaced} /></ErrorBoundary>
+          <ErrorBoundary><TradingOrder symbol={selectedSymbol} baseCurrency={selectedPair?.baseCurrency} quoteCurrency={selectedPair?.quoteCurrency} onOrderPlaced={handleOrderPlaced} /></ErrorBoundary>
           <ErrorBoundary><ConditionalOrdersPanel symbol={selectedSymbol} limit={5} /></ErrorBoundary>
         </div>
       ) : (
@@ -74,7 +79,7 @@ const HomePage: React.FC = () => {
           <Col xs={24} sm={12} md={5}>
             <Row gutter={[0, 16]} style={{ height: '100%', overflow: 'auto' }}>
               <Col span={24}>
-                <ErrorBoundary><TradingOrder symbol={selectedSymbol} onOrderPlaced={handleOrderPlaced} /></ErrorBoundary>
+                <ErrorBoundary><TradingOrder symbol={selectedSymbol} baseCurrency={selectedPair?.baseCurrency} quoteCurrency={selectedPair?.quoteCurrency} onOrderPlaced={handleOrderPlaced} /></ErrorBoundary>
               </Col>
               <Col span={24}>
                 <ErrorBoundary><ConditionalOrdersPanel symbol={selectedSymbol} limit={10} /></ErrorBoundary>


### PR DESCRIPTION
## 问题描述

交易面板显示 `undefined`，原因是 symbol 格式不一致导致 quoteCurrency 解析失败。

### 根因分析

| 交易类型 | symbol 格式 | split("/")[1] 结果 |
|---------|------------|---------------------|
| 股票 (AAPL) | `"AAPL"` | `undefined` ❌ |
| 加密货币 (BTC/USD) | `"BTC/USD"` | `"USD"` ✅ |

API 已返回 `baseCurrency` 和 `quoteCurrency` 字段，但前端未使用，而是依赖 symbol 字符串解析。

## 修复方案

### 1. `useMarketData.ts`
- 优先使用 API 返回的 `baseCurrency` 和 `quoteCurrency` 字段
- 仅在 API 未提供时回退到 symbol 解析
- 对于股票 symbol，默认 quoteCurrency 为 "USD"

### 2. `TradingOrder.tsx`
- 添加可选的 `baseCurrency` 和 `quoteCurrency` props
- 支持父组件传入已解析的 currency 信息
- 保留 symbol 解析作为回退方案

### 3. `HomePage.tsx`
- 使用 `useMarketData` hook 获取市场数据
- 将解析后的 currency 信息传递给 `TradingOrder` 组件

## 验证

- ✅ TypeScript 编译通过
- ✅ 单元测试通过 (9 tests)
- ✅ AAPL 等股票 symbol 显示正确的 quoteCurrency (USD)
- ✅ BTC/USD 等加密货币 pair 正常工作

## 关联 Issue

Fixes #170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `baseCurrency`/`quoteCurrency` are derived and passed into the order ticket, which affects displayed units, balance lookups, and validation messages for orders (especially for stock symbols without `/`). Scope is limited to client-side parsing/mapping, with low likelihood of impacting order submission payloads beyond UI context.
> 
> **Overview**
> Fixes currency display/derivation when `symbol` is not in `BASE/QUOTE` format (e.g. stocks like `AAPL`). `useMarketData` now prefers API-provided `baseCurrency`/`quoteCurrency` (with symbol-parsing fallback and default `quoteCurrency` of `USD`) and also maps `lastPrice` from `tick.lastPrice`.
> 
> `TradingOrder` accepts optional `baseCurrency`/`quoteCurrency` props and falls back to parsing `symbol`/defaulting to `USD`, and `HomePage` wires this through by looking up the selected pair from `useMarketData` and passing currencies into `TradingOrder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31aabfbf51cf526a9d96ed6f5a0746b251bb7cb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->