### PR TITLE
fix: correct Supabase RealtimeChannel unsubscribe API usage

### DIFF
--- a/src/api/SupabaseRealtimeService.ts
+++ b/src/api/SupabaseRealtimeService.ts
@@ -280,9 +280,6 @@ export class SupabaseRealtimeService {
   /**
    * Listen to broadcast messages on a channel
    */
-/**
-   * Listen to broadcast messages on a channel
-   */
   public onBroadcast(
     topic: string,
     event: string | '*',
@@ -307,9 +304,6 @@ export class SupabaseRealtimeService {
   }
 
   /**
-   * Listen to presence events
-   */
-/**
    * Listen to presence events
    */
   public onPresence(

--- a/src/client/utils/realtime.ts
+++ b/src/client/utils/realtime.ts
@@ -359,9 +359,6 @@ export class RealtimeClient {
   /**
    * Listen to broadcast messages
    */
-/**
-   * Listen to broadcast messages
-   */
   public on(topic: string, event: string, callback: (payload: any) => void): () => void {
     const channel = this.getChannel(topic);
     const filter = { event };


### PR DESCRIPTION
## Summary

Fixes #182

The Holdings page was showing "组件加载失败" error with  in the console.

## Root Cause

The issue was in  and . We were using:
- `channel.on('broadcast', handler)` - missing filter object
- `channel.off('broadcast', handler)` - `off` method doesn't exist

Supabase RealtimeChannel API:
- `on('broadcast', { event }, handler)` - requires filter object
- `_off('broadcast', filter)` - private method for unsubscription

## Changes

1. **realtime.ts**: 
   - Added `filter` object to `on` method call
   - Changed `off` to `_off` with filter object

2. **SupabaseRealtimeService.ts**:
   - Same fixes for `onBroadcast` method
   - Fixed `onPresence` method's cleanup function

## Testing

- TypeScript compilation passes
- Build succeeds
- Manual testing on Holdings page recommended

## Acceptance Criteria

- [ ] Holdings page loads without errors
- [ ] No console errors related to realtime subscriptions
- [ ] Real-time updates still work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime subscription/unsubscription paths; using Supabase’s private `_off` API and filter objects could break if the library changes, and incorrect filters could leak listeners or miss events.
> 
> **Overview**
> Fixes Supabase Realtime subscription API usage for broadcast and presence listeners.
> 
> `SupabaseRealtimeService.onBroadcast` and `RealtimeClient.on` now call `channel.on('broadcast', { event }, handler)` (instead of an unfiltered handler) and unsubscribe via `(channel as any)._off('broadcast', { event })`. Presence cleanup in both service/client is also updated to remove listeners via `_off` for `sync`/`join`/`leave`, replacing the prior `off`/no-op handler approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7170fad5f8ddc7c19875448bcd6bf7e05ec23970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->