### PR TITLE
fix: add explicit width to Sider component

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -117,7 +117,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <Layout style={{ minHeight: '100vh' }}>
         {/* Desktop Sider */}
         {!isMobile && (
-          <Sider collapsible collapsed={collapsed} onCollapse={setCollapsed} theme="dark">
+          <Sider width={200} collapsedWidth={48} collapsible collapsed={collapsed} onCollapse={setCollapsed} theme="dark">
           <div
             style={{
               height: 32,

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -450,3 +450,15 @@ body {
 .realtime-indicator.disconnected {
   background-color: #cf1322;
 }
+
+/* Desktop Sider explicit width */
+@media (min-width: 769px) {
+  .arco-layout-sider {
+    width: 200px !important;
+    min-width: 200px;
+  }
+  .arco-layout-sider-collapsed {
+    width: 48px !important;
+    min-width: 48px;
+  }
+}


### PR DESCRIPTION
## Root Cause
- Sider component did not have `width` prop set
- CSS styles only applied on mobile (max-width: 768px)
- Desktop had no explicit width defined

## Changes
1. **App.tsx**: Added `width={200}` and `collapsedWidth={48}` props to Sider component
2. **index.css**: Added desktop media query (`min-width: 769px`) with explicit sider width styles

## Files Changed
- `src/client/App.tsx` - Added width props to Sider
- `src/client/index.css` - Added desktop sider width CSS rules

## Testing
- Desktop: Sider should have 200px width (expanded) / 48px (collapsed)
- Mobile: No change (existing mobile styles still apply)