### PR TITLE
fix: trigger degraded mode on 'reconnecting' status

### DIFF
--- a/src/client/store/connectionStore.tsx
+++ b/src/client/store/connectionStore.tsx
@@ -113,7 +113,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   const setStatus = useCallback((status: ConnectionStatus) => {
     setState(prev => {
       // If setting to disconnected but REST API is available, use degraded instead
-      if (status === 'disconnected' && prev.isRestApiAvailable) {
+      if ((status === 'disconnected' || status === 'reconnecting') && prev.isRestApiAvailable) {
         return {
           ...prev,
           status: 'degraded',


### PR DESCRIPTION
## Summary

Fixes WebSocket degradation logic to handle 'reconnecting' status.

## Root Cause

The  only handled 'disconnected' → 'degraded' transition, but the actual connection flow goes 'connecting' → 'reconnecting'. When WebSocket enters 'reconnecting' state, the degraded mode was not triggered, leaving users seeing connection errors instead of graceful degradation.

## Fix

Modified the  method in  to treat 'reconnecting' status the same as 'disconnected' when REST API is available:

```javascript
if ((status === 'disconnected' || status === 'reconnecting') && prev.isRestApiAvailable) {
  return {
    ...prev,
    status: 'degraded',
    lastDisconnectedAt: Date.now(),
  };
}
```

## Verification

- ✅ Degraded mode correctly triggers on 'reconnecting' status
- ✅ Users see friendly degradation message instead of connection error
- ✅ REST API data continues to work during WebSocket reconnection

## Testing

1. Simulate WebSocket disconnection (network throttle or server restart)
2. Observe status transitions: 'connecting' → 'reconnecting' → 'degraded'
3. Verify friendly UI message shows: "实时推送暂停，使用 API 轮询"
4. Verify data continues to load via REST API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk conditional change limited to connection status transitions; main risk is altering UI/state behavior during transient reconnects.
> 
> **Overview**
> Updates `ConnectionProvider`’s `setStatus` logic so that when status becomes `reconnecting` (in addition to `disconnected`) and `isRestApiAvailable` is true, the store switches to **`degraded`** and records `lastDisconnectedAt`, enabling graceful REST fallback during realtime reconnect attempts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd9b4258da7f7bf844f0ba18ab1ff59ef89697df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->