### PR TITLE
feat(ci): Integrate E2E tests into GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,89 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Puppeteer browsers
+        run: npx puppeteer browsers install chrome
+
+      - name: Build application
+        run: npm run build:client
+
+      - name: Start preview server
+        run: |
+          npx vite preview --port 3000 --host &
+          echo "Waiting for server to start..."
+          for i in {1..30}; do
+            if curl -s http://localhost:3000 > /dev/null 2>&1; then
+              echo "Server is ready on http://localhost:3000"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 1
+          done
+
+      - name: Create output directory
+        run: mkdir -p midscene_run
+
+      - name: Run E2E tests - Trading Pair Switching
+        id: test-trading
+        run: |
+          E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/trading-pair-switching.test.ts
+          echo "trading_result=\$?" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Run E2E tests - Page Navigation
+        id: test-nav
+        run: |
+          E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/page-navigation.test.ts
+          echo "nav_result=\$?" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-test-artifacts
+          path: |
+            midscene_run/
+          retention-days: 14
+
+      - name: Aggregate test results
+        run: |
+          echo "## E2E Test Results Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test Suite | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Trading Pair Switching | ${{ steps.test-trading.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Page Navigation | ${{ steps.test-nav.outcome == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Test artifacts (screenshots) are available in the workflow artifacts." >> $GITHUB_STEP_SUMMARY
+
+      - name: Check overall test status
+        run: |
+          if [[ "${{ steps.test-trading.outcome }}" != "success" || "${{ steps.test-nav.outcome }}" != "success" ]]; then
+            echo "❌ One or more E2E test suites failed. Check artifacts for details."
+            exit 1
+          fi
+          echo "✅ All E2E tests passed!"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 
 # Supabase
 .supabase/
+
+# E2E test output
+midscene_run/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
+    "test:e2e": "E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/trading-pair-switching.test.ts && E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/page-navigation.test.ts",
+    "test:e2e:trading": "E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/trading-pair-switching.test.ts",
+    "test:e2e:nav": "E2E_BASE_URL=http://localhost:3000 npx ts-node --transpile-only tests/e2e/page-navigation.test.ts",
+    "preview": "vite preview --port 3000 --host"
   },
   "repository": {
     "type": "git",
@@ -56,7 +60,8 @@
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "ts-node": "^10.9.2"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.66.11",


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow for automated E2E testing
- Integrates existing E2E tests (trading-pair-switching, page-navigation) into CI/CD pipeline
- Tests run automatically on push to main and PRs

## Changes

### New Files
- `.github/workflows/e2e-test.yml` - GitHub Actions workflow for E2E tests

### Modified Files
- `package.json` - Added E2E test scripts and ts-node dependency
- `.gitignore` - Added `midscene_run/` to ignore test output

## Workflow Features

- ✅ Runs on push to `main` branch
- ✅ Runs on pull requests to `main` branch
- ✅ Installs Puppeteer browsers automatically
- ✅ Builds and serves the application using Vite preview
- ✅ Runs both E2E test suites (trading pair switching + page navigation)
- ✅ Uploads screenshots as artifacts for debugging
- ✅ Provides test summary in workflow output
- ✅ Fails the build if any tests fail

## Test Plan

- [x] Workflow file created and validated
- [x] E2E test scripts added to package.json
- [ ] CI workflow runs successfully (will verify after merge)

## Related Issues

Closes #186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk repo/CI change that adds a new GitHub Actions workflow and npm scripts; primary impact is CI runtime/stability rather than production code behavior.
> 
> **Overview**
> Adds an `E2E Tests` GitHub Actions workflow that builds the client, starts a `vite preview` server, runs the existing Puppeteer E2E suites (`trading-pair-switching` and `page-navigation`), uploads `midscene_run/` screenshots as artifacts, and fails the job if any suite fails.
> 
> Updates `package.json` with `test:e2e*` and `preview` scripts and adds `ts-node` to support running the TypeScript E2E tests locally/CI, and ignores `midscene_run/` output in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d06fd3811ff8fe87b30252394181bcf3a70bf38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->