### PR TITLE
fix(settings): make settings button more discoverable

### DIFF
--- a/src/client/components/SettingsPanel.tsx
+++ b/src/client/components/SettingsPanel.tsx
@@ -4,10 +4,11 @@
  * Provides UI for user preferences including theme and language settings.
  * 
  * Issue #197: Sprint 10: 用户偏好设置功能
+ * Issue #209: Settings panel button not easily discoverable - added tooltip and hover effects
  */
 
 import React, { useState } from 'react';
-import { Modal, Button, Radio, Space, Divider, Typography } from '@arco-design/web-react';
+import { Modal, Button, Radio, Space, Divider, Typography, Tooltip } from '@arco-design/web-react';
 import { IconSettings, IconSun, IconMoonFill, IconLanguage } from '@arco-design/web-react/icon';
 import { useSettings } from '../store/settingsStore';
 
@@ -35,24 +36,27 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ compact = false }) => {
 
   return (
     <>
-      <Button
-        icon={<IconSettings />}
-        onClick={() => setVisible(true)}
-        size="small"
-        type="text"
-        style={{
-          background: 'transparent',
-          border: 'none',
-          color: 'var(--color-text-1)',
-          padding: compact ? 4 : 8,
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          transition: 'all 0.3s ease',
-        }}
-        aria-label="打开设置"
-      />
+      <Tooltip content="设置 (主题、语言)" position="br">
+        <Button
+          icon={<IconSettings style={{ fontSize: compact ? 18 : 20 }} />}
+          onClick={() => setVisible(true)}
+          size="small"
+          type="text"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--color-text-1)',
+            padding: compact ? 4 : 8,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            transition: 'all 0.3s ease',
+          }}
+          className="settings-button"
+          aria-label="打开设置"
+        />
+      </Tooltip>
       
       <Modal
         title={

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -462,3 +462,13 @@ body {
     min-width: 48px;
   }
 }
+
+/* Settings button hover effects for better discoverability (Issue #209) */
+.settings-button:hover {
+  background-color: var(--color-fill-2) !important;
+  border-radius: 4px;
+}
+
+.settings-button:active {
+  background-color: var(--color-fill-3) !important;
+}


### PR DESCRIPTION
## Summary
- Add Tooltip component to the settings button with clear label "设置 (主题、语言)"
- Increase icon size to match the ThemeToggle component (18px on mobile, 20px on desktop)
- Add hover effect with background highlight for better visual feedback
- Add CSS class `settings-button` for styling

## Problem
During smoke testing (Issue #209), the AI tester could not locate the settings button. The button was present but lacked visual cues (tooltip) and had no hover effect to indicate it was interactive.

## Solution
1. Wrapped the settings button with Arco Design's `Tooltip` component (same pattern used in `ThemeToggle`)
2. Added a clear tooltip message "设置 (主题、语言)" to indicate the button's purpose
3. Added hover effect via CSS for better discoverability
4. Matched icon sizing with the adjacent ThemeToggle button for visual consistency

## Testing
- All 15 existing tests for settings store pass
- Build succeeds
- Verified the tooltip appears on hover
- Verified the button is visually consistent with ThemeToggle

Fixes #209