### PR TITLE
feat: Portfolio Analytics Enhancement (Issue #212)

### DIFF
--- a/src/client/hooks/usePortfolioAnalytics.ts
+++ b/src/client/hooks/usePortfolioAnalytics.ts
@@ -1,0 +1,119 @@
+/**
+ * Hook for Portfolio Analytics
+ * 
+ * Provides calculated risk metrics, performance metrics, and position analysis
+ * for portfolio visualization and monitoring.
+ */
+
+import { useMemo } from 'react';
+import type { Trade } from '../utils/api';
+import {
+  calculateRiskMetrics,
+  calculatePerformanceMetrics,
+  analyzePositions,
+  calculatePnLBreakdown,
+  type RiskMetrics,
+  type PerformanceMetrics,
+  type PositionAnalysis,
+  type PnLBreakdown,
+  type HistoricalDataPoint,
+} from '../utils/portfolioAnalytics';
+
+interface UsePortfolioAnalyticsOptions {
+  trades: Trade[];
+  portfolioValue: number;
+  initialCapital: number;
+  positions: Array<{
+    symbol: string;
+    quantity: number;
+    averageCost: number;
+    currentPrice?: number;
+    marketValue?: number;
+    unrealizedPnL?: number;
+    priceChange24h?: number;
+    priceChangePercent24h?: number;
+  }>;
+  historicalValues: HistoricalDataPoint[];
+  currentUnrealizedPnL: number;
+}
+
+interface PortfolioAnalyticsResult {
+  riskMetrics: RiskMetrics;
+  performanceMetrics: PerformanceMetrics;
+  positionAnalysis: PositionAnalysis;
+  pnlBreakdown: PnLBreakdown;
+  isLoading: boolean;
+}
+
+/**
+ * Hook for calculating comprehensive portfolio analytics
+ */
+export function usePortfolioAnalytics(
+  options: UsePortfolioAnalyticsOptions
+): PortfolioAnalyticsResult {
+  const {
+    trades,
+    portfolioValue,
+    initialCapital,
+    positions,
+    historicalValues,
+    currentUnrealizedPnL,
+  } = options;
+
+  // Calculate risk metrics from historical data
+  const riskMetrics = useMemo(() => {
+    if (historicalValues.length < 2) {
+      return {
+        volatility: 0,
+        maxDrawdown: 0,
+        maxDrawdownPercent: 0,
+        sharpeRatio: 0,
+        sortinoRatio: 0,
+        valueAtRisk95: 0,
+        expectedShortfall: 0,
+      };
+    }
+    return calculateRiskMetrics(historicalValues);
+  }, [historicalValues]);
+
+  // Calculate performance metrics from trades
+  const performanceMetrics = useMemo(() => {
+    return calculatePerformanceMetrics(
+      trades,
+      portfolioValue,
+      initialCapital,
+      historicalValues
+    );
+  }, [trades, portfolioValue, initialCapital, historicalValues]);
+
+  // Analyze positions
+  const positionAnalysis = useMemo(() => {
+    if (positions.length === 0) {
+      return {
+        positions: [],
+        topGainers: [],
+        topLosers: [],
+        concentrationRisk: 0,
+        largestPositionWeight: 0,
+      };
+    }
+    return analyzePositions(positions, portfolioValue);
+  }, [positions, portfolioValue]);
+
+  // Calculate P&L breakdown
+  const pnlBreakdown = useMemo(() => {
+    return calculatePnLBreakdown(trades, currentUnrealizedPnL, portfolioValue);
+  }, [trades, currentUnrealizedPnL, portfolioValue]);
+
+  const isLoading = !trades || !positions;
+
+  return {
+    riskMetrics,
+    performanceMetrics,
+    positionAnalysis,
+    pnlBreakdown,
+    isLoading,
+  };
+}
+
+export default usePortfolioAnalytics;

--- a/src/client/pages/HoldingsPage.tsx
+++ b/src/client/pages/HoldingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Typography, Card, Table, Tag, Statistic, Select, Grid, Radio, Space } from '@arco-design/web-react';
+import { Typography, Card, Table, Tag, Statistic, Select, Grid, Radio, Space, Progress, Tooltip, Spin, Empty } from '@arco-design/web-react';
 import {
   LineChart,
   Line,
@@ -11,13 +11,17 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip,
+  Tooltip as RechartsTooltip,
   Legend,
   ResponsiveContainer,
+  BarChart,
+  Bar,
 } from 'recharts';
 import { useStrategies, useTrades, usePortfolioHistory } from '../hooks/useData';
 import { usePortfolioRealtime } from '../hooks/usePortfolioRealtime';
+import { usePortfolioAnalytics } from '../hooks/usePortfolioAnalytics';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { formatPercent, formatCurrency, formatDuration } from '../utils/portfolioAnalytics';
 import type { TableProps } from '@arco-design/web-react';
 import type { PortfolioWithPnL } from '../hooks/usePortfolioRealtime';
 
@@ -25,6 +29,9 @@ const { Row, Col } = Grid;
 const { Title, Text } = Typography;
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#FF6B6B'];
+
+// Default initial capital for calculations
+const DEFAULT_INITIAL_CAPITAL = 100000;
 
 interface PnLData {
   realizedPnL: number;
@@ -90,6 +97,24 @@ const HoldingsPage: React.FC = () => {
     }
   }, [recentChanges]);
 
+  // Prepare historical data for analytics
+  const historicalDataPoints = useMemo(() => {
+    return pnlHistory.map(item => ({
+      timestamp: new Date(item.timestamp),
+      value: item.totalValue,
+    }));
+  }, [pnlHistory]);
+
+  // Calculate comprehensive analytics
+  const analytics = usePortfolioAnalytics({
+    trades,
+    portfolioValue: portfolio?.totalValue || 0,
+    initialCapital: DEFAULT_INITIAL_CAPITAL,
+    positions: portfolio?.positions || [],
+    historicalValues: historicalDataPoints,
+    currentUnrealizedPnL: portfolio?.totalUnrealizedPnL || 0,
+  });
+
   // Calculate P&L from trades
   const pnlData: PnLData = useMemo(() => {
     if (trades.length === 0) {
@@ -153,6 +178,22 @@ const HoldingsPage: React.FC = () => {
       realizedPnL: item.realizedPnL,
       unrealizedPnL: item.unrealizedPnL,
     }));
+  }, [pnlHistory]);
+
+  // Prepare drawdown chart data
+  const drawdownData = useMemo(() => {
+    if (pnlHistory.length < 2) return [];
+
+    let peak = pnlHistory[0]?.totalValue || 0;
+    return pnlHistory.map((item) => {
+      const value = item.totalValue;
+      if (value > peak) peak = value;
+      const drawdown = peak > 0 ? ((peak - value) / peak) * 100 : 0;
+      return {
+        time: new Date(item.timestamp).toLocaleString(),
+        drawdown: Math.max(0, drawdown),
+      };
+    });
   }, [pnlHistory]);
 
   // Position table columns with real-time P/L
@@ -248,12 +289,44 @@ const HoldingsPage: React.FC = () => {
 
   const loading = strategiesLoading || portfolioLoading || tradesLoading;
 
+  // Risk metric display component
+  const RiskMetricCard: React.FC<{
+    title: string;
+    value: number;
+    format: 'percent' | 'number' | 'ratio';
+    tooltip?: string;
+    goodThreshold?: { low: number; high: number };
+  }> = ({ title, value, format, tooltip, goodThreshold }) => {
+    const formattedValue = format === 'percent' 
+      ? formatPercent(value) 
+      : format === 'ratio' 
+        ? value.toFixed(2) 
+        : value.toFixed(4);
+    
+    let color = 'inherit';
+    if (goodThreshold) {
+      color = value >= goodThreshold.low && value <= goodThreshold.high ? '#3f8600' : '#cf1322';
+    }
+
+    return (
+      <Tooltip content={tooltip}>
+        <Card style={{ height: '100%' }}>
+          <Statistic
+            title={title}
+            value={formattedValue}
+            valueStyle={{ color, fontSize: isMobile ? '18px' : '24px' }}
+          />
+        </Card>
+      </Tooltip>
+    );
+  };
+
   return (
     <ErrorBoundary>
       <div>
         {/* Page Title */}
         <Title heading={3} style={{ marginBottom: isMobile ? 12 : 24 }}>
-          Holdings
+          Holdings & Analytics
         </Title>
 
         {/* Strategy Selector */}
@@ -297,19 +370,13 @@ const HoldingsPage: React.FC = () => {
           <Col xs={12} sm={12} md={6}>
             <Card loading={loading}>
               <Statistic
-                title="Unrealized P&L"
-                value={portfolio?.totalUnrealizedPnL || 0}
-                prefixText="$"
+                title="Total Return"
+                value={analytics.performanceMetrics.totalReturnPercent}
+                suffixText="%"
                 precision={2}
                 valueStyle={{ 
-                  color: (portfolio?.totalUnrealizedPnL || 0) >= 0 ? '#3f8600' : '#cf1322',
-                  transition: 'color 0.3s ease',
+                  color: analytics.performanceMetrics.totalReturnPercent >= 0 ? '#3f8600' : '#cf1322',
                 }}
-                extra={
-                  <span style={{ fontSize: '14px', color: (portfolio?.totalUnrealizedPnLPercent || 0) >= 0 ? '#3f8600' : '#cf1322' }}>
-                    {(portfolio?.totalUnrealizedPnLPercent || 0) >= 0 ? '+' : ''}{portfolio?.totalUnrealizedPnLPercent?.toFixed(2)}%
-                  </span>
-                }
               />
             </Card>
           </Col>
@@ -317,9 +384,110 @@ const HoldingsPage: React.FC = () => {
             <Card loading={loading}>
               <Statistic
                 title="Win Rate"
-                value={pnlData.winRate}
+                value={analytics.performanceMetrics.winRate}
                 suffixText="%"
                 precision={1}
+              />
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Risk Metrics Section */}
+        <Title heading={5} style={{ marginBottom: 12 }}>Risk Metrics</Title>
+        <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
+          <Col xs={12} sm={12} md={6}>
+            <RiskMetricCard
+              title="Volatility (Ann.)"
+              value={analytics.riskMetrics.volatility}
+              format="percent"
+              tooltip="Annualized standard deviation of returns. Higher = more risk."
+            />
+          </Col>
+          <Col xs={12} sm={12} md={6}>
+            <RiskMetricCard
+              title="Max Drawdown"
+              value={analytics.riskMetrics.maxDrawdownPercent}
+              format="percent"
+              tooltip="Largest peak-to-trough decline in portfolio value."
+              goodThreshold={{ low: 0, high: 20 }}
+            />
+          </Col>
+          <Col xs={12} sm={12} md={6}>
+            <RiskMetricCard
+              title="Sharpe Ratio"
+              value={analytics.riskMetrics.sharpeRatio}
+              format="ratio"
+              tooltip="Risk-adjusted return. >1 is good, >2 is excellent."
+              goodThreshold={{ low: 1, high: 100 }}
+            />
+          </Col>
+          <Col xs={12} sm={12} md={6}>
+            <RiskMetricCard
+              title="Sortino Ratio"
+              value={analytics.riskMetrics.sortinoRatio}
+              format="ratio"
+              tooltip="Downside risk-adjusted return. Higher is better."
+              goodThreshold={{ low: 1, high: 100 }}
+            />
+          </Col>
+        </Row>
+
+        {/* P&L Breakdown Section */}
+        <Title heading={5} style={{ marginBottom: 12 }}>P&L Breakdown</Title>
+        <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
+          <Col xs={24} sm={12} md={6}>
+            <Card loading={loading}>
+              <Statistic
+                title="Daily P&L"
+                value={analytics.pnlBreakdown.daily.total}
+                prefixText="$"
+                precision={2}
+                valueStyle={{ 
+                  color: analytics.pnlBreakdown.daily.total >= 0 ? '#3f8600' : '#cf1322',
+                }}
+                extra={<Text type="secondary" style={{ fontSize: '12px' }}>
+                  {formatPercent(analytics.performanceMetrics.dailyPnLPercent)}
+                </Text>}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card loading={loading}>
+              <Statistic
+                title="Weekly P&L"
+                value={analytics.pnlBreakdown.weekly.total}
+                prefixText="$"
+                precision={2}
+                valueStyle={{ 
+                  color: analytics.pnlBreakdown.weekly.total >= 0 ? '#3f8600' : '#cf1322',
+                }}
+                extra={<Text type="secondary" style={{ fontSize: '12px' }}>
+                  {formatPercent(analytics.performanceMetrics.weeklyPnLPercent)}
+                </Text>}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card loading={loading}>
+              <Statistic
+                title="Monthly P&L"
+                value={analytics.pnlBreakdown.monthly.total}
+                prefixText="$"
+                precision={2}
+                valueStyle={{ 
+                  color: analytics.pnlBreakdown.monthly.total >= 0 ? '#3f8600' : '#cf1322',
+                }}
+                extra={<Text type="secondary" style={{ fontSize: '12px' }}>
+                  {formatPercent(analytics.performanceMetrics.monthlyPnLPercent)}
+                </Text>}
+              />
+            </Card>
+          </Col>
+          <Col xs={24} sm={12} md={6}>
+            <Card loading={loading}>
+              <Statistic
+                title="Avg Trade Duration"
+                value={formatDuration(analytics.performanceMetrics.averageTradeDuration)}
               />
             </Card>
           </Col>
@@ -329,26 +497,30 @@ const HoldingsPage: React.FC = () => {
         <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
           <Col xs={24} md={12}>
             <Card title="Asset Allocation" loading={loading}>
-              <ResponsiveContainer width="100%" height={isMobile ? 250 : 300}>
-                <PieChart>
-                  <Pie
-                    data={allocationData}
-                    cx="50%"
-                    cy="50%"
-                    labelLine
-                    label={({ name, percent }) => `${name}: ${((percent || 0) * 100).toFixed(0)}%`}
-                    outerRadius={80}
-                    fill="#8884d8"
-                    dataKey="value"
-                  >
-                    {allocationData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
+              {allocationData.length > 0 ? (
+                <ResponsiveContainer width="100%" height={isMobile ? 250 : 300}>
+                  <PieChart>
+                    <Pie
+                      data={allocationData}
+                      cx="50%"
+                      cy="50%"
+                      labelLine
+                      label={({ name, percent }) => `${name}: ${((percent || 0) * 100).toFixed(0)}%`}
+                      outerRadius={80}
+                      fill="#8884d8"
+                      dataKey="value"
+                    >
+                      {allocationData.map((entry, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <RechartsTooltip />
+                    <Legend />
+                  </PieChart>
+                </ResponsiveContainer>
+              ) : (
+                <Empty description="No positions" style={{ height: isMobile ? 250 : 300, display: 'flex', flexDirection: 'column', justifyContent: 'center' }} />
+              )}
             </Card>
           </Col>
           <Col xs={24} md={12}>
@@ -390,7 +562,7 @@ const HoldingsPage: React.FC = () => {
                       tick={{ fontSize: isMobile ? 10 : 12 }}
                       tickFormatter={(value) => `$${(value / 1000).toFixed(0)}K`}
                     />
-                    <Tooltip
+                    <RechartsTooltip
                       formatter={(value: number) => [`$${value.toLocaleString()}`, 'Portfolio Value']}
                       labelFormatter={(label) => `Time: ${label}`}
                     />
@@ -422,60 +594,225 @@ const HoldingsPage: React.FC = () => {
           </Col>
         </Row>
 
-        {/* P&L Analysis */}
+        {/* Drawdown Chart */}
         <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
           <Col span={24}>
-            <Card title="P&L Analysis" loading={loading}>
+            <Card title="Drawdown History" loading={loading || historyLoading}>
+              {drawdownData.length > 0 ? (
+                <ResponsiveContainer width="100%" height={isMobile ? 200 : 250}>
+                  <AreaChart data={drawdownData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="time"
+                      tick={{ fontSize: isMobile ? 10 : 12 }}
+                      tickFormatter={(value) => {
+                        const date = new Date(value);
+                        return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+                      }}
+                    />
+                    <YAxis
+                      tick={{ fontSize: isMobile ? 10 : 12 }}
+                      tickFormatter={(value) => `${value.toFixed(0)}%`}
+                    />
+                    <RechartsTooltip
+                      formatter={(value: number) => [`${value.toFixed(2)}%`, 'Drawdown']}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="drawdown"
+                      stroke="#cf1322"
+                      fill="#cf1322"
+                      fillOpacity={0.3}
+                      name="Drawdown"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div
+                  style={{
+                    height: isMobile ? 200 : 250,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: '#999',
+                  }}
+                >
+                  No drawdown data available
+                </div>
+              )}
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Top Gainers / Losers */}
+        <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
+          <Col xs={24} md={12}>
+            <Card title="Top Gainers" loading={loading}>
+              {analytics.positionAnalysis.topGainers.length > 0 ? (
+                <div>
+                  {analytics.positionAnalysis.topGainers.map((pos) => (
+                    <div key={pos.symbol} style={{ 
+                      display: 'flex', 
+                      justifyContent: 'space-between', 
+                      padding: '8px 0',
+                      borderBottom: '1px solid #f0f0f0'
+                    }}>
+                      <Text strong>{pos.symbol}</Text>
+                      <Text style={{ color: '#3f8600' }}>
+                        +${pos.unrealizedPnL.toFixed(2)} ({formatPercent(pos.unrealizedPnLPercent)})
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <Empty description="No gainers" />
+              )}
+            </Card>
+          </Col>
+          <Col xs={24} md={12}>
+            <Card title="Top Losers" loading={loading}>
+              {analytics.positionAnalysis.topLosers.length > 0 ? (
+                <div>
+                  {analytics.positionAnalysis.topLosers.map((pos) => (
+                    <div key={pos.symbol} style={{ 
+                      display: 'flex', 
+                      justifyContent: 'space-between', 
+                      padding: '8px 0',
+                      borderBottom: '1px solid #f0f0f0'
+                    }}>
+                      <Text strong>{pos.symbol}</Text>
+                      <Text style={{ color: '#cf1322' }}>
+                        ${pos.unrealizedPnL.toFixed(2)} ({formatPercent(pos.unrealizedPnLPercent)})
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <Empty description="No losers" />
+              )}
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Position Concentration */}
+        <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
+          <Col span={24}>
+            <Card title="Position Concentration" loading={loading}>
+              <Row gutter={16}>
+                <Col xs={24} sm={12}>
+                  <Statistic
+                    title="Concentration Risk (HHI)"
+                    value={analytics.positionAnalysis.concentrationRisk.toFixed(2)}
+                    suffix="/ 10000"
+                  />
+                  <Progress
+                    percent={analytics.positionAnalysis.concentrationRisk / 100}
+                    strokeColor={analytics.positionAnalysis.concentrationRisk > 2500 ? '#cf1322' : '#3f8600'}
+                    showText={false}
+                    style={{ marginTop: 8 }}
+                  />
+                  <Text type="secondary" style={{ fontSize: '12px' }}>
+                    HHI &lt; 1500 = Diversified, &gt; 2500 = Concentrated
+                  </Text>
+                </Col>
+                <Col xs={24} sm={12}>
+                  <Statistic
+                    title="Largest Position"
+                    value={analytics.positionAnalysis.largestPositionWeight.toFixed(1)}
+                    suffix="%"
+                  />
+                  <Progress
+                    percent={analytics.positionAnalysis.largestPositionWeight}
+                    strokeColor={analytics.positionAnalysis.largestPositionWeight > 30 ? '#cf1322' : '#3f8600'}
+                    showText={false}
+                    style={{ marginTop: 8 }}
+                  />
+                  <Text type="secondary" style={{ fontSize: '12px' }}>
+                    &lt; 20% = Healthy, &gt; 30% = High Risk
+                  </Text>
+                </Col>
+              </Row>
+            </Card>
+          </Col>
+        </Row>
+
+        {/* Performance Metrics */}
+        <Row gutter={isMobile ? 8 : 16} style={{ marginBottom: isMobile ? 16 : 24 }}>
+          <Col span={24}>
+            <Card title="Trading Performance" loading={loading}>
               <Row gutter={isMobile ? 8 : 16}>
-                <Col xs={24} sm={8}>
+                <Col xs={12} sm={8} md={4}>
                   <Statistic
-                    title="Total Cost Basis"
-                    value={pnlData.totalCost}
-                    prefixText="$"
-                    precision={2}
+                    title="Total Trades"
+                    value={analytics.performanceMetrics.totalTrades}
                   />
                 </Col>
-                <Col xs={24} sm={8}>
+                <Col xs={12} sm={8} md={4}>
                   <Statistic
-                    title="Total Proceeds"
-                    value={pnlData.totalProceeds}
-                    prefixText="$"
-                    precision={2}
+                    title="Winning"
+                    value={analytics.performanceMetrics.winningTrades}
+                    valueStyle={{ color: '#3f8600' }}
                   />
                 </Col>
-                <Col xs={24} sm={8}>
+                <Col xs={12} sm={8} md={4}>
                   <Statistic
-                    title="Total P&L"
-                    value={(portfolio?.totalPnL || 0) + pnlData.realizedPnL}
+                    title="Losing"
+                    value={analytics.performanceMetrics.losingTrades}
+                    valueStyle={{ color: '#cf1322' }}
+                  />
+                </Col>
+                <Col xs={12} sm={8} md={4}>
+                  <Statistic
+                    title="Avg Win"
+                    value={analytics.performanceMetrics.averageWin}
                     prefixText="$"
                     precision={2}
+                    valueStyle={{ color: '#3f8600' }}
+                  />
+                </Col>
+                <Col xs={12} sm={8} md={4}>
+                  <Statistic
+                    title="Avg Loss"
+                    value={Math.abs(analytics.performanceMetrics.averageLoss)}
+                    prefixText="$"
+                    precision={2}
+                    valueStyle={{ color: '#cf1322' }}
+                  />
+                </Col>
+                <Col xs={12} sm={8} md={4}>
+                  <Statistic
+                    title="Profit Factor"
+                    value={analytics.performanceMetrics.profitFactor.toFixed(2)}
                     valueStyle={{ 
-                      color: ((portfolio?.totalPnL || 0) + pnlData.realizedPnL) >= 0 ? '#3f8600' : '#cf1322',
+                      color: analytics.performanceMetrics.profitFactor >= 1 ? '#3f8600' : '#cf1322' 
                     }}
-                    extra={
-                      <span style={{ fontSize: '14px' }}>
-                        (Unrealized: ${portfolio?.totalUnrealizedPnL?.toFixed(2) || '0.00'})
-                      </span>
-                    }
                   />
                 </Col>
               </Row>
               <Row gutter={isMobile ? 8 : 16} style={{ marginTop: 16 }}>
-                <Col span={12}>
-                  <Text type="secondary">
-                    Winning Trades:{' '}
-                    <Text strong style={{ color: '#3f8600' }}>
-                      {pnlData.winningTrades}
-                    </Text>
-                  </Text>
+                <Col xs={12} sm={8}>
+                  <Statistic
+                    title="Best Trade"
+                    value={analytics.performanceMetrics.bestTrade}
+                    prefixText="$"
+                    precision={2}
+                    valueStyle={{ color: '#3f8600' }}
+                  />
                 </Col>
-                <Col span={12}>
-                  <Text type="secondary">
-                    Losing Trades:{' '}
-                    <Text strong style={{ color: '#cf1322' }}>
-                      {pnlData.losingTrades}
-                    </Text>
-                  </Text>
+                <Col xs={12} sm={8}>
+                  <Statistic
+                    title="Worst Trade"
+                    value={analytics.performanceMetrics.worstTrade}
+                    prefixText="$"
+                    precision={2}
+                    valueStyle={{ color: '#cf1322' }}
+                  />
+                </Col>
+                <Col xs={12} sm={8}>
+                  <Statistic
+                    title="Avg Duration"
+                    value={formatDuration(analytics.performanceMetrics.averageTradeDuration)}
+                  />
                 </Col>
               </Row>
             </Card>
@@ -504,7 +841,7 @@ const HoldingsPage: React.FC = () => {
                       tick={{ fontSize: isMobile ? 10 : 12 }}
                       tickFormatter={(value) => `$${value.toLocaleString()}`}
                     />
-                    <Tooltip
+                    <RechartsTooltip
                       formatter={(value: number) => [`$${value.toLocaleString()}`]}
                       labelFormatter={(label) => `Time: ${new Date(label).toLocaleString()}`}
                     />

--- a/src/client/utils/__tests__/portfolioAnalytics.test.ts
+++ b/src/client/utils/__tests__/portfolioAnalytics.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for Portfolio Analytics Utilities
+ */
+
+import {
+  calculateVolatility,
+  calculateMaxDrawdown,
+  calculateSharpeRatio,
+  calculateSortinoRatio,
+  calculateVaR,
+  calculateExpectedShortfall,
+  calculateRiskMetrics,
+  analyzePositions,
+  calculateCorrelation,
+  calculateCorrelationMatrix,
+  calculatePnLBreakdown,
+  formatPercent,
+  formatCurrency,
+  formatDuration,
+} from '../portfolioAnalytics';
+
+describe('calculateVolatility', () => {
+  it('should return 0 for empty or single-element arrays', () => {
+    expect(calculateVolatility([])).toBe(0);
+    expect(calculateVolatility([0.01])).toBe(0);
+  });
+
+  it('should calculate annualized volatility correctly', () => {
+    // Simple test with known values
+    const returns = [0.01, -0.02, 0.03, -0.01, 0.02];
+    const volatility = calculateVolatility(returns);
+    
+    // Volatility should be positive
+    expect(volatility).toBeGreaterThan(0);
+    
+    // For these returns, volatility should be reasonable (not too high)
+    expect(volatility).toBeLessThan(1); // Less than 100% annualized
+  });
+
+  it('should return 0 for constant returns', () => {
+    const returns = [0.01, 0.01, 0.01, 0.01];
+    expect(calculateVolatility(returns)).toBe(0);
+  });
+});
+
+describe('calculateMaxDrawdown', () => {
+  it('should return 0 for empty or single-element arrays', () => {
+    expect(calculateMaxDrawdown([])).toEqual({ maxDrawdown: 0, maxDrawdownPercent: 0 });
+    expect(calculateMaxDrawdown([100])).toEqual({ maxDrawdown: 0, maxDrawdownPercent: 0 });
+  });
+
+  it('should calculate max drawdown correctly', () => {
+    // Portfolio goes: 100 -> 110 -> 90 -> 95
+    // Max drawdown is from 110 to 90 = 20
+    const values = [100, 110, 90, 95];
+    const result = calculateMaxDrawdown(values);
+    
+    expect(result.maxDrawdown).toBe(20);
+    expect(result.maxDrawdownPercent).toBeCloseTo(18.18, 1); // 20/110 * 100
+  });
+
+  it('should return 0 for monotonically increasing values', () => {
+    const values = [100, 110, 120, 130];
+    const result = calculateMaxDrawdown(values);
+    
+    expect(result.maxDrawdown).toBe(0);
+    expect(result.maxDrawdownPercent).toBe(0);
+  });
+});
+
+describe('calculateSharpeRatio', () => {
+  it('should return 0 for insufficient data', () => {
+    expect(calculateSharpeRatio([])).toBe(0);
+    expect(calculateSharpeRatio([0.01])).toBe(0);
+  });
+
+  it('should calculate positive Sharpe for positive returns', () => {
+    // Consistent positive returns should give positive Sharpe
+    const returns = [0.01, 0.02, 0.01, 0.015, 0.01];
+    const sharpe = calculateSharpeRatio(returns);
+    
+    expect(sharpe).toBeGreaterThan(0);
+  });
+
+  it('should calculate negative Sharpe for negative returns', () => {
+    // Consistent negative returns should give negative Sharpe
+    const returns = [-0.01, -0.02, -0.01, -0.015, -0.01];
+    const sharpe = calculateSharpeRatio(returns);
+    
+    expect(sharpe).toBeLessThan(0);
+  });
+});
+
+describe('calculateSortinoRatio', () => {
+  it('should return 0 for insufficient data', () => {
+    expect(calculateSortinoRatio([])).toBe(0);
+    expect(calculateSortinoRatio([0.01])).toBe(0);
+  });
+
+  it('should return Infinity for no negative returns', () => {
+    const returns = [0.01, 0.02, 0.03, 0.04];
+    expect(calculateSortinoRatio(returns)).toBe(Infinity);
+  });
+
+  it('should calculate Sortino ratio correctly with mixed returns', () => {
+    const returns = [0.02, -0.01, 0.03, -0.02, 0.01];
+    const sortino = calculateSortinoRatio(returns);
+    
+    // Sortino should be defined
+    expect(sortino).toBeDefined();
+  });
+});
+
+describe('calculateVaR', () => {
+  it('should return 0 for insufficient data', () => {
+    expect(calculateVaR([])).toBe(0);
+    expect(calculateVaR([0.01, 0.02])).toBe(0);
+  });
+
+  it('should calculate VaR correctly', () => {
+    // Generate returns where we can predict VaR
+    const returns = Array.from({ length: 100 }, (_, i) => (i - 50) / 100);
+    const var95 = calculateVaR(returns, 0.95);
+    
+    // VaR should be positive (it's a potential loss)
+    expect(var95).toBeGreaterThan(0);
+  });
+});
+
+describe('calculateExpectedShortfall', () => {
+  it('should return 0 for insufficient data', () => {
+    expect(calculateExpectedShortfall([])).toBe(0);
+    expect(calculateExpectedShortfall([0.01, 0.02])).toBe(0);
+  });
+
+  it('should calculate ES correctly', () => {
+    const returns = Array.from({ length: 100 }, (_, i) => (i - 50) / 100);
+    const es = calculateExpectedShortfall(returns, 0.95);
+    
+    // ES should be >= VaR for the same confidence level
+    const var95 = calculateVaR(returns, 0.95);
+    expect(es).toBeGreaterThanOrEqual(var95);
+  });
+});
+
+describe('calculateRiskMetrics', () => {
+  it('should return zeros for insufficient data', () => {
+    const result = calculateRiskMetrics([]);
+    
+    expect(result.volatility).toBe(0);
+    expect(result.maxDrawdown).toBe(0);
+    expect(result.sharpeRatio).toBe(0);
+  });
+
+  it('should calculate all metrics correctly', () => {
+    const historical = [
+      { timestamp: new Date('2024-01-01'), value: 100000 },
+      { timestamp: new Date('2024-01-02'), value: 101000 },
+      { timestamp: new Date('2024-01-03'), value: 100500 },
+      { timestamp: new Date('2024-01-04'), value: 102000 },
+      { timestamp: new Date('2024-01-05'), value: 101500 },
+    ];
+    
+    const result = calculateRiskMetrics(historical);
+    
+    expect(result.volatility).toBeGreaterThan(0);
+    expect(result.maxDrawdown).toBeGreaterThanOrEqual(0);
+    expect(result.sharpeRatio).toBeDefined();
+  });
+});
+
+describe('analyzePositions', () => {
+  it('should return empty results for no positions', () => {
+    const result = analyzePositions([], 100000);
+    
+    expect(result.positions).toEqual([]);
+    expect(result.topGainers).toEqual([]);
+    expect(result.topLosers).toEqual([]);
+    expect(result.concentrationRisk).toBe(0);
+  });
+
+  it('should calculate position analytics correctly', () => {
+    const positions = [
+      { symbol: 'BTC', quantity: 1, averageCost: 50000 },
+      { symbol: 'ETH', quantity: 10, averageCost: 3000 },
+    ];
+    
+    const result = analyzePositions(positions, 100000);
+    
+    expect(result.positions.length).toBe(2);
+    expect(result.concentrationRisk).toBeGreaterThan(0);
+    expect(result.largestPositionWeight).toBeGreaterThan(0);
+  });
+
+  it('should identify top gainers and losers', () => {
+    const positions = [
+      { symbol: 'BTC', quantity: 1, averageCost: 50000, currentPrice: 55000, unrealizedPnL: 5000 },
+      { symbol: 'ETH', quantity: 10, averageCost: 3000, currentPrice: 2500, unrealizedPnL: -5000 },
+      { symbol: 'SOL', quantity: 100, averageCost: 100, currentPrice: 150, unrealizedPnL: 5000 },
+    ];
+    
+    const result = analyzePositions(positions, 100000);
+    
+    expect(result.topGainers.length).toBeGreaterThan(0);
+    expect(result.topLosers.length).toBeGreaterThan(0);
+    
+    // Top gainers should have positive PnL
+    result.topGainers.forEach(p => {
+      expect(p.unrealizedPnL).toBeGreaterThan(0);
+    });
+    
+    // Top losers should have negative PnL
+    result.topLosers.forEach(p => {
+      expect(p.unrealizedPnL).toBeLessThan(0);
+    });
+  });
+});
+
+describe('calculateCorrelation', () => {
+  it('should return 0 for mismatched or insufficient data', () => {
+    expect(calculateCorrelation([], [])).toBe(0);
+    expect(calculateCorrelation([1, 2], [])).toBe(0);
+    expect(calculateCorrelation([1], [2])).toBe(0);
+  });
+
+  it('should return 1 for identical series', () => {
+    const series = [1, 2, 3, 4, 5];
+    expect(calculateCorrelation(series, series)).toBeCloseTo(1, 5);
+  });
+
+  it('should return -1 for perfectly negatively correlated series', () => {
+    const series1 = [1, 2, 3, 4, 5];
+    const series2 = [5, 4, 3, 2, 1];
+    expect(calculateCorrelation(series1, series2)).toBeCloseTo(-1, 5);
+  });
+});
+
+describe('calculateCorrelationMatrix', () => {
+  it('should return empty array for no data', () => {
+    const result = calculateCorrelationMatrix(new Map());
+    expect(result).toEqual([]);
+  });
+
+  it('should calculate correlation matrix correctly', () => {
+    const priceHistory = new Map([
+      ['BTC', [50000, 51000, 52000, 51500, 52500]],
+      ['ETH', [3000, 3100, 3200, 3150, 3250]],
+    ]);
+    
+    const result = calculateCorrelationMatrix(priceHistory);
+    
+    expect(result.length).toBe(3); // BTC-BTC, BTC-ETH, ETH-ETH
+    expect(result.find((e: any) => e.symbol1 === 'BTC' && e.symbol2 === 'BTC')?.correlation).toBe(1);
+    expect(result.find((e: any) => e.symbol1 === 'ETH' && e.symbol2 === 'ETH')?.correlation).toBe(1);
+  });
+});
+
+describe('calculatePnLBreakdown', () => {
+  it('should calculate P&L breakdown correctly', () => {
+    // Create trades with proper structure
+    const now = Date.now();
+    const mockTrades = [
+      {
+        id: '1',
+        strategyId: 'test',
+        symbol: 'BTC',
+        side: 'buy' as const,
+        price: 50000,
+        quantity: 1,
+        total: 50000,
+        executedAt: new Date(now - 12 * 60 * 60 * 1000).toISOString(), // 12 hours ago (within daily)
+      },
+      {
+        id: '2',
+        strategyId: 'test',
+        symbol: 'BTC',
+        side: 'sell' as const,
+        price: 60000, // Sell at higher price for profit
+        quantity: 1,
+        total: 60000,
+        executedAt: new Date(now - 6 * 60 * 60 * 1000).toISOString(), // 6 hours ago (within daily)
+      },
+    ];
+
+    const result = calculatePnLBreakdown(mockTrades as any, 1000, 100000);
+    
+    expect(result.daily).toBeDefined();
+    expect(result.weekly).toBeDefined();
+    expect(result.monthly).toBeDefined();
+    expect(result.allTime).toBeDefined();
+    
+    // Daily should have profit: sell 60000 - buy 50000 = 10000
+    expect(result.daily.realized).toBe(10000);
+    expect(result.daily.total).toBe(11000); // 10000 realized + 1000 unrealized
+  });
+
+  it('should handle no trades', () => {
+    const result = calculatePnLBreakdown([], 1000, 100000);
+    
+    expect(result.daily.realized).toBe(0);
+    expect(result.weekly.realized).toBe(0);
+    expect(result.monthly.realized).toBe(0);
+    expect(result.allTime.realized).toBe(0);
+  });
+});
+
+describe('formatPercent', () => {
+  it('should format positive values with plus sign', () => {
+    expect(formatPercent(5.5)).toBe('+5.50%');
+    expect(formatPercent(0)).toBe('+0.00%');
+  });
+
+  it('should format negative values with minus sign', () => {
+    expect(formatPercent(-5.5)).toBe('-5.50%');
+  });
+
+  it('should respect decimal places', () => {
+    expect(formatPercent(5.555, 1)).toBe('+5.6%');
+    expect(formatPercent(5.555, 3)).toBe('+5.555%');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('should format small values with dollar sign', () => {
+    expect(formatCurrency(500)).toBe('$500.00');
+  });
+
+  it('should format thousands with K suffix', () => {
+    expect(formatCurrency(5000)).toBe('$5.00K');
+    expect(formatCurrency(15000)).toBe('$15.00K');
+  });
+
+  it('should format millions with M suffix', () => {
+    expect(formatCurrency(1500000)).toBe('$1.50M');
+  });
+
+  it('should format billions with B suffix', () => {
+    expect(formatCurrency(1500000000)).toBe('$1.50B');
+  });
+
+  it('should handle negative values', () => {
+    expect(formatCurrency(-5000)).toBe('$-5.00K');
+  });
+});
+
+describe('formatDuration', () => {
+  it('should format minutes', () => {
+    expect(formatDuration(0.5)).toBe('30m');
+    expect(formatDuration(0.25)).toBe('15m');
+  });
+
+  it('should format hours', () => {
+    expect(formatDuration(2)).toBe('2.0h');
+    expect(formatDuration(12.5)).toBe('12.5h');
+  });
+
+  it('should format days', () => {
+    expect(formatDuration(24)).toBe('1.0d');
+    expect(formatDuration(48)).toBe('2.0d');
+  });
+});

--- a/src/client/utils/portfolioAnalytics.ts
+++ b/src/client/utils/portfolioAnalytics.ts
@@ -1,0 +1,606 @@
+/**
+ * Portfolio Analytics Utilities
+ * 
+ * Provides calculation functions for portfolio risk metrics and performance analysis.
+ * All calculations are designed to be non-blocking for UI rendering.
+ */
+
+import type { Trade, Portfolio } from '../utils/api';
+
+/**
+ * Position with extended analytics data
+ */
+export interface PositionAnalytics {
+  symbol: string;
+  quantity: number;
+  averageCost: number;
+  currentPrice: number;
+  marketValue: number;
+  unrealizedPnL: number;
+  unrealizedPnLPercent: number;
+  costBasis: number;
+  weight: number; // Percentage of total portfolio
+  priceChange24h: number;
+  priceChangePercent24h: number;
+}
+
+/**
+ * Portfolio risk metrics
+ */
+export interface RiskMetrics {
+  volatility: number; // Standard deviation of returns (annualized)
+  maxDrawdown: number; // Maximum peak-to-trough decline
+  maxDrawdownPercent: number;
+  sharpeRatio: number; // Risk-adjusted return (annualized)
+  sortinoRatio: number; // Downside risk-adjusted return
+  valueAtRisk95: number; // 95% VaR (daily)
+  expectedShortfall: number; // CVaR (average loss beyond VaR)
+}
+
+/**
+ * Performance metrics
+ */
+export interface PerformanceMetrics {
+  totalReturn: number;
+  totalReturnPercent: number;
+  dailyPnL: number;
+  weeklyPnL: number;
+  monthlyPnL: number;
+  dailyPnLPercent: number;
+  weeklyPnLPercent: number;
+  monthlyPnLPercent: number;
+  winRate: number;
+  averageTradeDuration: number; // in hours
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  averageWin: number;
+  averageLoss: number;
+  profitFactor: number; // Gross profit / Gross loss
+  bestTrade: number;
+  worstTrade: number;
+}
+
+/**
+ * Position analysis result
+ */
+export interface PositionAnalysis {
+  positions: PositionAnalytics[];
+  topGainers: PositionAnalytics[];
+  topLosers: PositionAnalytics[];
+  concentrationRisk: number; // Herfindahl index
+  largestPositionWeight: number;
+}
+
+/**
+ * P&L breakdown by period
+ */
+export interface PnLBreakdown {
+  daily: { realized: number; unrealized: number; total: number };
+  weekly: { realized: number; unrealized: number; total: number };
+  monthly: { realized: number; unrealized: number; total: number };
+  allTime: { realized: number; unrealized: number; total: number };
+}
+
+/**
+ * Correlation matrix entry
+ */
+export interface CorrelationEntry {
+  symbol1: string;
+  symbol2: string;
+  correlation: number; // -1 to 1
+}
+
+/**
+ * Historical data point for calculations
+ */
+export interface HistoricalDataPoint {
+  timestamp: Date;
+  value: number;
+  return?: number; // Percentage return from previous period
+}
+
+/**
+ * Calculate volatility (annualized standard deviation of returns)
+ * Uses population standard deviation for consistency
+ */
+export function calculateVolatility(
+  returns: number[],
+  periodsPerYear: number = 252
+): number {
+  if (returns.length < 2) return 0;
+
+  const mean = returns.reduce((sum, r) => sum + r, 0) / returns.length;
+  const squaredDiffs = returns.map(r => Math.pow(r - mean, 2));
+  const variance = squaredDiffs.reduce((sum, d) => sum + d, 0) / returns.length;
+  
+  // Annualize the volatility
+  return Math.sqrt(variance * periodsPerYear);
+}
+
+/**
+ * Calculate maximum drawdown from historical values
+ */
+export function calculateMaxDrawdown(
+  values: number[]
+): { maxDrawdown: number; maxDrawdownPercent: number } {
+  if (values.length < 2) {
+    return { maxDrawdown: 0, maxDrawdownPercent: 0 };
+  }
+
+  let peak = values[0];
+  let maxDrawdown = 0;
+  let maxDrawdownPercent = 0;
+
+  for (const value of values) {
+    if (value > peak) {
+      peak = value;
+    }
+    
+    const drawdown = peak - value;
+    const drawdownPercent = peak > 0 ? (drawdown / peak) * 100 : 0;
+    
+    if (drawdown > maxDrawdown) {
+      maxDrawdown = drawdown;
+      maxDrawdownPercent = drawdownPercent;
+    }
+  }
+
+  return { maxDrawdown, maxDrawdownPercent };
+}
+
+/**
+ * Calculate Sharpe Ratio (annualized)
+ * Assumes risk-free rate of 0 for simplicity
+ */
+export function calculateSharpeRatio(
+  returns: number[],
+  riskFreeRate: number = 0,
+  periodsPerYear: number = 252
+): number {
+  if (returns.length < 2) return 0;
+
+  const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
+  const volatility = calculateVolatility(returns, periodsPerYear);
+  
+  if (volatility === 0) return 0;
+
+  // Annualize the average return
+  const annualizedReturn = avgReturn * periodsPerYear;
+  const annualizedRiskFree = riskFreeRate;
+
+  return (annualizedReturn - annualizedRiskFree) / volatility;
+}
+
+/**
+ * Calculate Sortino Ratio (downside risk-adjusted return)
+ */
+export function calculateSortinoRatio(
+  returns: number[],
+  riskFreeRate: number = 0,
+  periodsPerYear: number = 252
+): number {
+  if (returns.length < 2) return 0;
+
+  const avgReturn = returns.reduce((sum, r) => sum + r, 0) / returns.length;
+  
+  // Calculate downside deviation (only negative returns)
+  const negativeReturns = returns.filter(r => r < 0);
+  if (negativeReturns.length === 0) return Infinity;
+
+  const squaredDownside = negativeReturns.map(r => Math.pow(r, 2));
+  const downsideVariance = squaredDownside.reduce((sum, d) => sum + d, 0) / returns.length;
+  const downsideDeviation = Math.sqrt(downsideVariance * periodsPerYear);
+
+  if (downsideDeviation === 0) return 0;
+
+  const annualizedReturn = avgReturn * periodsPerYear;
+  return (annualizedReturn - riskFreeRate) / downsideDeviation;
+}
+
+/**
+ * Calculate Value at Risk (VaR) using historical method
+ * @param returns Array of historical returns
+ * @param confidence Confidence level (default 95%)
+ */
+export function calculateVaR(
+  returns: number[],
+  confidence: number = 0.95
+): number {
+  if (returns.length < 10) return 0;
+
+  const sortedReturns = [...returns].sort((a, b) => a - b);
+  const index = Math.floor((1 - confidence) * sortedReturns.length);
+  
+  return Math.abs(sortedReturns[index] || 0);
+}
+
+/**
+ * Calculate Expected Shortfall (CVaR)
+ * Average of returns below VaR threshold
+ */
+export function calculateExpectedShortfall(
+  returns: number[],
+  confidence: number = 0.95
+): number {
+  if (returns.length < 10) return 0;
+
+  const sortedReturns = [...returns].sort((a, b) => a - b);
+  const index = Math.floor((1 - confidence) * sortedReturns.length);
+  const tailReturns = sortedReturns.slice(0, index + 1);
+  
+  if (tailReturns.length === 0) return 0;
+  
+  return Math.abs(tailReturns.reduce((sum, r) => sum + r, 0) / tailReturns.length);
+}
+
+/**
+ * Calculate all risk metrics from historical data
+ */
+export function calculateRiskMetrics(
+  historicalValues: HistoricalDataPoint[]
+): RiskMetrics {
+  if (historicalValues.length < 2) {
+    return {
+      volatility: 0,
+      maxDrawdown: 0,
+      maxDrawdownPercent: 0,
+      sharpeRatio: 0,
+      sortinoRatio: 0,
+      valueAtRisk95: 0,
+      expectedShortfall: 0,
+    };
+  }
+
+  // Calculate returns
+  const returns: number[] = [];
+  for (let i = 1; i < historicalValues.length; i++) {
+    const prev = historicalValues[i - 1].value;
+    const curr = historicalValues[i].value;
+    if (prev > 0) {
+      returns.push((curr - prev) / prev);
+    }
+  }
+
+  const values = historicalValues.map(h => h.value);
+  const { maxDrawdown, maxDrawdownPercent } = calculateMaxDrawdown(values);
+
+  return {
+    volatility: calculateVolatility(returns),
+    maxDrawdown,
+    maxDrawdownPercent,
+    sharpeRatio: calculateSharpeRatio(returns),
+    sortinoRatio: calculateSortinoRatio(returns),
+    valueAtRisk95: calculateVaR(returns),
+    expectedShortfall: calculateExpectedShortfall(returns),
+  };
+}
+
+/**
+ * Calculate performance metrics from trades and portfolio data
+ */
+export function calculatePerformanceMetrics(
+  trades: Trade[],
+  portfolioValue: number,
+  initialCapital: number,
+  historicalValues: HistoricalDataPoint[]
+): PerformanceMetrics {
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  // Calculate realized P&L from trades
+  const sells = trades.filter(t => t.side === 'sell');
+  const buys = trades.filter(t => t.side === 'buy');
+
+  // Total return
+  const totalReturn = portfolioValue - initialCapital;
+  const totalReturnPercent = initialCapital > 0 
+    ? (totalReturn / initialCapital) * 100 
+    : 0;
+
+  // Period P&L calculations
+  const dailyTrades = trades.filter(t => new Date(t.executedAt) >= oneDayAgo);
+  const weeklyTrades = trades.filter(t => new Date(t.executedAt) >= oneWeekAgo);
+  const monthlyTrades = trades.filter(t => new Date(t.executedAt) >= oneMonthAgo);
+
+  const calculateRealizedPnL = (tradeList: Trade[]): number => {
+    const periodSells = tradeList.filter(t => t.side === 'sell');
+    const periodBuys = tradeList.filter(t => t.side === 'buy');
+    const totalCost = periodBuys.reduce((sum, t) => sum + t.total, 0);
+    const totalProceeds = periodSells.reduce((sum, t) => sum + t.total, 0);
+    return totalProceeds - totalCost;
+  };
+
+  const dailyPnL = calculateRealizedPnL(dailyTrades);
+  const weeklyPnL = calculateRealizedPnL(weeklyTrades);
+  const monthlyPnL = calculateRealizedPnL(monthlyTrades);
+
+  // Estimate P&L percentages based on current portfolio value
+  const dailyPnLPercent = portfolioValue > 0 ? (dailyPnL / portfolioValue) * 100 : 0;
+  const weeklyPnLPercent = portfolioValue > 0 ? (weeklyPnL / portfolioValue) * 100 : 0;
+  const monthlyPnLPercent = portfolioValue > 0 ? (monthlyPnL / portfolioValue) * 100 : 0;
+
+  // Win rate calculation
+  const winningTrades = sells.filter((sell, idx) => {
+    // Simple heuristic: profitable if sell price > average buy price
+    const symbolBuys = buys.filter(b => b.symbol === sell.symbol);
+    if (symbolBuys.length === 0) return false;
+    const avgBuyPrice = symbolBuys.reduce((sum, b) => sum + b.price * b.quantity, 0) 
+      / symbolBuys.reduce((sum, b) => sum + b.quantity, 0);
+    return sell.price > avgBuyPrice;
+  });
+
+  const losingTrades = sells.filter((sell, idx) => {
+    const symbolBuys = buys.filter(b => b.symbol === sell.symbol);
+    if (symbolBuys.length === 0) return false;
+    const avgBuyPrice = symbolBuys.reduce((sum, b) => sum + b.price * b.quantity, 0) 
+      / symbolBuys.reduce((sum, b) => sum + b.quantity, 0);
+    return sell.price <= avgBuyPrice;
+  });
+
+  const winRate = sells.length > 0 ? (winningTrades.length / sells.length) * 100 : 0;
+
+  // Average trade duration (simplified - assumes FIFO)
+  const tradeDurations: number[] = [];
+  const positionOpenTimes: Map<string, Date> = new Map();
+  
+  for (const trade of trades.sort((a, b) => 
+    new Date(a.executedAt).getTime() - new Date(b.executedAt).getTime()
+  )) {
+    if (trade.side === 'buy') {
+      positionOpenTimes.set(trade.symbol, new Date(trade.executedAt));
+    } else if (trade.side === 'sell') {
+      const openTime = positionOpenTimes.get(trade.symbol);
+      if (openTime) {
+        const duration = (new Date(trade.executedAt).getTime() - openTime.getTime()) / (1000 * 60 * 60);
+        tradeDurations.push(duration);
+      }
+    }
+  }
+
+  const averageTradeDuration = tradeDurations.length > 0
+    ? tradeDurations.reduce((sum, d) => sum + d, 0) / tradeDurations.length
+    : 0;
+
+  // Profit factor
+  const grossProfit = winningTrades.reduce((sum, t) => sum + t.total, 0);
+  const grossLoss = Math.abs(losingTrades.reduce((sum, t) => sum + t.total, 0));
+  const profitFactor = grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Infinity : 0;
+
+  // Average win/loss
+  const averageWin = winningTrades.length > 0 
+    ? winningTrades.reduce((sum, t) => sum + t.total, 0) / winningTrades.length 
+    : 0;
+  const averageLoss = losingTrades.length > 0 
+    ? losingTrades.reduce((sum, t) => sum + t.total, 0) / losingTrades.length 
+    : 0;
+
+  // Best and worst trades
+  const allTradePnLs = sells.map(sell => {
+    const symbolBuys = buys.filter(b => b.symbol === sell.symbol);
+    if (symbolBuys.length === 0) return 0;
+    const avgBuyPrice = symbolBuys.reduce((sum, b) => sum + b.price * b.quantity, 0) 
+      / symbolBuys.reduce((sum, b) => sum + b.quantity, 0);
+    return (sell.price - avgBuyPrice) * sell.quantity;
+  });
+
+  const bestTrade = allTradePnLs.length > 0 ? Math.max(...allTradePnLs) : 0;
+  const worstTrade = allTradePnLs.length > 0 ? Math.min(...allTradePnLs) : 0;
+
+  return {
+    totalReturn,
+    totalReturnPercent,
+    dailyPnL,
+    weeklyPnL,
+    monthlyPnL,
+    dailyPnLPercent,
+    weeklyPnLPercent,
+    monthlyPnLPercent,
+    winRate,
+    averageTradeDuration,
+    totalTrades: trades.length,
+    winningTrades: winningTrades.length,
+    losingTrades: losingTrades.length,
+    averageWin,
+    averageLoss,
+    profitFactor,
+    bestTrade,
+    worstTrade,
+  };
+}
+
+/**
+ * Analyze positions for risk and performance
+ */
+export function analyzePositions(
+  positions: Array<{
+    symbol: string;
+    quantity: number;
+    averageCost: number;
+    currentPrice?: number;
+    marketValue?: number;
+    unrealizedPnL?: number;
+    priceChange24h?: number;
+    priceChangePercent24h?: number;
+  }>,
+  totalPortfolioValue: number
+): PositionAnalysis {
+  const analytics: PositionAnalytics[] = positions.map(pos => {
+    const currentPrice = pos.currentPrice || pos.averageCost;
+    const marketValue = pos.marketValue || (pos.quantity * currentPrice);
+    const costBasis = pos.quantity * pos.averageCost;
+    const unrealizedPnL = pos.unrealizedPnL || (marketValue - costBasis);
+    const unrealizedPnLPercent = costBasis > 0 ? (unrealizedPnL / costBasis) * 100 : 0;
+    const weight = totalPortfolioValue > 0 ? (marketValue / totalPortfolioValue) * 100 : 0;
+
+    return {
+      symbol: pos.symbol,
+      quantity: pos.quantity,
+      averageCost: pos.averageCost,
+      currentPrice,
+      marketValue,
+      unrealizedPnL,
+      unrealizedPnLPercent,
+      costBasis,
+      weight,
+      priceChange24h: pos.priceChange24h || 0,
+      priceChangePercent24h: pos.priceChangePercent24h || 0,
+    };
+  });
+
+  // Sort by unrealized P&L for top gainers/losers
+  const sorted = [...analytics].sort((a, b) => b.unrealizedPnL - a.unrealizedPnL);
+  const topGainers = sorted.filter(p => p.unrealizedPnL > 0).slice(0, 5);
+  const topLosers = sorted.filter(p => p.unrealizedPnL < 0).reverse().slice(0, 5);
+
+  // Calculate concentration risk (Herfindahl index)
+  const concentrationRisk = analytics.reduce((sum, p) => sum + Math.pow(p.weight, 2), 0);
+  const largestPositionWeight = Math.max(...analytics.map(p => p.weight), 0);
+
+  return {
+    positions: analytics,
+    topGainers,
+    topLosers,
+    concentrationRisk,
+    largestPositionWeight,
+  };
+}
+
+/**
+ * Calculate correlation between two price series
+ */
+export function calculateCorrelation(
+  series1: number[],
+  series2: number[]
+): number {
+  if (series1.length !== series2.length || series1.length < 2) return 0;
+
+  const n = series1.length;
+  const mean1 = series1.reduce((sum, v) => sum + v, 0) / n;
+  const mean2 = series2.reduce((sum, v) => sum + v, 0) / n;
+
+  let numerator = 0;
+  let denom1 = 0;
+  let denom2 = 0;
+
+  for (let i = 0; i < n; i++) {
+    const diff1 = series1[i] - mean1;
+    const diff2 = series2[i] - mean2;
+    numerator += diff1 * diff2;
+    denom1 += diff1 * diff1;
+    denom2 += diff2 * diff2;
+  }
+
+  const denominator = Math.sqrt(denom1 * denom2);
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+/**
+ * Calculate correlation matrix for held assets
+ * Requires historical price data for each symbol
+ */
+export function calculateCorrelationMatrix(
+  priceHistory: Map<string, number[]>
+): CorrelationEntry[] {
+  const symbols = Array.from(priceHistory.keys());
+  const entries: CorrelationEntry[] = [];
+
+  for (let i = 0; i < symbols.length; i++) {
+    for (let j = i; j < symbols.length; j++) {
+      const series1 = priceHistory.get(symbols[i]) || [];
+      const series2 = priceHistory.get(symbols[j]) || [];
+      
+      entries.push({
+        symbol1: symbols[i],
+        symbol2: symbols[j],
+        correlation: i === j ? 1 : calculateCorrelation(series1, series2),
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Calculate P&L breakdown by time period
+ */
+export function calculatePnLBreakdown(
+  trades: Trade[],
+  currentUnrealizedPnL: number,
+  portfolioValue: number
+): PnLBreakdown {
+  const now = new Date();
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  const calculatePeriodPnL = (startDate: Date) => {
+    const periodTrades = trades.filter(t => new Date(t.executedAt) >= startDate);
+    const buys = periodTrades.filter(t => t.side === 'buy');
+    const sells = periodTrades.filter(t => t.side === 'sell');
+    const realized = sells.reduce((sum, t) => sum + t.total, 0) 
+      - buys.reduce((sum, t) => sum + t.total, 0);
+    return realized;
+  };
+
+  return {
+    daily: {
+      realized: calculatePeriodPnL(oneDayAgo),
+      unrealized: currentUnrealizedPnL, // Simplified: current unrealized
+      total: calculatePeriodPnL(oneDayAgo) + currentUnrealizedPnL,
+    },
+    weekly: {
+      realized: calculatePeriodPnL(oneWeekAgo),
+      unrealized: currentUnrealizedPnL,
+      total: calculatePeriodPnL(oneWeekAgo) + currentUnrealizedPnL,
+    },
+    monthly: {
+      realized: calculatePeriodPnL(oneMonthAgo),
+      unrealized: currentUnrealizedPnL,
+      total: calculatePeriodPnL(oneMonthAgo) + currentUnrealizedPnL,
+    },
+    allTime: {
+      realized: calculatePeriodPnL(new Date(0)),
+      unrealized: currentUnrealizedPnL,
+      total: calculatePeriodPnL(new Date(0)) + currentUnrealizedPnL,
+    },
+  };
+}
+
+/**
+ * Format a number as percentage string
+ */
+export function formatPercent(value: number, decimals: number = 2): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(decimals)}%`;
+}
+
+/**
+ * Format a number as currency string
+ */
+export function formatCurrency(value: number, decimals: number = 2): string {
+  const absValue = Math.abs(value);
+  if (absValue >= 1e9) {
+    return `$${(value / 1e9).toFixed(2)}B`;
+  } else if (absValue >= 1e6) {
+    return `$${(value / 1e6).toFixed(2)}M`;
+  } else if (absValue >= 1e3) {
+    return `$${(value / 1e3).toFixed(2)}K`;
+  }
+  return `$${value.toFixed(decimals)}`;
+}
+
+/**
+ * Format duration in hours to human-readable string
+ */
+export function formatDuration(hours: number): string {
+  if (hours < 1) {
+    return `${Math.round(hours * 60)}m`;
+  } else if (hours < 24) {
+    return `${hours.toFixed(1)}h`;
+  } else {
+    const days = hours / 24;
+    return `${days.toFixed(1)}d`;
+  }
+}


### PR DESCRIPTION
## Description

Implements Issue #212: 投资组合分析增强

This PR adds comprehensive portfolio analytics to the Holdings page, including risk metrics, performance metrics, and position analysis.

## Changes

### New Files
- `src/client/utils/portfolioAnalytics.ts` - Core calculation functions for:
  - Volatility (annualized standard deviation)
  - Max drawdown
  - Sharpe ratio
  - Sortino ratio
  - Value at Risk (VaR)
  - Expected Shortfall (CVaR)
  - Position analysis
  - Correlation matrix
  - P&L breakdown

- `src/client/hooks/usePortfolioAnalytics.ts` - React hook for analytics state management

- `src/client/utils/__tests__/portfolioAnalytics.test.ts` - Comprehensive unit tests (39 tests, all passing)

### Enhanced Files
- `src/client/pages/HoldingsPage.tsx` - Major enhancements:
  - Risk Metrics section (volatility, max drawdown, Sharpe, Sortino)
  - P&L Breakdown section (daily/weekly/monthly)
  - Drawdown history chart
  - Top Gainers/Losers lists
  - Position Concentration analysis (HHI)
  - Trading Performance statistics
  - All components are mobile-responsive

## Acceptance Criteria

- [x] Portfolio metrics display correctly
- [x] Risk indicators calculate and display accurately  
- [x] Position analysis visualizations render properly
- [x] Performance chart updates in real-time
- [x] Mobile-friendly layout for all new components
- [x] Unit tests for calculation functions

## Testing

- All 39 new unit tests pass
- TypeScript compilation successful
- Pre-existing tests unaffected

## Screenshots

The new analytics sections include:
- Risk Metrics cards with tooltips explaining each metric
- P&L Breakdown with daily/weekly/monthly breakdown
- Drawdown chart showing portfolio risk over time
- Top Gainers/Losers lists
- Position Concentration with HHI indicator
- Trading Performance statistics with profit factor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new analytics calculations and rewires `HoldingsPage` to display them; incorrect assumptions (e.g., hardcoded initial capital, simplified trade P&L heuristics) could lead to misleading metrics and UI regressions.
> 
> **Overview**
> Adds a new `portfolioAnalytics` utility module (with unit tests) and a `usePortfolioAnalytics` hook to compute portfolio *risk metrics* (volatility/drawdown/Sharpe/Sortino/VaR/ES), *performance metrics* (returns, win rate, profit factor, trade duration, best/worst), *position analysis* (top gainers/losers, concentration/HHI), and *P&L breakdown* by period.
> 
> Updates `HoldingsPage` to use these analytics and significantly expands the UI: replaces the overview’s unrealized P&L with total return, adds dedicated Risk Metrics and P&L Breakdown sections, introduces a drawdown history chart, top gainers/losers lists, position concentration indicators, and a trading performance panel, plus improved empty-state handling and recharts tooltip naming to avoid component conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c732ae3534cc3ba28e19b734c905e41696369a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->