### PR TITLE
feat(strategy): Add RSI (Relative Strength Index) trading strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,19 @@ npx alpha-arena portfolio --show
 npx alpha-arena run --strategy sma --symbol BTC/USDT --timeframe 1h
 ```
 
-#### 2. 执行历史回测
+#### 2. 运行 RSI 策略
+
+```bash
+npx alpha-arena run --strategy rsi --symbol BTC/USDT --timeframe 1h
+```
+
+#### 3. 执行历史回测
 
 ```bash
 npx alpha-arena backtest --strategy sma --symbol BTC/USDT --start 2024-01-01 --end 2024-12-31 --initial-capital 10000
 ```
 
-#### 3. 查看当前持仓
+#### 4. 查看当前持仓
 
 ```bash
 npx alpha-arena portfolio --show
@@ -77,7 +83,7 @@ npx alpha-arena portfolio --show
 ### 代码使用示例
 
 ```typescript
-import { OrderBook, MatchingEngine, Portfolio, SMAStrategy } from 'alphaarena';
+import { OrderBook, MatchingEngine, Portfolio, SMAStrategy, RSIStrategy } from 'alphaarena';
 
 // 创建订单簿
 const orderBook = new OrderBook('BTC/USDT');
@@ -92,8 +98,11 @@ const engine = new MatchingEngine(orderBook);
 // 创建投资组合
 const portfolio = new Portfolio(10000); // 初始资金 10000 USDT
 
-// 创建策略
-const strategy = new SMAStrategy({ shortPeriod: 10, longPeriod: 30 });
+// 创建 SMA 策略
+const smaStrategy = new SMAStrategy({ shortPeriod: 10, longPeriod: 30 });
+
+// 创建 RSI 策略
+const rsiStrategy = new RSIStrategy({ period: 14, overbought: 70, oversold: 30 });
 ```
 
 ## 架构说明
@@ -121,6 +130,7 @@ AlphaArena/
 │   ├── strategy/         # 策略框架模块
 │   │   ├── Strategy.ts   # 策略接口
 │   │   ├── SMAStrategy.ts # SMA 交叉策略实现
+│   │   ├── RSIStrategy.ts # RSI 策略实现
 │   │   ├── types.ts      # 策略类型定义
 │   │   └── index.ts      # 模块导出
 │   │
@@ -158,6 +168,31 @@ AlphaArena/
 3. **Portfolio**: 跟踪现金和持仓变化，计算盈亏
 4. **Strategy**: 定义策略接口，包括 `onData()`, `generateSignal()`, `execute()` 等方法
 5. **BacktestEngine**: 模拟历史交易，评估策略表现
+
+### 内置策略
+
+#### SMA 交叉策略 (SMAStrategy)
+
+基于简单移动平均线的交叉策略：
+- **金叉**：短期均线上穿长期均线 → 买入信号
+- **死叉**：短期均线下穿长期均线 → 卖出信号
+
+配置参数：
+- `shortPeriod`: 短期均线周期 (默认: 5)
+- `longPeriod`: 长期均线周期 (默认: 20)
+- `tradeQuantity`: 每次交易数量 (默认: 10)
+
+#### RSI 策略 (RSIStrategy)
+
+基于相对强弱指数的动量策略：
+- **超卖信号**：RSI < 30 → 买入信号
+- **超买信号**：RSI > 70 → 卖出信号
+
+配置参数：
+- `period`: RSI 计算周期 (默认: 14)
+- `overbought`: 超买阈值 (默认: 70)
+- `oversold`: 超卖阈值 (默认: 30)
+- `tradeQuantity`: 每次交易数量 (默认: 10)
 
 ## 开发
 

--- a/src/backtest/BacktestEngine.ts
+++ b/src/backtest/BacktestEngine.ts
@@ -14,6 +14,7 @@ import { Portfolio } from '../portfolio/Portfolio';
 import { OrderBook } from '../orderbook/OrderBook';
 import { MatchingEngine } from '../matching/MatchingEngine';
 import { SMAStrategy } from '../strategy/SMAStrategy';
+import { RSIStrategy } from '../strategy/RSIStrategy';
 import { Strategy } from '../strategy/Strategy';
 import { OrderType, Order } from '../orderbook/types';
 import { PortfolioSnapshot } from '../portfolio/types';
@@ -60,6 +61,17 @@ export class BacktestEngine {
           params: {
             shortPeriod: params?.shortPeriod ?? 5,
             longPeriod: params?.longPeriod ?? 20,
+            tradeQuantity: params?.tradeQuantity ?? 10,
+          },
+        });
+      case 'rsi':
+        return new RSIStrategy({
+          id: 'rsi-strategy',
+          name: 'RSI Strategy',
+          params: {
+            period: params?.period ?? 14,
+            overbought: params?.overbought ?? 70,
+            oversold: params?.oversold ?? 30,
             tradeQuantity: params?.tradeQuantity ?? 10,
           },
         });

--- a/src/cli/realtime-runner.ts
+++ b/src/cli/realtime-runner.ts
@@ -11,6 +11,7 @@
 import { TradingEngine } from '../engine/TradingEngine';
 import { EngineConfig, EngineState, RiskControlConfig } from '../engine/types';
 import { SMAStrategy } from '../strategy/SMAStrategy';
+import { RSIStrategy } from '../strategy/RSIStrategy';
 
 /**
  * Real-time Trading Runner Configuration
@@ -24,13 +25,16 @@ export interface RunnerConfig {
   initialCapital: number;
   /** Strategies to run */
   strategies: Array<{
-    type: 'SMA';
+    type: 'SMA' | 'RSI';
     params: {
       id: string;
       name: string;
       params: {
-        shortPeriod: number;
-        longPeriod: number;
+        shortPeriod?: number;
+        longPeriod?: number;
+        period?: number;
+        overbought?: number;
+        oversold?: number;
         tradeQuantity: number;
       };
     };
@@ -130,7 +134,15 @@ export class RealtimeRunner {
           const strategy = new SMAStrategy({
             id: strategyConfig.params.id,
             name: strategyConfig.params.name,
-            params: strategyConfig.params.params,
+            params: strategyConfig.params.params as any,
+          });
+          this.engine!.addStrategy(strategy);
+          console.log(`[${new Date().toISOString()}]   ✓ Strategy added: ${strategyConfig.params.id}`);
+        } else if (strategyConfig.type === 'RSI') {
+          const strategy = new RSIStrategy({
+            id: strategyConfig.params.id,
+            name: strategyConfig.params.name,
+            params: strategyConfig.params.params as any,
           });
           this.engine!.addStrategy(strategy);
           console.log(`[${new Date().toISOString()}]   ✓ Strategy added: ${strategyConfig.params.id}`);

--- a/src/strategy/RSIStrategy.ts
+++ b/src/strategy/RSIStrategy.ts
@@ -1,0 +1,291 @@
+/**
+ * RSI (Relative Strength Index) Strategy
+ *
+ * A momentum oscillator strategy that generates buy signals when RSI is below
+ * the oversold threshold (indicating potential upward reversal) and sell signals
+ * when RSI is above the overbought threshold (indicating potential downward reversal).
+ *
+ * RSI Formula:
+ * RSI = 100 - (100 / (1 + RS))
+ * RS = Average Gain / Average Loss
+ */
+
+import { Strategy } from './Strategy';
+import { StrategyConfig, StrategyContext, OrderSignal } from './types';
+
+/**
+ * RSI Strategy configuration
+ */
+export interface RSIStrategyConfig extends StrategyConfig {
+  params?: {
+    /** RSI period (default: 14) */
+    period?: number;
+    /** Overbought threshold (default: 70) - RSI above this indicates overbought */
+    overbought?: number;
+    /** Oversold threshold (default: 30) - RSI below this indicates oversold */
+    oversold?: number;
+    /** Quantity to trade per signal */
+    tradeQuantity?: number;
+  };
+}
+
+/**
+ * RSI Strategy - RSI 策略
+ *
+ * Implements RSI (Relative Strength Index) strategy:
+ * - RSI < oversold (default 30): Buy signal (oversold condition)
+ * - RSI > overbought (default 70): Sell signal (overbought condition)
+ * - Otherwise: No signal
+ */
+export class RSIStrategy extends Strategy {
+  private period: number;
+  private overbought: number;
+  private oversold: number;
+  private tradeQuantity: number;
+
+  // Price history for RSI calculation
+  private priceHistory: number[] = [];
+  // Previous average gain and loss for smooth RSI calculation
+  private prevAvgGain: number | null = null;
+  private prevAvgLoss: number | null = null;
+  // Last calculated RSI value
+  private lastRSI: number | null = null;
+  // Track if we've seen enough data to calculate RSI
+  private hasEnoughData: boolean = false;
+
+  // Track if we're in a position to avoid repeated signals
+  private lastSignal: 'buy' | 'sell' | null = null;
+
+  constructor(config: RSIStrategyConfig) {
+    super(config);
+
+    // Default parameters
+    this.period = config.params?.period ?? 14;
+    this.overbought = config.params?.overbought ?? 70;
+    this.oversold = config.params?.oversold ?? 30;
+    this.tradeQuantity = config.params?.tradeQuantity ?? 10;
+
+    // Validate parameters
+    if (this.period <= 1) {
+      throw new Error('RSI period must be greater than 1');
+    }
+    if (this.oversold >= this.overbought) {
+      throw new Error('Oversold threshold must be less than overbought threshold');
+    }
+    if (this.oversold <= 0 || this.overbought >= 100) {
+      throw new Error('Thresholds must be between 0 and 100');
+    }
+    if (this.tradeQuantity <= 0) {
+      throw new Error('Trade quantity must be positive');
+    }
+  }
+
+  /**
+   * Initialize strategy
+   */
+  protected init(_context: StrategyContext): void {
+    this.priceHistory = [];
+    this.prevAvgGain = null;
+    this.prevAvgLoss = null;
+    this.lastRSI = null;
+    this.hasEnoughData = false;
+    this.lastSignal = null;
+  }
+
+  /**
+   * Handle tick event - generate trading signals based on RSI
+   */
+  onTick(context: StrategyContext): OrderSignal | null {
+    const marketData = context.getMarketData();
+
+    // Get the mid price from order book
+    const midPrice = this.getMidPrice(marketData.orderBook);
+    if (midPrice === null) {
+      return null;
+    }
+
+    // Add price to history
+    this.priceHistory.push(midPrice);
+
+    // Need at least (period + 1) data points to calculate RSI
+    // (period price changes require period + 1 prices)
+    if (this.priceHistory.length < this.period + 1) {
+      return null;
+    }
+
+    // Calculate RSI
+    const rsi = this.calculateRSI();
+
+    if (rsi === null) {
+      return null;
+    }
+
+    this.lastRSI = rsi;
+    this.hasEnoughData = true;
+
+    // Generate signal based on RSI levels
+    let signal: OrderSignal | null = null;
+
+    // Buy signal: RSI < oversold (and not already signaled buy)
+    if (rsi < this.oversold && this.lastSignal !== 'buy') {
+      signal = this.createSignal('buy', midPrice, this.tradeQuantity, {
+        confidence: this.calculateConfidence(rsi, 'buy'),
+        reason: `RSI Oversold: RSI=${rsi.toFixed(2)} < ${this.oversold}`,
+      });
+      this.lastSignal = 'buy';
+    }
+    // Sell signal: RSI > overbought (and not already signaled sell)
+    else if (rsi > this.overbought && this.lastSignal !== 'sell') {
+      signal = this.createSignal('sell', midPrice, this.tradeQuantity, {
+        confidence: this.calculateConfidence(rsi, 'sell'),
+        reason: `RSI Overbought: RSI=${rsi.toFixed(2)} > ${this.overbought}`,
+      });
+      this.lastSignal = 'sell';
+    }
+    // Reset signal state when RSI is in neutral zone
+    else if (rsi >= this.oversold && rsi <= this.overbought) {
+      this.lastSignal = null;
+    }
+
+    return signal;
+  }
+
+  /**
+   * Get mid price from order book
+   */
+  private getMidPrice(orderBook: any): number | null {
+    // Try to get best bid and ask
+    const bestBid = orderBook.getBestBid?.();
+    const bestAsk = orderBook.getBestAsk?.();
+
+    if (bestBid !== null && bestAsk !== null) {
+      return (bestBid + bestAsk) / 2;
+    }
+
+    // Fallback to last trade price if available
+    return null;
+  }
+
+  /**
+   * Calculate RSI using Wilder's smoothing method
+   *
+   * RSI = 100 - (100 / (1 + RS))
+   * RS = Average Gain / Average Loss
+   */
+  private calculateRSI(): number | null {
+    if (this.priceHistory.length < this.period + 1) {
+      return null;
+    }
+
+    // Calculate price changes
+    const changes: number[] = [];
+    for (let i = 1; i < this.priceHistory.length; i++) {
+      changes.push(this.priceHistory[i] - this.priceHistory[i - 1]);
+    }
+
+    // Separate gains and losses
+    const gains = changes.map(c => (c > 0 ? c : 0));
+    const losses = changes.map(c => (c < 0 ? Math.abs(c) : 0));
+
+    let avgGain: number;
+    let avgLoss: number;
+
+    // First calculation: simple average
+    if (this.prevAvgGain === null || this.prevAvgLoss === null) {
+      // Use the first 'period' changes for initial average
+      const initialGains = gains.slice(0, this.period);
+      const initialLosses = losses.slice(0, this.period);
+
+      avgGain = initialGains.reduce((a, b) => a + b, 0) / this.period;
+      avgLoss = initialLosses.reduce((a, b) => a + b, 0) / this.period;
+    } else {
+      // Use Wilder's smoothing method
+      // New Average = ((Previous Average * (period - 1)) + Current) / period
+      const lastGain = gains[gains.length - 1];
+      const lastLoss = losses[losses.length - 1];
+
+      avgGain = (this.prevAvgGain * (this.period - 1) + lastGain) / this.period;
+      avgLoss = (this.prevAvgLoss * (this.period - 1) + lastLoss) / this.period;
+    }
+
+    // Store for next calculation
+    this.prevAvgGain = avgGain;
+    this.prevAvgLoss = avgLoss;
+
+    // Calculate RS and RSI
+    if (avgLoss === 0) {
+      // If no losses, RSI is 100
+      return 100;
+    }
+
+    const rs = avgGain / avgLoss;
+    const rsi = 100 - (100 / (1 + rs));
+
+    return rsi;
+  }
+
+  /**
+   * Calculate confidence based on RSI extremity
+   * More extreme RSI = higher confidence
+   */
+  private calculateConfidence(rsi: number, side: 'buy' | 'sell'): number {
+    if (side === 'buy') {
+      // RSI closer to 0 = more oversold = higher confidence
+      // Scale from 0.5 (at oversold threshold) to 0.9 (at RSI=0)
+      const extremity = 1 - (rsi / this.oversold);
+      return Math.min(0.5 + extremity * 0.4, 0.9);
+    } else {
+      // RSI closer to 100 = more overbought = higher confidence
+      // Scale from 0.5 (at overbought threshold) to 0.9 (at RSI=100)
+      const extremity = (rsi - this.overbought) / (100 - this.overbought);
+      return Math.min(0.5 + extremity * 0.4, 0.9);
+    }
+  }
+
+  /**
+   * Get current RSI value
+   */
+  getRSI(): number | null {
+    return this.lastRSI;
+  }
+
+  /**
+   * Get price history length
+   */
+  getPriceHistoryLength(): number {
+    return this.priceHistory.length;
+  }
+
+  /**
+   * Check if strategy has enough data to calculate RSI
+   */
+  isReady(): boolean {
+    return this.hasEnoughData;
+  }
+
+  /**
+   * Get current average gain (for testing/debugging)
+   */
+  getAvgGain(): number | null {
+    return this.prevAvgGain;
+  }
+
+  /**
+   * Get current average loss (for testing/debugging)
+   */
+  getAvgLoss(): number | null {
+    return this.prevAvgLoss;
+  }
+
+  /**
+   * Reset strategy state (useful for backtesting)
+   */
+  reset(): void {
+    this.priceHistory = [];
+    this.prevAvgGain = null;
+    this.prevAvgLoss = null;
+    this.lastRSI = null;
+    this.hasEnoughData = false;
+    this.lastSignal = null;
+  }
+}

--- a/src/strategy/index.ts
+++ b/src/strategy/index.ts
@@ -7,6 +7,7 @@
 export * from './types';
 export * from './Strategy';
 export * from './SMAStrategy';
+export * from './RSIStrategy';
 export * from './StrategyManager';
 export * from './LeaderboardService';
 export * from './LLMClient';

--- a/tests/strategy/rsi.test.ts
+++ b/tests/strategy/rsi.test.ts
@@ -1,0 +1,698 @@
+/**
+ * RSI Strategy Tests
+ *
+ * Tests for the RSI (Relative Strength Index) Strategy implementation
+ */
+
+import { RSIStrategy, RSIStrategyConfig } from '../../src/strategy/RSIStrategy';
+import { StrategyContext, OrderSignal } from '../../src/strategy';
+
+/**
+ * Mock OrderBook for testing
+ */
+class MockOrderBook {
+  private bestBidPrice: number;
+  private bestAskPrice: number;
+
+  constructor(bid: number, ask: number) {
+    this.bestBidPrice = bid;
+    this.bestAskPrice = ask;
+  }
+
+  getBestBid(): number | null {
+    return this.bestBidPrice;
+  }
+
+  getBestAsk(): number | null {
+    return this.bestAskPrice;
+  }
+
+  setPrices(bid: number, ask: number) {
+    this.bestBidPrice = bid;
+    this.bestAskPrice = ask;
+  }
+}
+
+/**
+ * Create mock context with configurable order book
+ */
+function createMockContext(orderBook: MockOrderBook): StrategyContext {
+  return {
+    portfolio: {
+      cash: 100000,
+      positions: [],
+      totalValue: 100000,
+      unrealizedPnL: 0,
+      timestamp: Date.now(),
+    },
+    clock: Date.now(),
+    getMarketData: () => ({
+      orderBook: orderBook as any,
+      trades: [],
+      timestamp: Date.now(),
+    }),
+    getPosition: (_symbol: string) => 0,
+    getCash: () => 100000,
+  };
+}
+
+describe('RSIStrategy', () => {
+  describe('Construction', () => {
+    test('should create strategy with default parameters', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-default',
+        name: 'RSI Default Strategy',
+      };
+      const strategy = new RSIStrategy(config);
+
+      expect(strategy).toBeDefined();
+      expect(strategy.getConfig().id).toBe('rsi-default');
+    });
+
+    test('should create strategy with custom parameters', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-custom',
+        name: 'RSI Custom Strategy',
+        params: {
+          period: 21,
+          overbought: 80,
+          oversold: 20,
+          tradeQuantity: 50,
+        },
+      };
+      const strategy = new RSIStrategy(config);
+
+      expect(strategy.getConfig().params?.period).toBe(21);
+      expect(strategy.getConfig().params?.overbought).toBe(80);
+      expect(strategy.getConfig().params?.oversold).toBe(20);
+      expect(strategy.getConfig().params?.tradeQuantity).toBe(50);
+    });
+
+    test('should throw error when period is <= 1', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-invalid-period',
+        name: 'RSI Invalid Period',
+        params: {
+          period: 1,
+        },
+      };
+
+      expect(() => new RSIStrategy(config)).toThrow('RSI period must be greater than 1');
+    });
+
+    test('should throw error when oversold >= overbought', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-invalid-thresholds',
+        name: 'RSI Invalid Thresholds',
+        params: {
+          oversold: 70,
+          overbought: 70,
+        },
+      };
+
+      expect(() => new RSIStrategy(config)).toThrow('Oversold threshold must be less than overbought threshold');
+    });
+
+    test('should throw error when thresholds are out of range', () => {
+      const config1: RSIStrategyConfig = {
+        id: 'rsi-invalid-threshold1',
+        name: 'RSI Invalid Threshold1',
+        params: {
+          oversold: 0,
+        },
+      };
+
+      const config2: RSIStrategyConfig = {
+        id: 'rsi-invalid-threshold2',
+        name: 'RSI Invalid Threshold2',
+        params: {
+          overbought: 100,
+        },
+      };
+
+      expect(() => new RSIStrategy(config1)).toThrow('Thresholds must be between 0 and 100');
+      expect(() => new RSIStrategy(config2)).toThrow('Thresholds must be between 0 and 100');
+    });
+
+    test('should throw error when trade quantity is not positive', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-invalid-quantity',
+        name: 'RSI Invalid Quantity',
+        params: {
+          tradeQuantity: 0,
+        },
+      };
+
+      expect(() => new RSIStrategy(config)).toThrow('Trade quantity must be positive');
+    });
+  });
+
+  describe('RSI Calculation', () => {
+    let strategy: RSIStrategy;
+    let orderBook: MockOrderBook;
+    let context: StrategyContext;
+
+    beforeEach(() => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-test',
+        name: 'RSI Test Strategy',
+        params: {
+          period: 5,
+          overbought: 70,
+          oversold: 30,
+        },
+      };
+      strategy = new RSIStrategy(config);
+      orderBook = new MockOrderBook(100, 102);
+      context = createMockContext(orderBook);
+      strategy.onInit(context);
+    });
+
+    test('should not calculate RSI until enough data points', () => {
+      // Need period + 1 = 6 prices for period 5
+      for (let i = 0; i < 5; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        strategy.onTick(context);
+      }
+
+      expect(strategy.isReady()).toBe(false);
+      expect(strategy.getRSI()).toBeNull();
+    });
+
+    test('should calculate RSI after enough data points', () => {
+      // Feed 6 prices for period 5
+      for (let i = 0; i < 6; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        strategy.onTick(context);
+      }
+
+      expect(strategy.isReady()).toBe(true);
+      expect(strategy.getRSI()).not.toBeNull();
+      // RSI should be between 0 and 100
+      expect(strategy.getRSI()).toBeGreaterThanOrEqual(0);
+      expect(strategy.getRSI()).toBeLessThanOrEqual(100);
+    });
+
+    test('should calculate correct RSI for upward trend', () => {
+      // Prices that consistently go up should result in high RSI
+      const prices = [100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        strategy.onTick(context);
+      }
+
+      // In a strong upward trend, RSI should be high (above 70)
+      expect(strategy.getRSI()).toBeGreaterThan(70);
+    });
+
+    test('should calculate correct RSI for downward trend', () => {
+      // Prices that consistently go down should result in low RSI
+      const prices = [120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        strategy.onTick(context);
+      }
+
+      // In a strong downward trend, RSI should be low (below 30)
+      expect(strategy.getRSI()).toBeLessThan(30);
+    });
+
+    test('should calculate RSI = 50 for no price change', () => {
+      // Prices that stay flat should result in RSI around 50
+      const prices = [100, 100, 100, 100, 100, 100, 100, 100, 100, 100];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        strategy.onTick(context);
+      }
+
+      // No gains or losses, but RSI calculation handles division by zero
+      // When there are no losses, RSI should be 100 (all gains)
+      // When there are no gains, RSI should be 0
+      // When there are neither, it's 100 by convention
+      expect(strategy.getRSI()).toBe(100);
+    });
+
+    test('should use Wilder smoothing for subsequent calculations', () => {
+      // Feed initial data with realistic price movements
+      const prices = [100, 102, 101, 103, 102, 104];
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        strategy.onTick(context);
+      }
+
+      const firstRSI = strategy.getRSI();
+      const firstAvgGain = strategy.getAvgGain();
+      const firstAvgLoss = strategy.getAvgLoss();
+
+      // Feed more data with a significant drop to change the RSI
+      orderBook.setPrices(98, 100);
+      strategy.onTick(context);
+
+      const secondRSI = strategy.getRSI();
+      const secondAvgGain = strategy.getAvgGain();
+      const secondAvgLoss = strategy.getAvgLoss();
+
+      // RSI should change smoothly (Wilder's smoothing)
+      expect(firstRSI).not.toBeNull();
+      expect(secondRSI).not.toBeNull();
+      
+      // Average gain and loss should be smoothed (not recalculated from scratch)
+      // With Wilder's smoothing, the averages change gradually
+      expect(firstAvgGain).not.toBeNull();
+      expect(firstAvgLoss).not.toBeNull();
+      expect(secondAvgGain).not.toBeNull();
+      expect(secondAvgLoss).not.toBeNull();
+      
+      // The presence of a loss should increase avgLoss
+      expect(secondAvgLoss).toBeGreaterThan(firstAvgLoss!);
+    });
+  });
+
+  describe('Buy Signals (Oversold)', () => {
+    let strategy: RSIStrategy;
+    let orderBook: MockOrderBook;
+    let context: StrategyContext;
+
+    beforeEach(() => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-buy',
+        name: 'RSI Buy Test',
+        params: {
+          period: 5,
+          overbought: 70,
+          oversold: 30,
+        },
+      };
+      strategy = new RSIStrategy(config);
+      orderBook = new MockOrderBook(100, 102);
+      context = createMockContext(orderBook);
+      strategy.onInit(context);
+    });
+
+    test('should generate buy signal when RSI < oversold threshold', () => {
+      // Create a strong downtrend to get RSI below 30
+      const prices = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50];
+      let buySignal: OrderSignal | null = null;
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'buy') {
+          buySignal = signal;
+        }
+      }
+
+      expect(buySignal).not.toBeNull();
+      expect(buySignal!.side).toBe('buy');
+      expect(buySignal!.reason).toContain('Oversold');
+    });
+
+    test('should not generate repeated buy signals while oversold', () => {
+      // Create a downtrend
+      const prices = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50, 48, 46, 44];
+      let buySignalCount = 0;
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'buy') {
+          buySignalCount++;
+        }
+      }
+
+      // Should only generate one buy signal, not repeated ones
+      expect(buySignalCount).toBe(1);
+    });
+
+    test('should generate new buy signal after RSI normalizes', () => {
+      // Strong downtrend
+      const downtrendPrices = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50];
+      let buySignalCount = 0;
+
+      for (const price of downtrendPrices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'buy') {
+          buySignalCount++;
+        }
+      }
+
+      // RSI should be oversold, one buy signal generated
+      expect(buySignalCount).toBe(1);
+
+      // Prices stabilize (RSI moves to neutral zone)
+      const neutralPrices = [52, 54, 56, 58, 60, 62, 64, 66, 68, 70];
+      for (const price of neutralPrices) {
+        orderBook.setPrices(price - 1, price + 1);
+        strategy.onTick(context);
+      }
+
+      // Another strong downtrend
+      const downtrend2 = [65, 60, 55, 50, 45, 40, 35, 30, 25];
+      for (const price of downtrend2) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'buy') {
+          buySignalCount++;
+        }
+      }
+
+      // Should have generated a second buy signal
+      expect(buySignalCount).toBe(2);
+    });
+  });
+
+  describe('Sell Signals (Overbought)', () => {
+    let strategy: RSIStrategy;
+    let orderBook: MockOrderBook;
+    let context: StrategyContext;
+
+    beforeEach(() => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-sell',
+        name: 'RSI Sell Test',
+        params: {
+          period: 5,
+          overbought: 70,
+          oversold: 30,
+        },
+      };
+      strategy = new RSIStrategy(config);
+      orderBook = new MockOrderBook(100, 102);
+      context = createMockContext(orderBook);
+      strategy.onInit(context);
+    });
+
+    test('should generate sell signal when RSI > overbought threshold', () => {
+      // Create a strong uptrend to get RSI above 70
+      const prices = [50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100];
+      let sellSignal: OrderSignal | null = null;
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'sell') {
+          sellSignal = signal;
+        }
+      }
+
+      expect(sellSignal).not.toBeNull();
+      expect(sellSignal!.side).toBe('sell');
+      expect(sellSignal!.reason).toContain('Overbought');
+    });
+
+    test('should not generate repeated sell signals while overbought', () => {
+      // Create an uptrend
+      const prices = [50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115];
+      let sellSignalCount = 0;
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'sell') {
+          sellSignalCount++;
+        }
+      }
+
+      // Should only generate one sell signal, not repeated ones
+      expect(sellSignalCount).toBe(1);
+    });
+  });
+
+  describe('Signal Structure', () => {
+    let strategy: RSIStrategy;
+    let orderBook: MockOrderBook;
+    let context: StrategyContext;
+
+    beforeEach(() => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-signal',
+        name: 'RSI Signal Test',
+        params: {
+          period: 5,
+          overbought: 70,
+          oversold: 30,
+          tradeQuantity: 25,
+        },
+      };
+      strategy = new RSIStrategy(config);
+      orderBook = new MockOrderBook(100, 102);
+      context = createMockContext(orderBook);
+      strategy.onInit(context);
+    });
+
+    test('should generate signal with correct quantity', () => {
+      const prices = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal) {
+          expect(signal.quantity).toBe(25);
+          break;
+        }
+      }
+    });
+
+    test('should generate signal with valid structure', () => {
+      const prices = [100, 95, 90, 85, 80, 75, 70, 65, 60, 55, 50];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal) {
+          expect(signal.id).toBeDefined();
+          expect(signal.side).toBeDefined();
+          expect(signal.price).toBeDefined();
+          expect(signal.quantity).toBeDefined();
+          expect(signal.timestamp).toBeDefined();
+          expect(signal.confidence).toBeDefined();
+          expect(signal.reason).toBeDefined();
+          break;
+        }
+      }
+    });
+
+    test('should calculate confidence based on RSI extremity', () => {
+      // Strong downtrend for high confidence buy
+      const prices = [100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 5];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        if (signal && signal.side === 'buy') {
+          // More extreme RSI should result in higher confidence
+          expect(signal.confidence).toBeGreaterThan(0.5);
+          expect(signal.confidence).toBeLessThanOrEqual(0.9);
+          break;
+        }
+      }
+    });
+  });
+
+  describe('Reset Functionality', () => {
+    let strategy: RSIStrategy;
+    let orderBook: MockOrderBook;
+    let context: StrategyContext;
+
+    beforeEach(() => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-reset',
+        name: 'RSI Reset Test',
+        params: {
+          period: 5,
+        },
+      };
+      strategy = new RSIStrategy(config);
+      orderBook = new MockOrderBook(100, 102);
+      context = createMockContext(orderBook);
+      strategy.onInit(context);
+    });
+
+    test('should reset strategy state', () => {
+      // Feed some prices
+      for (let i = 0; i < 10; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        strategy.onTick(context);
+      }
+
+      expect(strategy.getPriceHistoryLength()).toBe(10);
+      expect(strategy.isReady()).toBe(true);
+
+      // Reset
+      strategy.reset();
+
+      expect(strategy.getPriceHistoryLength()).toBe(0);
+      expect(strategy.isReady()).toBe(false);
+      expect(strategy.getRSI()).toBeNull();
+    });
+
+    test('should work correctly after reset', () => {
+      // First round
+      for (let i = 0; i < 10; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        strategy.onTick(context);
+      }
+
+      // Reset and start again
+      strategy.reset();
+
+      // Should not have RSI until enough data
+      for (let i = 0; i < 5; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        const signal = strategy.onTick(context);
+        expect(strategy.isReady()).toBe(false);
+        expect(signal).toBeNull();
+      }
+    });
+  });
+
+  describe('Backtesting Support', () => {
+    test('should support multiple reset cycles for backtesting', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-backtest',
+        name: 'RSI Backtest',
+        params: {
+          period: 5,
+        },
+      };
+      const strategy = new RSIStrategy(config);
+      const orderBook = new MockOrderBook(100, 102);
+      const context = createMockContext(orderBook);
+
+      // Run multiple backtest cycles
+      for (let cycle = 0; cycle < 3; cycle++) {
+        strategy.onInit(context);
+
+        // Feed prices
+        for (let i = 0; i < 15; i++) {
+          orderBook.setPrices(100 + i + cycle * 10, 102 + i + cycle * 10);
+          strategy.onTick(context);
+        }
+
+        expect(strategy.isReady()).toBe(true);
+        strategy.reset();
+      }
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('should handle empty order book gracefully', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-edge',
+        name: 'RSI Edge Test',
+        params: {
+          period: 5,
+        },
+      };
+      const strategy = new RSIStrategy(config);
+
+      const emptyOrderBook = {};
+      const context: StrategyContext = {
+        portfolio: {
+          cash: 100000,
+          positions: [],
+          totalValue: 100000,
+          unrealizedPnL: 0,
+          timestamp: Date.now(),
+        },
+        clock: Date.now(),
+        getMarketData: () => ({
+          orderBook: emptyOrderBook as any,
+          trades: [],
+          timestamp: Date.now(),
+        }),
+        getPosition: (_symbol: string) => 0,
+        getCash: () => 100000,
+      };
+
+      strategy.onInit(context);
+
+      // Should not throw, just return null
+      expect(() => strategy.onTick(context)).not.toThrow();
+      expect(strategy.onTick(context)).toBeNull();
+    });
+
+    test('should handle oscillating prices', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-oscillate',
+        name: 'RSI Oscillate Test',
+        params: {
+          period: 5,
+          overbought: 70,
+          oversold: 30,
+        },
+      };
+      const strategy = new RSIStrategy(config);
+      const orderBook = new MockOrderBook(100, 102);
+      const context = createMockContext(orderBook);
+      strategy.onInit(context);
+
+      // Oscillating prices (up, down, up, down)
+      const prices = [100, 110, 95, 115, 90, 120, 85, 125, 80, 130, 75, 135];
+
+      for (const price of prices) {
+        orderBook.setPrices(price - 1, price + 1);
+        const signal = strategy.onTick(context);
+        // Should not throw
+        expect(signal === null || typeof signal === 'object').toBe(true);
+      }
+
+      // RSI should be valid
+      expect(strategy.getRSI()).toBeGreaterThanOrEqual(0);
+      expect(strategy.getRSI()).toBeLessThanOrEqual(100);
+    });
+
+    test('should handle zero price change', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-zero-change',
+        name: 'RSI Zero Change Test',
+        params: {
+          period: 5,
+        },
+      };
+      const strategy = new RSIStrategy(config);
+      const orderBook = new MockOrderBook(100, 102);
+      const context = createMockContext(orderBook);
+      strategy.onInit(context);
+
+      // All prices the same (no change)
+      for (let i = 0; i < 15; i++) {
+        orderBook.setPrices(100, 102);
+        strategy.onTick(context);
+      }
+
+      // No losses, so RSI should be 100
+      expect(strategy.getRSI()).toBe(100);
+    });
+  });
+
+  describe('Integration with Strategy Interface', () => {
+    test('should implement IStrategy interface correctly', () => {
+      const config: RSIStrategyConfig = {
+        id: 'rsi-interface',
+        name: 'RSI Interface Test',
+      };
+      const strategy = new RSIStrategy(config);
+      const orderBook = new MockOrderBook(100, 102);
+      const context = createMockContext(orderBook);
+
+      // Test lifecycle
+      strategy.onInit(context);
+      expect(strategy.isInitialized()).toBe(true);
+
+      // Test tick processing
+      for (let i = 0; i < 10; i++) {
+        orderBook.setPrices(100 + i, 102 + i);
+        strategy.onTick(context);
+      }
+
+      // Test cleanup
+      strategy.onCleanup(context);
+      expect(strategy.isInitialized()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements RSI (Relative Strength Index) trading strategy as specified in Issue #195.

## Changes

### New Files
- `src/strategy/RSIStrategy.ts` - RSI strategy implementation
- `tests/strategy/rsi.test.ts` - Comprehensive unit tests (27 tests)

### Modified Files
- `src/strategy/index.ts` - Export RSIStrategy
- `src/backtest/BacktestEngine.ts` - Add RSI strategy support
- `src/cli/realtime-runner.ts` - Add RSI strategy support
- `README.md` - Document RSI strategy

## Implementation Details

### RSI Calculation
- Uses Wilder's smoothing method for RSI calculation
- Formula: `RSI = 100 - (100 / (1 + RS))` where `RS = Average Gain / Average Loss`
- Requires `period + 1` data points to calculate (default: 15 prices for period 14)

### Trading Signals
- **Buy Signal**: RSI < oversold threshold (default 30)
- **Sell Signal**: RSI > overbought threshold (default 70)
- Confidence scoring based on RSI extremity (more extreme = higher confidence)

### Configuration Parameters
- `period`: RSI calculation period (default: 14)
- `overbought`: Overbought threshold (default: 70)
- `oversold`: Oversold threshold (default: 30)
- `tradeQuantity`: Trade quantity per signal (default: 10)

## Testing

All 27 unit tests pass:
- Construction and validation tests
- RSI calculation tests
- Buy/sell signal generation tests
- Reset and backtesting support tests
- Edge case handling tests

## Usage

### Code
```typescript
import { RSIStrategy } from 'alphaarena';

const strategy = new RSIStrategy({
  id: 'rsi-btc',
  name: 'RSI Strategy - BTC/USDT',
  params: {
    period: 14,
    overbought: 70,
    oversold: 30,
    tradeQuantity: 10,
  },
});
```

### CLI
```bash
npx alpha-arena run --strategy rsi --symbol BTC/USDT
npx alpha-arena backtest --strategy rsi --symbol BTC/USDT --start 2024-01-01 --end 2024-12-31
```

Closes #195