### PR TITLE
feat(strategy): Add MACD trading strategy

### DIFF
--- a/src/backtest/BacktestEngine.ts
+++ b/src/backtest/BacktestEngine.ts
@@ -15,6 +15,7 @@ import { OrderBook } from '../orderbook/OrderBook';
 import { MatchingEngine } from '../matching/MatchingEngine';
 import { SMAStrategy } from '../strategy/SMAStrategy';
 import { RSIStrategy } from '../strategy/RSIStrategy';
+import { MACDStrategy } from '../strategy/MACDStrategy';
 import { Strategy } from '../strategy/Strategy';
 import { OrderType, Order } from '../orderbook/types';
 import { PortfolioSnapshot } from '../portfolio/types';
@@ -72,6 +73,17 @@ export class BacktestEngine {
             period: params?.period ?? 14,
             overbought: params?.overbought ?? 70,
             oversold: params?.oversold ?? 30,
+            tradeQuantity: params?.tradeQuantity ?? 10,
+          },
+        });
+      case 'macd':
+        return new MACDStrategy({
+          id: 'macd-strategy',
+          name: 'MACD Strategy',
+          params: {
+            fastPeriod: params?.fastPeriod ?? 12,
+            slowPeriod: params?.slowPeriod ?? 26,
+            signalPeriod: params?.signalPeriod ?? 9,
             tradeQuantity: params?.tradeQuantity ?? 10,
           },
         });

--- a/src/strategy/MACDStrategy.ts
+++ b/src/strategy/MACDStrategy.ts
@@ -1,0 +1,348 @@
+/**
+ * MACD (Moving Average Convergence Divergence) Strategy
+ *
+ * A trend-following momentum strategy that generates buy signals when the MACD line
+ * crosses above the signal line (golden cross/bullish crossover), and sell signals
+ * when the MACD line crosses below the signal line (death cross/bearish crossover).
+ *
+ * MACD Formula:
+ * MACD Line = EMA(fastPeriod) - EMA(slowPeriod)
+ * Signal Line = EMA(MACD Line, signalPeriod)
+ * Histogram = MACD Line - Signal Line
+ *
+ * Standard parameters: fast=12, slow=26, signal=9
+ */
+
+import { Strategy } from './Strategy';
+import { StrategyConfig, StrategyContext, OrderSignal } from './types';
+
+/**
+ * MACD Strategy configuration
+ */
+export interface MACDStrategyConfig extends StrategyConfig {
+  params?: {
+    /** Fast EMA period (default: 12) */
+    fastPeriod?: number;
+    /** Slow EMA period (default: 26) */
+    slowPeriod?: number;
+    /** Signal line period (default: 9) */
+    signalPeriod?: number;
+    /** Quantity to trade per signal */
+    tradeQuantity?: number;
+  };
+}
+
+/**
+ * MACD data point
+ */
+export interface MACDData {
+  macdLine: number;
+  signalLine: number;
+  histogram: number;
+}
+
+/**
+ * MACD Strategy - MACD 策略
+ *
+ * Implements MACD (Moving Average Convergence Divergence) strategy:
+ * - Golden Cross: MACD line crosses above signal line → Buy signal
+ * - Death Cross: MACD line crosses below signal line → Sell signal
+ * - Otherwise: No signal
+ */
+export class MACDStrategy extends Strategy {
+  private fastPeriod: number;
+  private slowPeriod: number;
+  private signalPeriod: number;
+  private tradeQuantity: number;
+
+  // Price history for EMA calculation
+  private priceHistory: number[] = [];
+  // EMA values for fast and slow periods
+  private fastEMA: number | null = null;
+  private slowEMA: number | null = null;
+  // MACD line history for signal line calculation
+  private macdHistory: number[] = [];
+  // Signal line EMA
+  private signalLine: number | null = null;
+  // Last MACD data for crossover detection
+  private lastMACDLine: number | null = null;
+  private lastSignalLine: number | null = null;
+  // Current MACD data (for external access)
+  private currentMACD: MACDData | null = null;
+
+  constructor(config: MACDStrategyConfig) {
+    super(config);
+
+    // Default parameters (standard MACD settings)
+    this.fastPeriod = config.params?.fastPeriod ?? 12;
+    this.slowPeriod = config.params?.slowPeriod ?? 26;
+    this.signalPeriod = config.params?.signalPeriod ?? 9;
+    this.tradeQuantity = config.params?.tradeQuantity ?? 10;
+
+    // Validate parameters
+    if (this.fastPeriod >= this.slowPeriod) {
+      throw new Error('Fast period must be less than slow period');
+    }
+    if (this.fastPeriod <= 0 || this.slowPeriod <= 0 || this.signalPeriod <= 0) {
+      throw new Error('All periods must be positive');
+    }
+    if (this.tradeQuantity <= 0) {
+      throw new Error('Trade quantity must be positive');
+    }
+  }
+
+  /**
+   * Initialize strategy
+   */
+  protected init(_context: StrategyContext): void {
+    this.priceHistory = [];
+    this.fastEMA = null;
+    this.slowEMA = null;
+    this.macdHistory = [];
+    this.signalLine = null;
+    this.lastMACDLine = null;
+    this.lastSignalLine = null;
+    this.currentMACD = null;
+  }
+
+  /**
+   * Handle tick event - generate trading signals based on MACD crossover
+   */
+  onTick(context: StrategyContext): OrderSignal | null {
+    const marketData = context.getMarketData();
+
+    // Get the mid price from order book
+    const midPrice = this.getMidPrice(marketData.orderBook);
+    if (midPrice === null) {
+      return null;
+    }
+
+    // Add price to history
+    this.priceHistory.push(midPrice);
+
+    // Need at least slowPeriod data points to calculate slow EMA
+    if (this.priceHistory.length < this.slowPeriod) {
+      return null;
+    }
+
+    // Calculate EMAs
+    this.fastEMA = this.calculateEMA(this.fastPeriod, this.fastEMA);
+    this.slowEMA = this.calculateEMA(this.slowPeriod, this.slowEMA);
+
+    if (this.fastEMA === null || this.slowEMA === null) {
+      return null;
+    }
+
+    // Calculate MACD line
+    const macdLine = this.fastEMA - this.slowEMA;
+    this.macdHistory.push(macdLine);
+
+    // Need at least signalPeriod MACD values to calculate signal line
+    if (this.macdHistory.length < this.signalPeriod) {
+      return null;
+    }
+
+    // Calculate signal line (EMA of MACD line)
+    this.signalLine = this.calculateSignalEMA(this.signalPeriod, this.signalLine);
+
+    if (this.signalLine === null) {
+      return null;
+    }
+
+    // Calculate histogram
+    const histogram = macdLine - this.signalLine;
+
+    // Store current MACD data
+    this.currentMACD = {
+      macdLine,
+      signalLine: this.signalLine,
+      histogram,
+    };
+
+    // Generate signal based on crossover
+    let signal: OrderSignal | null = null;
+
+    if (this.lastMACDLine !== null && this.lastSignalLine !== null) {
+      // Golden Cross: MACD line crosses above signal line
+      if (this.lastMACDLine <= this.lastSignalLine && macdLine > this.signalLine) {
+        signal = this.createSignal('buy', midPrice, this.tradeQuantity, {
+          confidence: this.calculateConfidence(histogram, 'buy'),
+          reason: `MACD Golden Cross: MACD(${macdLine.toFixed(4)}) crossed above Signal(${this.signalLine.toFixed(4)})`,
+        });
+      }
+      // Death Cross: MACD line crosses below signal line
+      else if (this.lastMACDLine >= this.lastSignalLine && macdLine < this.signalLine) {
+        signal = this.createSignal('sell', midPrice, this.tradeQuantity, {
+          confidence: this.calculateConfidence(histogram, 'sell'),
+          reason: `MACD Death Cross: MACD(${macdLine.toFixed(4)}) crossed below Signal(${this.signalLine.toFixed(4)})`,
+        });
+      }
+    }
+
+    // Update last values for next crossover detection
+    this.lastMACDLine = macdLine;
+    this.lastSignalLine = this.signalLine;
+
+    return signal;
+  }
+
+  /**
+   * Get mid price from order book
+   */
+  private getMidPrice(orderBook: any): number | null {
+    // Try to get best bid and ask
+    const bestBid = orderBook.getBestBid?.();
+    const bestAsk = orderBook.getBestAsk?.();
+
+    if (bestBid !== null && bestAsk !== null) {
+      return (bestBid + bestAsk) / 2;
+    }
+
+    // Fallback to last trade price if available
+    return null;
+  }
+
+  /**
+   * Calculate Exponential Moving Average
+   *
+   * EMA = (Close - Previous EMA) * multiplier + Previous EMA
+   * Multiplier = 2 / (Period + 1)
+   */
+  private calculateEMA(period: number, previousEMA: number | null): number | null {
+    if (this.priceHistory.length < period) {
+      return null;
+    }
+
+    const multiplier = 2 / (period + 1);
+
+    // First EMA is SMA
+    if (previousEMA === null) {
+      const prices = this.priceHistory.slice(0, period);
+      const sma = prices.reduce((sum, price) => sum + price, 0) / period;
+      return sma;
+    }
+
+    // Subsequent EMA uses previous EMA
+    const currentPrice = this.priceHistory[this.priceHistory.length - 1];
+    return (currentPrice - previousEMA) * multiplier + previousEMA;
+  }
+
+  /**
+   * Calculate Signal Line EMA (EMA of MACD line values)
+   */
+  private calculateSignalEMA(period: number, previousEMA: number | null): number | null {
+    if (this.macdHistory.length < period) {
+      return null;
+    }
+
+    const multiplier = 2 / (period + 1);
+
+    // First signal line is SMA of MACD values
+    if (previousEMA === null) {
+      const macdValues = this.macdHistory.slice(0, period);
+      const sma = macdValues.reduce((sum, macd) => sum + macd, 0) / period;
+      return sma;
+    }
+
+    // Subsequent signal line uses previous EMA
+    const currentMACD = this.macdHistory[this.macdHistory.length - 1];
+    return (currentMACD - previousEMA) * multiplier + previousEMA;
+  }
+
+  /**
+   * Calculate confidence based on histogram strength
+   * Stronger histogram = higher confidence
+   */
+  private calculateConfidence(histogram: number, side: 'buy' | 'sell'): number {
+    // Histogram magnitude indicates momentum strength
+    const absHistogram = Math.abs(histogram);
+    // Normalize to a reasonable confidence range (0.5 to 0.9)
+    // This is a simple heuristic - in practice, you might want more sophisticated logic
+    const normalizedConfidence = Math.min(0.5 + absHistogram * 10, 0.9);
+
+    // For buy signals, positive histogram (MACD > Signal) is expected
+    // For sell signals, negative histogram (MACD < Signal) is expected
+    // This shouldn't happen in normal operation, but we check for sanity
+    if (side === 'buy' && histogram < 0) {
+      return 0.5; // Lower confidence if histogram is negative on buy
+    }
+    if (side === 'sell' && histogram > 0) {
+      return 0.5; // Lower confidence if histogram is positive on sell
+    }
+
+    return normalizedConfidence;
+  }
+
+  /**
+   * Get current MACD data
+   */
+  getMACDData(): MACDData | null {
+    return this.currentMACD;
+  }
+
+  /**
+   * Get current MACD line value
+   */
+  getMACDLine(): number | null {
+    return this.currentMACD?.macdLine ?? null;
+  }
+
+  /**
+   * Get current signal line value
+   */
+  getSignalLine(): number | null {
+    return this.currentMACD?.signalLine ?? null;
+  }
+
+  /**
+   * Get current histogram value
+   */
+  getHistogram(): number | null {
+    return this.currentMACD?.histogram ?? null;
+  }
+
+  /**
+   * Get fast EMA value
+   */
+  getFastEMA(): number | null {
+    return this.fastEMA;
+  }
+
+  /**
+   * Get slow EMA value
+   */
+  getSlowEMA(): number | null {
+    return this.slowEMA;
+  }
+
+  /**
+   * Get price history length
+   */
+  getPriceHistoryLength(): number {
+    return this.priceHistory.length;
+  }
+
+  /**
+   * Check if strategy has enough data to generate signals
+   */
+  isReady(): boolean {
+    return (
+      this.priceHistory.length >= this.slowPeriod + this.signalPeriod &&
+      this.currentMACD !== null
+    );
+  }
+
+  /**
+   * Reset strategy state (useful for backtesting)
+   */
+  reset(): void {
+    this.priceHistory = [];
+    this.fastEMA = null;
+    this.slowEMA = null;
+    this.macdHistory = [];
+    this.signalLine = null;
+    this.lastMACDLine = null;
+    this.lastSignalLine = null;
+    this.currentMACD = null;
+  }
+}

--- a/src/strategy/index.ts
+++ b/src/strategy/index.ts
@@ -8,6 +8,7 @@ export * from './types';
 export * from './Strategy';
 export * from './SMAStrategy';
 export * from './RSIStrategy';
+export * from './MACDStrategy';
 export * from './StrategyManager';
 export * from './LeaderboardService';
 export * from './LLMClient';

--- a/tests/strategy/MACDStrategy.test.ts
+++ b/tests/strategy/MACDStrategy.test.ts
@@ -1,0 +1,383 @@
+/**
+ * MACD Strategy Tests
+ *
+ * Tests for the MACD (Moving Average Convergence Divergence) strategy
+ */
+
+import { MACDStrategy, MACDStrategyConfig } from '../../src/strategy/MACDStrategy';
+import { StrategyContext, OrderSignal } from '../../src/strategy/types';
+
+/**
+ * Mock OrderBook for testing
+ */
+class MockOrderBook {
+  private bestBid: number;
+  private bestAsk: number;
+
+  constructor(bestBid: number = 100, bestAsk: number = 101) {
+    this.bestBid = bestBid;
+    this.bestAsk = bestAsk;
+  }
+
+  getBestBid(): number {
+    return this.bestBid;
+  }
+
+  getBestAsk(): number {
+    return this.bestAsk;
+  }
+
+  setPrices(bid: number, ask: number): void {
+    this.bestBid = bid;
+    this.bestAsk = ask;
+  }
+}
+
+/**
+ * Create a mock context for testing
+ */
+function createMockContext(orderBook: MockOrderBook): StrategyContext {
+  return {
+    portfolio: {
+      cash: 100000,
+      positions: [],
+      totalValue: 100000,
+      unrealizedPnL: 0,
+      timestamp: Date.now(),
+    },
+    clock: Date.now(),
+    getMarketData: () => ({
+      orderBook: orderBook as any,
+      trades: [],
+      timestamp: Date.now(),
+    }),
+    getPosition: (_symbol: string) => 0,
+    getCash: () => 100000,
+  };
+}
+
+describe('MACDStrategy', () => {
+  let strategy: MACDStrategy;
+  let mockOrderBook: MockOrderBook;
+  let mockContext: StrategyContext;
+
+  const defaultConfig: MACDStrategyConfig = {
+    id: 'macd-test',
+    name: 'MACD Test Strategy',
+    params: {
+      fastPeriod: 12,
+      slowPeriod: 26,
+      signalPeriod: 9,
+      tradeQuantity: 10,
+    },
+  };
+
+  beforeEach(() => {
+    mockOrderBook = new MockOrderBook(100, 101);
+    mockContext = createMockContext(mockOrderBook);
+    strategy = new MACDStrategy(defaultConfig);
+    strategy.onInit(mockContext);
+  });
+
+  describe('Constructor and Configuration', () => {
+    test('should create strategy with default parameters', () => {
+      const config: MACDStrategyConfig = {
+        id: 'macd-default',
+        name: 'Default MACD',
+      };
+      const defaultStrategy = new MACDStrategy(config);
+      expect(defaultStrategy).toBeDefined();
+    });
+
+    test('should use default values when params are not provided', () => {
+      const config: MACDStrategyConfig = {
+        id: 'macd-no-params',
+        name: 'No Params MACD',
+      };
+      const noParamStrategy = new MACDStrategy(config);
+      expect(noParamStrategy).toBeDefined();
+    });
+
+    test('should throw error when fast period >= slow period', () => {
+      const config: MACDStrategyConfig = {
+        id: 'macd-invalid',
+        name: 'Invalid MACD',
+        params: {
+          fastPeriod: 26,
+          slowPeriod: 12,
+        },
+      };
+      expect(() => new MACDStrategy(config)).toThrow('Fast period must be less than slow period');
+    });
+
+    test('should throw error when signal period is zero or negative', () => {
+      const config: MACDStrategyConfig = {
+        id: 'macd-invalid-signal',
+        name: 'Invalid Signal Period MACD',
+        params: { 
+          fastPeriod: 12,
+          slowPeriod: 26,
+          signalPeriod: 0 
+        },
+      };
+      expect(() => new MACDStrategy(config)).toThrow('All periods must be positive');
+    });
+
+    test('should throw error when trade quantity is zero or negative', () => {
+      const config: MACDStrategyConfig = {
+        id: 'macd-invalid-qty',
+        name: 'Invalid Quantity MACD',
+        params: { tradeQuantity: 0 },
+      };
+      expect(() => new MACDStrategy(config)).toThrow('Trade quantity must be positive');
+    });
+  });
+
+  describe('Initialization', () => {
+    test('should initialize with empty state', () => {
+      expect(strategy.getPriceHistoryLength()).toBe(0);
+      expect(strategy.getFastEMA()).toBeNull();
+      expect(strategy.getSlowEMA()).toBeNull();
+      expect(strategy.getMACDLine()).toBeNull();
+      expect(strategy.getSignalLine()).toBeNull();
+      expect(strategy.getHistogram()).toBeNull();
+      expect(strategy.isReady()).toBe(false);
+    });
+
+    test('should reset to initial state', () => {
+      // Run some ticks to build up state
+      for (let i = 0; i < 40; i++) {
+        strategy.onTick(mockContext);
+      }
+
+      expect(strategy.getPriceHistoryLength()).toBe(40);
+      expect(strategy.isReady()).toBe(true);
+
+      strategy.reset();
+
+      expect(strategy.getPriceHistoryLength()).toBe(0);
+      expect(strategy.getMACDLine()).toBeNull();
+      expect(strategy.isReady()).toBe(false);
+    });
+  });
+
+  describe('MACD Calculation', () => {
+    test('should return null before enough data points', () => {
+      // Need slowPeriod + signalPeriod data points
+      const signal = strategy.onTick(mockContext);
+      expect(signal).toBeNull();
+      expect(strategy.getPriceHistoryLength()).toBe(1);
+
+      // Still need more data
+      for (let i = 0; i < 25; i++) {
+        strategy.onTick(mockContext);
+      }
+      expect(strategy.getPriceHistoryLength()).toBe(26);
+      // Now we have enough for slow EMA, but not for signal line yet
+      // Total needed: slowPeriod (26) + signalPeriod (9) - 1 = 34
+    });
+
+    test('should start generating MACD values after warmup period', () => {
+      // Generate enough ticks to warm up
+      for (let i = 0; i < 35; i++) {
+        mockOrderBook.setPrices(100 + i * 0.1, 101 + i * 0.1);
+        strategy.onTick(mockContext);
+      }
+
+      // Strategy should now be ready
+      expect(strategy.isReady()).toBe(true);
+      expect(strategy.getMACDLine()).not.toBeNull();
+      expect(strategy.getSignalLine()).not.toBeNull();
+      expect(strategy.getHistogram()).not.toBeNull();
+    });
+
+    test('should calculate correct EMA values', () => {
+      // Use constant prices to verify EMA calculation
+      // With constant prices, EMA should equal the price
+      for (let i = 0; i < 40; i++) {
+        mockOrderBook.setPrices(100, 100); // midPrice = 100
+        strategy.onTick(mockContext);
+      }
+
+      // With constant prices, MACD should be close to 0
+      // (both EMAs converge to the same value)
+      const macdLine = strategy.getMACDLine();
+      expect(macdLine).not.toBeNull();
+      expect(Math.abs(macdLine!)).toBeLessThan(0.01); // Should be very close to 0
+    });
+
+    test('should handle upward price trend correctly', () => {
+      // Simulate upward trending prices
+      for (let i = 0; i < 50; i++) {
+        mockOrderBook.setPrices(100 + i, 100 + i); // Rising prices
+        strategy.onTick(mockContext);
+      }
+
+      // In an uptrend, MACD should be positive (fast EMA > slow EMA)
+      const macdLine = strategy.getMACDLine();
+      expect(macdLine).toBeGreaterThan(0);
+    });
+
+    test('should handle downward price trend correctly', () => {
+      // Simulate downward trending prices
+      for (let i = 0; i < 50; i++) {
+        mockOrderBook.setPrices(200 - i, 200 - i); // Falling prices
+        strategy.onTick(mockContext);
+      }
+
+      // In a downtrend, MACD should be negative (fast EMA < slow EMA)
+      const macdLine = strategy.getMACDLine();
+      expect(macdLine).toBeLessThan(0);
+    });
+  });
+
+  describe('Signal Generation', () => {
+    test('should generate buy signal on golden cross', () => {
+      const signals: OrderSignal[] = [];
+
+      // First, create a downtrend to get MACD below signal line
+      for (let i = 0; i < 40; i++) {
+        mockOrderBook.setPrices(200 - i * 2, 200 - i * 2);
+        strategy.onTick(mockContext);
+      }
+
+      // Verify MACD is below signal (bearish)
+      const histogramBefore = strategy.getHistogram();
+      expect(histogramBefore).toBeLessThan(0);
+
+      // Now create an uptrend to trigger golden cross
+      for (let i = 0; i < 20; i++) {
+        mockOrderBook.setPrices(100 + i * 5, 100 + i * 5);
+        const signal = strategy.onTick(mockContext);
+        if (signal) {
+          signals.push(signal);
+        }
+      }
+
+      // Should have generated at least one buy signal
+      expect(signals.length).toBeGreaterThan(0);
+      expect(signals[0].side).toBe('buy');
+      expect(signals[0].confidence).toBeGreaterThan(0);
+      expect(signals[0].reason).toContain('Golden Cross');
+    });
+
+    test('should generate sell signal on death cross', () => {
+      const signals: OrderSignal[] = [];
+
+      // First, create an uptrend to get MACD above signal line
+      for (let i = 0; i < 40; i++) {
+        mockOrderBook.setPrices(100 + i * 2, 100 + i * 2);
+        strategy.onTick(mockContext);
+      }
+
+      // Verify MACD is above signal (bullish)
+      const histogramBefore = strategy.getHistogram();
+      expect(histogramBefore).toBeGreaterThan(0);
+
+      // Now create a downtrend to trigger death cross
+      for (let i = 0; i < 20; i++) {
+        mockOrderBook.setPrices(200 - i * 5, 200 - i * 5);
+        const signal = strategy.onTick(mockContext);
+        if (signal) {
+          signals.push(signal);
+        }
+      }
+
+      // Should have generated at least one sell signal
+      expect(signals.length).toBeGreaterThan(0);
+      expect(signals[0].side).toBe('sell');
+      expect(signals[0].confidence).toBeGreaterThan(0);
+      expect(signals[0].reason).toContain('Death Cross');
+    });
+
+    test('should not generate signals during stable prices', () => {
+      // Use constant prices
+      for (let i = 0; i < 50; i++) {
+        mockOrderBook.setPrices(100, 100);
+        strategy.onTick(mockContext);
+      }
+
+      // MACD should be near 0 with constant prices
+      const macdLine = strategy.getMACDLine();
+      expect(Math.abs(macdLine!)).toBeLessThan(0.1);
+    });
+  });
+
+  describe('Getter Methods', () => {
+    test('should return correct MACD data', () => {
+      for (let i = 0; i < 40; i++) {
+        mockOrderBook.setPrices(100 + i, 100 + i);
+        strategy.onTick(mockContext);
+      }
+
+      const macdData = strategy.getMACDData();
+      expect(macdData).not.toBeNull();
+      expect(macdData!.macdLine).toBeDefined();
+      expect(macdData!.signalLine).toBeDefined();
+      expect(macdData!.histogram).toBe(macdData!.macdLine - macdData!.signalLine);
+    });
+
+    test('should return correct individual components', () => {
+      for (let i = 0; i < 40; i++) {
+        mockOrderBook.setPrices(100 + i, 100 + i);
+        strategy.onTick(mockContext);
+      }
+
+      const macdLine = strategy.getMACDLine();
+      const signalLine = strategy.getSignalLine();
+      const histogram = strategy.getHistogram();
+      const fastEMA = strategy.getFastEMA();
+      const slowEMA = strategy.getSlowEMA();
+
+      expect(macdLine).toBe(fastEMA! - slowEMA!);
+      expect(histogram).toBe(macdLine! - signalLine!);
+      expect(fastEMA).toBeGreaterThan(slowEMA); // In uptrend
+    });
+  });
+
+  describe('Custom Parameters', () => {
+    test('should work with custom periods', () => {
+      const customConfig: MACDStrategyConfig = {
+        id: 'macd-custom',
+        name: 'Custom MACD',
+        params: {
+          fastPeriod: 5,
+          slowPeriod: 15,
+          signalPeriod: 3,
+          tradeQuantity: 20,
+        },
+      };
+
+      const customStrategy = new MACDStrategy(customConfig);
+      mockContext = createMockContext(mockOrderBook);
+      customStrategy.onInit(mockContext);
+
+      // Generate signals with custom periods
+      for (let i = 0; i < 30; i++) {
+        mockOrderBook.setPrices(100 + i, 100 + i);
+        const signal = customStrategy.onTick(mockContext);
+        // Just verify it doesn't crash
+      }
+
+      // Should eventually be ready
+      expect(customStrategy.isReady()).toBe(true);
+    });
+  });
+
+  describe('Integration with Strategy Base Class', () => {
+    test('should be properly initialized', () => {
+      expect(strategy.isInitialized()).toBe(true);
+    });
+
+    test('should have correct config', () => {
+      const config = strategy.getConfig();
+      expect(config.id).toBe('macd-test');
+      expect(config.name).toBe('MACD Test Strategy');
+    });
+
+    test('should cleanup properly', () => {
+      strategy.onCleanup(mockContext);
+      expect(strategy.isInitialized()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the MACD (Moving Average Convergence Divergence) trading strategy for Issue #196.

### Changes

- **MACDStrategy class** (`src/strategy/MACDStrategy.ts`)
  - Calculates MACD line (EMA fast - EMA slow)
  - Calculates signal line (EMA of MACD)
  - Calculates histogram (MACD - signal)
  - Generates buy signals on golden cross
  - Generates sell signals on death cross
  - Configurable parameters: fastPeriod, slowPeriod, signalPeriod, tradeQuantity
  - Standard defaults: fast=12, slow=26, signal=9

- **Unit tests** (`tests/strategy/MACDStrategy.test.ts`)
  - Constructor and configuration validation
  - EMA and MACD calculation correctness
  - Signal generation on crossovers
  - Edge cases (insufficient data, stable prices, trends)
  - 21 test cases, all passing

- **BacktestEngine integration** (`src/backtest/BacktestEngine.ts`)
  - Added MACD strategy support for backtesting
  - Usage: `strategy: 'macd'` with optional params

- **Module exports** (`src/strategy/index.ts`)
  - Export MACDStrategy and MACDData interface

### Test Results

```
PASS tests/strategy/MACDStrategy.test.ts
PASS tests/backtest.test.ts
Tests: 35 passed, 35 total
```

### Usage Example

```typescript
import { MACDStrategy } from './strategy';

const strategy = new MACDStrategy({
  id: 'my-macd',
  name: 'MACD Strategy',
  params: {
    fastPeriod: 12,
    slowPeriod: 26,
    signalPeriod: 9,
    tradeQuantity: 10,
  },
});
```

Closes #196