### PR TITLE
fix: P0 - Handle chunk loading failures with retry logic

### DIFF
--- a/.virtucorp/knowledge/runbook/sprint-10-retrospective.md
+++ b/.virtucorp/knowledge/runbook/sprint-10-retrospective.md
@@ -1,0 +1,112 @@
+# sprint-10-retrospective
+
+_Saved: 2026-03-16_
+
+# Sprint 10 Retrospective
+
+**Sprint**: 10  
+**Period**: 2026-04-09 → 2026-04-16  
+**Milestone**: #7  
+**Status**: Completed
+
+---
+
+## Summary
+
+Sprint 10 focused on implementing trading strategies (RSI, MACD), user preference settings, and UX improvements for the trading panel. The sprint successfully delivered all 4 planned issues with good code quality.
+
+---
+
+## Completed Issues
+
+| Issue | Description | PR | Status |
+|-------|-------------|-----|--------|
+| #195 | RSI 策略 | #205 | ✅ Merged |
+| #196 | MACD 策略 | #206 | ✅ Merged |
+| #197 | 用户偏好设置功能 | #207 | ✅ Merged |
+| #198 | 交易面板 UX 优化 | #208 | ✅ Merged |
+
+---
+
+## Smoke Test Results
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Homepage | ✅ Pass | - |
+| Dashboard | ✅ Pass | - |
+| Trades | ✅ Pass | - |
+| Holdings | ✅ Pass | - |
+| Settings Panel | ❌ Failed | Button not discoverable - Issue #209 created |
+
+---
+
+## What Went Well ✅
+
+1. **100% Delivery Rate**: All 4 planned issues were completed and merged within the sprint timeline.
+
+2. **Strong Code Quality**: Every PR passed QA review on the first or second attempt, indicating good understanding of requirements and clean implementation.
+
+3. **Comprehensive Testing**: Unit tests were added for all new features (RSI strategy, MACD strategy, preferences, UX improvements), ensuring maintainability.
+
+4. **Clear Issue Specifications**: Issues were well-defined with clear acceptance criteria, reducing back-and-forth during implementation.
+
+5. **Efficient Sprint Execution**: No major blockers or unexpected complications arose during development.
+
+---
+
+## What Could Be Improved 🔧
+
+1. **Settings Panel UX**: The smoke test revealed that the settings button was not discoverable by the AI tester. This indicates:
+   - UI affordances may be too subtle
+   - Consider adding visible labels or more prominent placement
+   - Issue #209 has been created to track this fix
+
+2. **Pre-deployment Testing Gap**: The settings panel issue was only discovered during post-deploy smoke testing. Earlier testing during development could have caught this.
+
+3. **UI Component Accessibility**: The MidsceneJS AI tester couldn't find the settings button, which may indicate accessibility or discoverability issues that could also affect real users.
+
+---
+
+## Action Items for Sprint 11 📋
+
+### High Priority
+1. **Fix Settings Panel Button (Issue #209)**: Improve button discoverability
+   - Add visible label or icon
+   - Consider placement optimization
+   - Verify with manual UI testing
+
+### Process Improvements
+2. **Add Pre-merge UI Verification**: Before merging UI changes, run a quick manual check or automated visual regression test.
+
+3. **Enhance Component Accessibility**: Audit all interactive elements for:
+   - Sufficient contrast ratios
+   - Clear visual affordances
+   - Proper ARIA labels where needed
+
+4. **Document UI Patterns**: Create a knowledge base entry for UI component patterns to ensure consistency and discoverability across features.
+
+---
+
+## Metrics Summary
+
+| Metric | Value | Target | Status |
+|--------|-------|--------|--------|
+| Issues Planned | 4 | 4 | ✅ |
+| Issues Completed | 4 | 4 | ✅ |
+| PR Success Rate | 100% | 90%+ | ✅ |
+| Smoke Tests Passed | 4/5 (80%) | 100% | ⚠️ |
+| Unit Test Coverage | All new features | - | ✅ |
+
+---
+
+## Lessons Learned
+
+1. **Small, focused issues work well**: Each issue had a clear scope, enabling clean implementation and review.
+
+2. **Post-deploy verification catches UI issues**: The smoke test process successfully identified a UX problem that wasn't obvious during code review.
+
+3. **Accessibility matters for AI testing too**: Making UI elements discoverable for AI testers (like MidsceneJS) often correlates with better UX for actual users.
+
+---
+
+*Retrospective written by PM Agent on 2026-04-16*

--- a/.virtucorp/knowledge/runbook/sprint-11-planning.md
+++ b/.virtucorp/knowledge/runbook/sprint-11-planning.md
@@ -1,0 +1,74 @@
+# sprint-11-planning
+
+_Saved: 2026-03-16_
+
+# Sprint 11 Planning
+
+_Saved: 2026-03-17_
+
+## Sprint Overview
+
+**Sprint**: 11  
+**Period**: 2026-04-17 → 2026-04-24  
+**Milestone**: #12  
+**Theme**: Strategy Enhancement & UX Improvements
+
+---
+
+## Sprint Goals
+
+1. **Add Bollinger Bands trading strategy** - Expand strategy options for traders
+2. **Enhance portfolio analytics** - Add risk metrics and performance visualizations
+3. **Improve mobile responsiveness** - Better mobile trading experience
+4. **Enhance UI accessibility** - Address Sprint 10 retro action items
+
+---
+
+## Planned Issues
+
+| Issue | Description | Priority | Labels |
+|-------|-------------|----------|--------|
+| #211 | 添加 Bollinger Bands 策略 | P1 | type/feature |
+| #212 | 投资组合分析增强 | P1 | type/feature |
+| #213 | 移动端响应式优化 | P2 | type/feature |
+| #214 | UI 可访问性增强 | P2 | type/feature |
+
+---
+
+## Sprint Capacity
+
+4 issues planned for 7-day sprint:
+- 2 P1 features (strategy + analytics)
+- 2 P2 features (mobile + accessibility)
+
+---
+
+## Dependencies
+
+- Sprint 10 delivered: RSI Strategy, MACD Strategy, User Preferences, Trading Panel UX
+- Sprint 11 builds on:
+  - Strategy framework (from Sprint 10)
+  - Holdings page (for analytics enhancement)
+  - UI components (for accessibility improvements)
+
+---
+
+## Risks
+
+1. Portfolio analytics may require new API endpoints - consider backend work
+2. Mobile responsiveness testing needs real device verification
+3. Accessibility improvements may conflict with existing styling
+
+---
+
+## Success Criteria
+
+- All 4 issues completed and merged
+- Unit tests for new features pass
+- Mobile testing completed on iOS Safari and Android Chrome
+- Lighthouse accessibility score > 90
+- No P0/P1 bugs introduced
+
+---
+
+*Planning completed by PM Agent on 2026-03-17*

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,10 +1,10 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev|prs:0|ready:5|executing",
-    "timestamp": 1773689913291,
+    "digestHash": "spawn_qa_smoke|prs:0|ready:0|executing",
+    "timestamp": 1773701312337,
     "consecutiveCount": 1
   },
-  "highWaterMark": 10,
+  "highWaterMark": 11,
   "paused": false,
   "pauseReason": ""
 }

--- a/.virtucorp/sprint.json
+++ b/.virtucorp/sprint.json
@@ -1,7 +1,14 @@
 {
-  "current": 10,
-  "startDate": "2026-04-09",
-  "endDate": "2026-04-16",
-  "milestone": 7,
-  "status": "executing"
+  "current": 11,
+  "startDate": "2026-04-17",
+  "endDate": "2026-04-24",
+  "milestone": 12,
+  "status": "executing",
+  "issues": [211, 212, 213, 214],
+  "goals": [
+    "Add Bollinger Bands trading strategy",
+    "Enhance portfolio analytics with risk metrics and performance charts",
+    "Improve mobile responsiveness across the platform",
+    "Enhance UI accessibility based on Sprint 10 retro findings"
+  ]
 }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Layout, Menu, Spin, Drawer, Button } from '@arco-design/web-react';
 import {
@@ -21,14 +21,15 @@ import { ConnectionProvider } from './store/connectionStore';
 import { useRealtimeConnection } from './hooks/useRealtimeConnection';
 import useErrorReporter from './hooks/useErrorReporter';
 import ErrorReporterPanel from './components/ErrorReporterPanel';
+import { lazyWithRetry } from './utils/lazyWithRetry';
 
-// Lazy load pages for code splitting
-const HomePage = lazy(() => import('./pages/HomePage'));
-const DashboardPage = lazy(() => import('./pages/DashboardPage'));
-const StrategiesPage = lazy(() => import('./pages/StrategiesPage'));
-const TradesPage = lazy(() => import('./pages/TradesPage'));
-const HoldingsPage = lazy(() => import('./pages/HoldingsPage'));
-const LeaderboardPage = lazy(() => import('./pages/LeaderboardPage'));
+// Lazy load pages for code splitting with retry logic for chunk loading failures
+const HomePage = lazyWithRetry(() => import('./pages/HomePage'));
+const DashboardPage = lazyWithRetry(() => import('./pages/DashboardPage'));
+const StrategiesPage = lazyWithRetry(() => import('./pages/StrategiesPage'));
+const TradesPage = lazyWithRetry(() => import('./pages/TradesPage'));
+const HoldingsPage = lazyWithRetry(() => import('./pages/HoldingsPage'));
+const LeaderboardPage = lazyWithRetry(() => import('./pages/LeaderboardPage'));
 
 // Loading component for lazy routes
 const PageLoader: React.FC = () => (

--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -41,6 +41,26 @@ function isThirdPartyDOMError(error: Error | null): boolean {
 }
 
 /**
+ * Check if this is a chunk/module loading error
+ * These errors occur when the browser fails to load a JavaScript chunk
+ * Common causes: deployment updates, cache issues, network problems
+ */
+function isChunkLoadError(error: Error | null): boolean {
+  if (!error) return false;
+  
+  const chunkErrorPatterns = [
+    "Failed to fetch dynamically imported module",
+    "Loading chunk",
+    "Loading CSS chunk",
+    "ChunkLoadError",
+    "Unable to resolve module",
+  ];
+  
+  const errorString = `${error.name}: ${error.message}`;
+  return chunkErrorPatterns.some(pattern => errorString.includes(pattern));
+}
+
+/**
  * Error Boundary Component
  * Catches JavaScript errors anywhere in the component tree
  * and displays a fallback UI instead of crashing the whole app
@@ -114,8 +134,27 @@ export class ErrorBoundary extends Component<Props, State> {
 
     // Special handling for third-party DOM errors (e.g., Arco Design removeChild errors)
     // These are often transient timing issues during component cleanup
+    // Special handling for chunk loading errors (e.g., "Failed to fetch dynamically imported module")
+    // These occur when deployment updates change chunk hashes - reload to get fresh bundle
+    if (isChunkLoadError(error)) {
+      console.warn("[ErrorBoundary] Detected chunk loading error, will auto-reload...");
+      
+      // Auto-reload after a short delay to get fresh bundle
+      if (!this.isInRetryCycle && this.state.retryCount < 2) {
+        this.isInRetryCycle = true;
+        if (this.retryTimeout) clearTimeout(this.retryTimeout);
+        this.retryTimeout = setTimeout(() => {
+          console.log("[ErrorBoundary] Reloading page to fetch fresh bundle...");
+          window.location.reload();
+        }, 500);
+        return; // Do not show error UI, wait for reload
+      }
+    }
+    
+    // Special handling for third-party DOM errors (e.g., Arco Design removeChild errors)
+    // These are often transient timing issues during component cleanup
     if (isThirdPartyDOMError(error)) {
-      console.warn('[ErrorBoundary] Detected third-party DOM error, will auto-retry...');
+      console.warn("[ErrorBoundary] Detected third-party DOM error, will auto-retry...");
       
       // Auto-retry after a short delay (up to 3 attempts)
       if (!this.isInRetryCycle && this.state.retryCount < 3) {
@@ -129,8 +168,8 @@ export class ErrorBoundary extends Component<Props, State> {
             remountKey: prevState.remountKey + 1,
           }));
         }, 1000);
-        return; // Don't show error UI yet, wait for retry
-      }
+        return; // Do not show error UI yet, wait for retry
+    }
     }
     
     // Store error info for display if not auto-retrying
@@ -161,6 +200,35 @@ export class ErrorBoundary extends Component<Props, State> {
       }
 
       // Check if this is a third-party DOM error (e.g., Arco Design)
+      // Check if this is a chunk loading error (e.g., "Failed to fetch dynamically imported module")
+      const isChunkError = isChunkLoadError(this.state.error);
+
+      // For chunk loading errors, show a reload prompt
+      // These errors require a page reload to get the latest bundle
+      if (isChunkError) {
+        return (
+          <div style={{ 
+            display: 'flex', 
+            flexDirection: 'column',
+            justifyContent: 'center', 
+            alignItems: 'center', 
+            minHeight: 300,
+            padding: 24,
+          }}>
+            <Spin size="large" style={{ marginBottom: 16 }} />
+            <Text style={{ marginBottom: 8 }}>页面资源加载中，请稍候...</Text>
+            <Text type="secondary" style={{ fontSize: 12, marginBottom: 16 }}>
+              （系统更新后正在加载最新版本）
+            </Text>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Button type="primary" onClick={this.handleReload}>
+                刷新页面
+              </Button>
+            </div>
+          </div>
+        );
+      }
+
       const isDOMError = isThirdPartyDOMError(this.state.error);
 
       // For third-party DOM errors, show a graceful loading spinner with retry option

--- a/src/client/utils/lazyWithRetry.ts
+++ b/src/client/utils/lazyWithRetry.ts
@@ -1,0 +1,107 @@
+/**
+ * Lazy Loading with Retry Logic
+ * 
+ * Handles "Failed to fetch dynamically imported module" errors that occur when:
+ * - A new deployment changes chunk hashes
+ * - Browser cache holds old bundle with stale chunk references
+ * - Network issues during chunk loading
+ * 
+ * Solution: Retry the import and if that fails, force a page reload to get the latest bundle.
+ */
+
+import React, { ComponentType, LazyExoticComponent } from 'react';
+
+// Track retry attempts to prevent infinite loops
+const RETRY_LIMIT = 3;
+const RETRY_DELAY = 500; // ms
+
+// Store for tracking failed imports
+const failedImports = new Set<string>();
+
+/**
+ * Wrap a dynamic import with retry logic
+ * 
+ * Usage:
+ *   const MyComponent = lazyWithRetry(() => import('./MyComponent'));
+ */
+export function lazyWithRetry<T extends ComponentType<any>>(
+  importFn: () => Promise<{ default: T }>
+): LazyExoticComponent<T> {
+  return React.lazy(() => retryImport(importFn));
+}
+
+/**
+ * Retry an import with reload fallback
+ */
+async function retryImport<T extends ComponentType<any>>(
+  importFn: () => Promise<{ default: T }>,
+  attempt: number = 1
+): Promise<{ default: T }> {
+  try {
+    const module = await importFn();
+    
+    // Clear any previous failure tracking on success
+    const importPath = importFn.toString();
+    failedImports.delete(importPath);
+    
+    return module;
+  } catch (error) {
+    const importPath = importFn.toString();
+    
+    console.error(`[LazyLoad] Import failed (attempt ${attempt}/${RETRY_LIMIT}):`, error);
+    
+    // Check if this is a chunk loading error
+    const isChunkError = error instanceof Error && (
+      error.message.includes('Failed to fetch dynamically imported module') ||
+      error.message.includes('Loading chunk') ||
+      error.message.includes('Loading CSS chunk') ||
+      error.name === 'ChunkLoadError'
+    );
+    
+    if (!isChunkError) {
+      // Not a chunk error, re-throw
+      throw error;
+    }
+    
+    // Check if we've already tried too many times
+    if (attempt >= RETRY_LIMIT) {
+      console.error('[LazyLoad] Max retries reached, forcing page reload...');
+      
+      // Track this import as failed
+      failedImports.add(importPath);
+      
+      // Force reload to get fresh bundle
+      // Use setTimeout to ensure error is logged
+      setTimeout(() => {
+        // Preserve the current URL so user returns to the same page
+        window.location.reload();
+      }, 100);
+      
+      // Re-throw to show error boundary temporarily
+      throw error;
+    }
+    
+    // Wait before retrying
+    await new Promise(resolve => setTimeout(resolve, RETRY_DELAY * attempt));
+    
+    console.log(`[LazyLoad] Retrying import (attempt ${attempt + 1})...`);
+    
+    return retryImport(importFn, attempt + 1);
+  }
+}
+
+/**
+ * Check if we're in a retry loop for a specific import
+ */
+export function isImportFailed(importFn: () => Promise<any>): boolean {
+  return failedImports.has(importFn.toString());
+}
+
+/**
+ * Clear all failed import tracking
+ */
+export function clearFailedImports(): void {
+  failedImports.clear();
+}
+
+export default lazyWithRetry;


### PR DESCRIPTION
## Problem

Fixes #219 

The Dashboard page fails to load with error:
```
TypeError: Failed to fetch dynamically imported module
```

This error occurs when:
1. A new deployment changes chunk hashes
2. Browser cache holds old bundle with stale chunk references
3. Network issues during chunk loading

## Solution

### 1. Add lazyWithRetry utility (`src/client/utils/lazyWithRetry.ts`)
- Wraps React.lazy with automatic retry logic
- Detects chunk loading errors specifically
- Retries up to 3 times before forcing page reload
- Forces reload to get fresh bundle when chunk loading fails

### 2. Update ErrorBoundary (`src/client/components/ErrorBoundary.tsx`)
- Add `isChunkLoadError()` function to detect chunk loading failures
- Auto-reload page when chunk loading error is detected
- Show user-friendly loading message during recovery

### 3. Update App.tsx
- Replace all `React.lazy()` calls with `lazyWithRetry()`
- All lazy-loaded pages now have automatic recovery

## Testing

- Build succeeds locally
- TypeScript compilation passes
- The fix will auto-reload the page when chunk loading fails, ensuring users always get the latest bundle

## Impact

- Users will see a brief loading message then auto-reload instead of error screen
- Reduces support tickets from deployment-related errors
- Improves reliability during deployments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side routing/error recovery to auto-retry dynamic imports and trigger page reloads on chunk load failures, which could affect navigation UX or cause reload loops if mis-detected. Scope is limited to frontend error handling and lazy-loading utilities plus runbook/state metadata updates.
> 
> **Overview**
> Improves resilience to deployment/cache-related chunk loading failures by introducing `lazyWithRetry()` for all route-level dynamic imports, retrying chunk loads and forcing a reload after repeated failures.
> 
> Enhances `ErrorBoundary` to detect chunk/module load errors and automatically reload (or show a user-facing “reload” prompt) instead of surfacing a hard error screen.
> 
> Updates sprint/runbook metadata in `.virtucorp/*` (adds Sprint 10 retrospective + Sprint 11 planning, and advances sprint/state JSON).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2edcd929960dc385561e884dd8bb47b8e7105ca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->