### PR TITLE
fix: resolve left sidebar not rendering (Issue #194)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -117,7 +117,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <Layout style={{ minHeight: '100vh' }}>
         {/* Desktop Sider */}
         {!isMobile && (
-          <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed}>
+          <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed} theme="dark">
           <div
             style={{
               height: 32,

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -183,7 +183,7 @@ body {
 /* Responsive layout adjustments */
 @media (max-width: 768px) {
   /* Layout adjustments */
-  .ant-layout-sider {
+  .arco-layout-sider {
     position: fixed;
     left: 0;
     top: 0;
@@ -191,7 +191,7 @@ body {
     z-index: 1000;
   }
 
-  .ant-layout-sider-collapsed {
+  .arco-layout-sider-collapsed {
     width: 0 !important;
   }
 


### PR DESCRIPTION
## Summary
Fixes #194

This is a clean, minimal fix for the left sidebar not rendering issue.

## Root Cause
1. The Sider component was missing the `theme="dark"` prop required by Arco Design
2. CSS selectors were using Ant Design class names (`.ant-layout-sider`) instead of Arco Design class names (`.arco-layout-sider`)

## Changes
- **src/client/App.tsx**: Added `theme="dark"` to the Sider component
- **src/client/index.css**: Updated CSS selectors from `.ant-layout-sider` to `.arco-layout-sider`

## Files Changed
- `src/client/App.tsx` - 1 line changed
- `src/client/index.css` - 2 lines changed

Total: 2 files, 3 insertions, 3 deletions

## Testing
- Verified the sidebar renders correctly with dark theme
- Mobile responsive styles still apply correctly

## Note
This PR replaces #199 which contained 29 unrelated files. This PR contains only the essential fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust an Arco `Sider` prop and mobile CSS selectors; main risk is minor layout/style regressions on small screens.
> 
> **Overview**
> Fixes the left sidebar not rendering by setting the desktop `Sider` to `theme="dark"` in `App.tsx`.
> 
> Updates the mobile responsive CSS to target Arco layout classes (`.arco-layout-sider` / `.arco-layout-sider-collapsed`) instead of Ant Design equivalents so the sider positioning/collapsing rules apply.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a316d614ace49dc93a53ce54cacbda708da9b33f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->