### PR TITLE
fix: P0 - Fix chunk loading error recovery with cache-busting

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from 'react';
+import React, { Suspense, useState, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Layout, Menu, Spin, Drawer, Button } from '@arco-design/web-react';
 import {
@@ -21,7 +21,7 @@ import { ConnectionProvider } from './store/connectionStore';
 import { useRealtimeConnection } from './hooks/useRealtimeConnection';
 import useErrorReporter from './hooks/useErrorReporter';
 import ErrorReporterPanel from './components/ErrorReporterPanel';
-import { lazyWithRetry } from './utils/lazyWithRetry';
+import { lazyWithRetry, getPendingRoute } from './utils/lazyWithRetry';
 
 // Lazy load pages for code splitting with retry logic for chunk loading failures
 const HomePage = lazyWithRetry(() => import('./pages/HomePage'));
@@ -296,6 +296,27 @@ function RealtimeConnectionSync() {
   return null;
 }
 
+// Component to restore pending route after chunk-error reload
+function RouteRestorer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  
+  useEffect(() => {
+    // Check if we need to restore a pending route
+    const pendingRoute = getPendingRoute();
+    if (pendingRoute) {
+      // Remove the cache-busting query parameter if present
+      const cleanPath = pendingRoute.split('?__t=')[0].split('&__t=')[0];
+      if (cleanPath && cleanPath !== location.pathname + location.search + location.hash) {
+        console.log('[RouteRestorer] Restoring pending route:', cleanPath);
+        navigate(cleanPath, { replace: true });
+      }
+    }
+  }, [navigate, location]);
+  
+  return null;
+}
+
 function App() {
   // Enable error reporting with localStorage fallback
   const { errors, clearErrors, hasErrors } = useErrorReporter({
@@ -309,6 +330,7 @@ function App() {
       <ConnectionProvider>
         <RealtimeConnectionSync />
         <BrowserRouter>
+          <RouteRestorer />
           <OfflineIndicator />
           <MainLayout>
             <AppRoutes />

--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -44,6 +44,9 @@ function isThirdPartyDOMError(error: Error | null): boolean {
  * Check if this is a chunk/module loading error
  * These errors occur when the browser fails to load a JavaScript chunk
  * Common causes: deployment updates, cache issues, network problems
+ * 
+ * Note: lazyWithRetry handles chunk errors by forcing an immediate hard reload,
+ * so if we reach here with a chunk error, something unusual happened.
  */
 function isChunkLoadError(error: Error | null): boolean {
   if (!error) return false;
@@ -132,23 +135,18 @@ export class ErrorBoundary extends Component<Props, State> {
       this.props.onError(error, errorInfo);
     }
 
-    // Special handling for third-party DOM errors (e.g., Arco Design removeChild errors)
-    // These are often transient timing issues during component cleanup
-    // Special handling for chunk loading errors (e.g., "Failed to fetch dynamically imported module")
-    // These occur when deployment updates change chunk hashes - reload to get fresh bundle
+    // Special handling for chunk loading errors
+    // These should be rare now since lazyWithRetry handles them earlier
+    // But if they reach here, force an immediate hard reload
     if (isChunkLoadError(error)) {
-      console.warn("[ErrorBoundary] Detected chunk loading error, will auto-reload...");
+      console.warn("[ErrorBoundary] Chunk error reached ErrorBoundary, forcing immediate reload...");
       
-      // Auto-reload after a short delay to get fresh bundle
-      if (!this.isInRetryCycle && this.state.retryCount < 2) {
-        this.isInRetryCycle = true;
-        if (this.retryTimeout) clearTimeout(this.retryTimeout);
-        this.retryTimeout = setTimeout(() => {
-          console.log("[ErrorBoundary] Reloading page to fetch fresh bundle...");
-          window.location.reload();
-        }, 500);
-        return; // Do not show error UI, wait for reload
-      }
+      // Force immediate hard reload with cache-busting
+      const cacheBuster = `__t=${Date.now()}`;
+      const currentUrl = window.location.href;
+      const separator = currentUrl.includes('?') ? '&' : '?';
+      window.location.href = currentUrl + separator + cacheBuster;
+      return;
     }
     
     // Special handling for third-party DOM errors (e.g., Arco Design removeChild errors)
@@ -169,7 +167,7 @@ export class ErrorBoundary extends Component<Props, State> {
           }));
         }, 1000);
         return; // Do not show error UI yet, wait for retry
-    }
+      }
     }
     
     // Store error info for display if not auto-retrying
@@ -189,7 +187,11 @@ export class ErrorBoundary extends Component<Props, State> {
   };
 
   handleReload = () => {
-    window.location.reload();
+    // Force hard reload with cache-busting
+    const cacheBuster = `__t=${Date.now()}`;
+    const currentUrl = window.location.href;
+    const separator = currentUrl.includes('?') ? '&' : '?';
+    window.location.href = currentUrl + separator + cacheBuster;
   };
 
   render() {
@@ -199,12 +201,10 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
 
-      // Check if this is a third-party DOM error (e.g., Arco Design)
-      // Check if this is a chunk loading error (e.g., "Failed to fetch dynamically imported module")
+      // Check for chunk loading error (should be rare now)
       const isChunkError = isChunkLoadError(this.state.error);
 
       // For chunk loading errors, show a reload prompt
-      // These errors require a page reload to get the latest bundle
       if (isChunkError) {
         return (
           <div style={{ 
@@ -232,7 +232,6 @@ export class ErrorBoundary extends Component<Props, State> {
       const isDOMError = isThirdPartyDOMError(this.state.error);
 
       // For third-party DOM errors, show a graceful loading spinner with retry option
-      // These errors are often transient and don't indicate a real application problem
       if (isDOMError) {
         return (
           <div style={{ 

--- a/src/client/utils/lazyWithRetry.ts
+++ b/src/client/utils/lazyWithRetry.ts
@@ -1,25 +1,24 @@
 /**
- * Lazy Loading with Retry Logic
+ * Lazy Loading with Cache-Busting on Chunk Error
  * 
  * Handles "Failed to fetch dynamically imported module" errors that occur when:
  * - A new deployment changes chunk hashes
  * - Browser cache holds old bundle with stale chunk references
  * - Network issues during chunk loading
  * 
- * Solution: Retry the import and if that fails, force a page reload to get the latest bundle.
+ * IMPORTANT: The browser caches both successful AND failed dynamic imports.
+ * Retrying the same import() will return the cached error, not fetch fresh code.
+ * 
+ * Solution: Force immediate hard reload with cache-busting on chunk error.
  */
 
 import React, { ComponentType, LazyExoticComponent } from 'react';
 
-// Track retry attempts to prevent infinite loops
-const RETRY_LIMIT = 3;
-const RETRY_DELAY = 500; // ms
-
-// Store for tracking failed imports
-const failedImports = new Set<string>();
+// Key for storing the intended route before reload
+const PENDING_ROUTE_KEY = '__vite_pending_route__';
 
 /**
- * Wrap a dynamic import with retry logic
+ * Wrap a dynamic import with chunk error handling
  * 
  * Usage:
  *   const MyComponent = lazyWithRetry(() => import('./MyComponent'));
@@ -27,29 +26,22 @@ const failedImports = new Set<string>();
 export function lazyWithRetry<T extends ComponentType<any>>(
   importFn: () => Promise<{ default: T }>
 ): LazyExoticComponent<T> {
-  return React.lazy(() => retryImport(importFn));
+  return React.lazy(() => loadWithRetry(importFn));
 }
 
 /**
- * Retry an import with reload fallback
+ * Load a module with immediate hard reload on chunk error
+ * 
+ * Note: We don't retry the import because the browser caches failed imports.
+ * Retrying the same import() returns the cached error, wasting time.
  */
-async function retryImport<T extends ComponentType<any>>(
-  importFn: () => Promise<{ default: T }>,
-  attempt: number = 1
+async function loadWithRetry<T extends ComponentType<any>>(
+  importFn: () => Promise<{ default: T }>
 ): Promise<{ default: T }> {
   try {
     const module = await importFn();
-    
-    // Clear any previous failure tracking on success
-    const importPath = importFn.toString();
-    failedImports.delete(importPath);
-    
     return module;
   } catch (error) {
-    const importPath = importFn.toString();
-    
-    console.error(`[LazyLoad] Import failed (attempt ${attempt}/${RETRY_LIMIT}):`, error);
-    
     // Check if this is a chunk loading error
     const isChunkError = error instanceof Error && (
       error.message.includes('Failed to fetch dynamically imported module') ||
@@ -59,49 +51,64 @@ async function retryImport<T extends ComponentType<any>>(
     );
     
     if (!isChunkError) {
-      // Not a chunk error, re-throw
+      // Not a chunk error, re-throw normally
       throw error;
     }
     
-    // Check if we've already tried too many times
-    if (attempt >= RETRY_LIMIT) {
-      console.error('[LazyLoad] Max retries reached, forcing page reload...');
-      
-      // Track this import as failed
-      failedImports.add(importPath);
-      
-      // Force reload to get fresh bundle
-      // Use setTimeout to ensure error is logged
-      setTimeout(() => {
-        // Preserve the current URL so user returns to the same page
-        window.location.reload();
-      }, 100);
-      
-      // Re-throw to show error boundary temporarily
-      throw error;
+    console.error('[ChunkError] Chunk loading failed, forcing hard reload...');
+    console.error('[ChunkError] Error:', error);
+    
+    // Store current route for restoration after reload
+    try {
+      const currentPath = window.location.pathname + window.location.search + window.location.hash;
+      sessionStorage.setItem(PENDING_ROUTE_KEY, currentPath);
+    } catch (e) {
+      // Ignore sessionStorage errors
     }
     
-    // Wait before retrying
-    await new Promise(resolve => setTimeout(resolve, RETRY_DELAY * attempt));
+    // Force hard reload with cache-busting
+    // Using location.href with cache-busting query ensures fresh fetch
+    const cacheBuster = `__t=${Date.now()}`;
+    const currentUrl = window.location.href;
+    const separator = currentUrl.includes('?') ? '&' : '?';
     
-    console.log(`[LazyLoad] Retrying import (attempt ${attempt + 1})...`);
+    // Force reload - this will fetch all chunks fresh
+    window.location.href = currentUrl + separator + cacheBuster;
     
-    return retryImport(importFn, attempt + 1);
+    // Return a never-resolving promise while reload happens
+    // This prevents React from showing error UI briefly
+    return new Promise(() => {});
   }
 }
 
 /**
- * Check if we're in a retry loop for a specific import
+ * Check if there's a pending route to restore after reload
+ * Call this on app startup
  */
-export function isImportFailed(importFn: () => Promise<any>): boolean {
-  return failedImports.has(importFn.toString());
+export function getPendingRoute(): string | null {
+  try {
+    const route = sessionStorage.getItem(PENDING_ROUTE_KEY);
+    if (route) {
+      sessionStorage.removeItem(PENDING_ROUTE_KEY);
+    }
+    return route;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * Clear all failed import tracking
+ * Restore pending route if available
+ * Call this in the app's root component after router is ready
  */
-export function clearFailedImports(): void {
-  failedImports.clear();
+export function restorePendingRoute(): void {
+  const pendingRoute = getPendingRoute();
+  if (pendingRoute && pendingRoute !== window.location.pathname + window.location.search + window.location.hash) {
+    // Use history.replaceState to avoid adding to history stack
+    window.history.replaceState(null, '', pendingRoute);
+    // Trigger a popstate event so the router picks up the change
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
 }
 
 export default lazyWithRetry;


### PR DESCRIPTION
## Problem

The previous fix in PR #220 was ineffective because:
1. Browser caches failed dynamic imports
2. Retrying `import()` returns the same cached error
3. Simple `window.reload()` may serve cached chunks

## Root Cause Analysis

When `import()` fails with a chunk loading error, the browser caches that failure. Calling `import()` again with the same module path returns the same cached error immediately - no network request is made.

The retry loop in the original fix was wasting time by returning cached errors 3 times before reloading.

## Solution

### lazyWithRetry.ts
- **Remove ineffective retry loop** - browser caches failed imports, so retries don't work
- **Force immediate hard reload with cache-busting** - add `?__t=<timestamp>` to force fresh fetch
- **Store intended route in sessionStorage** - restore navigation after reload
- Add `getPendingRoute()` utility for route restoration

### ErrorBoundary.tsx
- Simplify chunk error handling (immediate hard reload)
- Add cache-busting to manual reload button
- Remove redundant retry logic (lazyWithRetry handles it now)

### App.tsx
- Add `RouteRestorer` component to restore pending route after reload

## Testing

- Build succeeds locally
- TypeScript compilation passes
- The fix now forces an immediate hard reload with cache-busting, ensuring fresh chunks are fetched

## Impact

- Users will see a brief flash during reload instead of error screen
- No wasted time on ineffective retries
- Navigation is restored after reload

Fixes #219

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the app’s chunk-error recovery and reload behavior, which can impact navigation flow and potentially cause unexpected reload loops if edge cases aren’t handled. Scope is limited to client-side lazy loading, error boundary handling, and route restoration.
> 
> **Overview**
> **Chunk-load recovery is reworked to avoid cached `import()` failures.** `lazyWithRetry` now skips retry loops and instead records the current route in `sessionStorage`, triggers an immediate hard reload with a `__t` cache-busting query param, and returns a never-resolving promise to prevent flashing error UI.
> 
> **Navigation is restored after reload and ErrorBoundary reloads are hardened.** `App` adds a `RouteRestorer` that reads the pending route and navigates back (stripping `__t`), while `ErrorBoundary` simplifies chunk-error handling and uses the same cache-busted hard reload for both auto-recovery and the manual reload button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a933c484e9bd3286132956adfa956230fc58042f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->