### PR TITLE
feat: 多交易所支持框架 (Multi-Exchange Support Framework)

### DIFF
--- a/src/exchange/BaseExchangeAdapter.ts
+++ b/src/exchange/BaseExchangeAdapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Base Exchange Adapter - Abstract base class for exchange implementations
+ */
+import { EventEmitter } from 'events';
+import {
+  IExchangeAdapter, ExchangeConfig, Balance, Ticker, OrderBook,
+  OrderParams, OrderResult, Order, TradeCallback, TickerCallback,
+  OrderBookCallback, ConnectionStatus, ExchangeError, ExchangeErrorType,
+  ExchangeCapabilities, TimeInForce,
+} from './types';
+
+export abstract class BaseExchangeAdapter extends EventEmitter implements IExchangeAdapter {
+  abstract readonly name: string;
+  abstract readonly exchangeId: string;
+  protected _status: ConnectionStatus = ConnectionStatus.DISCONNECTED;
+  protected _config: ExchangeConfig | null = null;
+  protected _reconnectAttempts: number = 0;
+  protected _maxReconnectAttempts: number = 5;
+  protected _reconnectDelay: number = 1000;
+
+  get status(): ConnectionStatus { return this._status; }
+
+  getCapabilities(): ExchangeCapabilities {
+    return {
+      spot: true, margin: false, futures: false, websocket: true, rest: true,
+      maxOrderBookDepth: 100,
+      supportedTimeInForce: [TimeInForce.GOOD_TILL_CANCEL, TimeInForce.IMMEDIATE_OR_CANCEL, TimeInForce.FILL_OR_KILL],
+      stopLoss: false, takeProfit: false, rateLimit: 20,
+    };
+  }
+
+  abstract connect(config: ExchangeConfig): Promise<void>;
+  abstract disconnect(): Promise<void>;
+  abstract getBalance(): Promise<Balance>;
+  abstract getTicker(symbol: string): Promise<Ticker>;
+  abstract getOrderBook(symbol: string, depth?: number): Promise<OrderBook>;
+  abstract placeOrder(order: OrderParams): Promise<OrderResult>;
+  abstract cancelOrder(orderId: string, symbol?: string): Promise<void>;
+  abstract getOpenOrders(symbol?: string): Promise<Order[]>;
+  abstract getOrderHistory(symbol?: string, limit?: number): Promise<Order[]>;
+  abstract subscribeToTrades(symbol: string, callback: TradeCallback): void;
+  abstract unsubscribeFromTrades(symbol: string): void;
+
+  protected setStatus(status: ConnectionStatus): void {
+    const previousStatus = this._status;
+    this._status = status;
+    if (previousStatus !== status) {
+      this.emit('statusChange', { previousStatus, status, timestamp: Date.now() });
+    }
+  }
+
+  protected validateConfig(config: ExchangeConfig): void {
+    if (!config.exchangeId) {
+      throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, 'Exchange ID is required', this.exchangeId);
+    }
+    if (!config.apiKey || !config.apiSecret) {
+      throw new ExchangeError(ExchangeErrorType.AUTHENTICATION_ERROR, 'API key and secret are required', this.exchangeId);
+    }
+  }
+
+  protected generateOrderId(): string {
+    return `${this.exchangeId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  protected generateTradeId(): string {
+    return `${this.exchangeId}-trade-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  protected sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  supportsFeature(feature: string): boolean {
+    const capabilities = this.getCapabilities();
+    return feature in capabilities && (capabilities as any)[feature] === true;
+  }
+
+  protected normalizeSymbol(symbol: string): string {
+    return symbol.toUpperCase().replace(/[-_]/g, '');
+  }
+
+  protected toExchangeSymbol(symbol: string): string {
+    return this.normalizeSymbol(symbol);
+  }
+
+  protected fromExchangeSymbol(exchangeSymbol: string): string {
+    return exchangeSymbol;
+  }
+}

--- a/src/exchange/BinanceAdapter.ts
+++ b/src/exchange/BinanceAdapter.ts
@@ -1,0 +1,213 @@
+/**
+ * Binance Exchange Adapter
+ */
+import { BaseExchangeAdapter } from './BaseExchangeAdapter';
+import {
+  ExchangeConfig, Balance, BalanceItem, Ticker, OrderBook, OrderParams,
+  OrderResult, Order, OrderSide, OrderType, OrderStatus, Trade, TradeCallback,
+  TickerCallback, OrderBookCallback, ConnectionStatus, ExchangeError,
+  ExchangeErrorType, ExchangeCapabilities, TimeInForce,
+} from './types';
+
+const BINANCE_REST_URL = 'https://api.binance.com';
+const BINANCE_WS_URL = 'wss://stream.binance.com:9443/ws';
+
+interface BinanceBalance { a: string; f: string; l: string; }
+interface BinanceTicker { s: string; c: string; b: string; a: string; h: string; l: string; v: string; q: string; P: string; E: number; }
+interface BinanceOrderBook { lastUpdateId: number; bids: [string, string][]; asks: [string, string][]; }
+interface BinanceOrder { orderId: number; clientOrderId?: string; symbol: string; side: 'BUY' | 'SELL'; type: string; status: string; origQty: string; executedQty: string; cummulativeQuoteQty: string; price: string; time: number; updateTime: number; }
+
+type RequestMethod = 'GET' | 'POST' | 'DELETE' | 'PUT';
+
+export class BinanceAdapter extends BaseExchangeAdapter {
+  readonly name = 'Binance';
+  readonly exchangeId = 'binance';
+  private _baseUrl: string = BINANCE_REST_URL;
+  private _wsUrl: string = BINANCE_WS_URL;
+  private _ws: WebSocket | null = null;
+  private _tradeSubscriptions: Map<string, Set<TradeCallback>> = new Map();
+  private _tickerSubscriptions: Map<string, Set<TickerCallback>> = new Map();
+  private _orderBookSubscriptions: Map<string, Set<OrderBookCallback>> = new Map();
+
+  getCapabilities(): ExchangeCapabilities {
+    return {
+      spot: true, margin: true, futures: false, websocket: true, rest: true,
+      maxOrderBookDepth: 5000,
+      supportedTimeInForce: [TimeInForce.GOOD_TILL_CANCEL, TimeInForce.IMMEDIATE_OR_CANCEL, TimeInForce.FILL_OR_KILL],
+      stopLoss: true, takeProfit: true, rateLimit: 50,
+    };
+  }
+
+  async connect(config: ExchangeConfig): Promise<void> {
+    this.validateConfig(config);
+    this._config = config;
+    this.setStatus(ConnectionStatus.CONNECTING);
+    if (config.testnet) {
+      this._baseUrl = 'https://testnet.binance.vision';
+      this._wsUrl = 'wss://testnet.binance.vision/ws';
+    }
+    try {
+      const time = await this.request<{ serverTime: number }>('/api/v3/time');
+      this.setStatus(ConnectionStatus.CONNECTED);
+      this.emit('connected', { timestamp: time.serverTime });
+    } catch (error) {
+      throw new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, (error as Error).message, this.exchangeId, error as Error);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this._ws) { this._ws.close(); this._ws = null; }
+    this._tradeSubscriptions.clear();
+    this._tickerSubscriptions.clear();
+    this._orderBookSubscriptions.clear();
+    this._config = null;
+    this.setStatus(ConnectionStatus.DISCONNECTED);
+    this.emit('disconnected', { timestamp: Date.now() });
+  }
+
+  async getBalance(): Promise<Balance> {
+    this.ensureConnected();
+    const result = await this.signedRequest<{ balances: BinanceBalance[]; updateTime: number }>('/api/v3/account');
+    return {
+      timestamp: result.updateTime,
+      assets: result.balances.filter(b => parseFloat(b.f) > 0 || parseFloat(b.l) > 0).map(b => ({
+        asset: b.a, total: parseFloat(b.f) + parseFloat(b.l), available: parseFloat(b.f), locked: parseFloat(b.l),
+      })),
+    };
+  }
+
+  async getTicker(symbol: string): Promise<Ticker> {
+    this.ensureConnected();
+    const r = await this.request<BinanceTicker>('/api/v3/ticker/24hr', 'GET', { symbol: this.toExchangeSymbol(symbol) });
+    return { symbol: this.fromExchangeSymbol(r.s), last: parseFloat(r.c), bid: parseFloat(r.b), ask: parseFloat(r.a), high: parseFloat(r.h), low: parseFloat(r.l), volume: parseFloat(r.v), quoteVolume: parseFloat(r.q), changePercent: parseFloat(r.P), timestamp: r.E };
+  }
+
+  async getOrderBook(symbol: string, depth: number = 20): Promise<OrderBook> {
+    this.ensureConnected();
+    const r = await this.request<BinanceOrderBook>('/api/v3/depth', 'GET', { symbol: this.toExchangeSymbol(symbol), limit: depth });
+    return { symbol, bids: r.bids.map(([p, q]) => ({ price: parseFloat(p), quantity: parseFloat(q) })), asks: r.asks.map(([p, q]) => ({ price: parseFloat(p), quantity: parseFloat(q) })), timestamp: Date.now(), sequence: r.lastUpdateId };
+  }
+
+  async placeOrder(order: OrderParams): Promise<OrderResult> {
+    this.ensureConnected();
+    const params: Record<string, string | number> = { symbol: this.toExchangeSymbol(order.symbol), side: order.side === OrderSide.BUY ? 'BUY' : 'SELL', type: this.toBinanceOrderType(order.type), quantity: order.quantity };
+    if (order.price) params.price = order.price;
+    if (order.timeInForce) params.timeInForce = order.timeInForce;
+    const r = await this.signedRequest<BinanceOrder>('/api/v3/order', 'POST', params);
+    return this.parseOrderResult(r);
+  }
+
+  async cancelOrder(orderId: string, symbol?: string): Promise<void> {
+    this.ensureConnected();
+    if (!symbol) throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, 'Symbol is required for Binance order cancellation', this.exchangeId);
+    await this.signedRequest('/api/v3/order', 'DELETE', { symbol: this.toExchangeSymbol(symbol), orderId });
+  }
+
+  async getOpenOrders(symbol?: string): Promise<Order[]> {
+    this.ensureConnected();
+    const params: Record<string, string> = {};
+    if (symbol) params.symbol = this.toExchangeSymbol(symbol);
+    const r = await this.signedRequest<BinanceOrder[]>('/api/v3/openOrders', 'GET', params);
+    return r.map(o => this.parseOrder(o));
+  }
+
+  async getOrderHistory(symbol?: string, limit: number = 500): Promise<Order[]> {
+    this.ensureConnected();
+    const params: Record<string, string | number> = { limit };
+    if (symbol) params.symbol = this.toExchangeSymbol(symbol);
+    const r = await this.signedRequest<BinanceOrder[]>('/api/v3/allOrders', 'GET', params);
+    return r.map(o => this.parseOrder(o));
+  }
+
+  subscribeToTrades(symbol: string, callback: TradeCallback): void {
+    if (!this._tradeSubscriptions.has(symbol)) this._tradeSubscriptions.set(symbol, new Set());
+    this._tradeSubscriptions.get(symbol)!.add(callback);
+    this.updateWebSocketSubscriptions();
+  }
+
+  unsubscribeFromTrades(symbol: string): void { this._tradeSubscriptions.delete(symbol); this.updateWebSocketSubscriptions(); }
+  subscribeToTicker(symbol: string, callback: TickerCallback): void {
+    if (!this._tickerSubscriptions.has(symbol)) this._tickerSubscriptions.set(symbol, new Set());
+    this._tickerSubscriptions.get(symbol)!.add(callback);
+    this.updateWebSocketSubscriptions();
+  }
+  unsubscribeFromTicker(symbol: string): void { this._tickerSubscriptions.delete(symbol); this.updateWebSocketSubscriptions(); }
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback): void {
+    if (!this._orderBookSubscriptions.has(symbol)) this._orderBookSubscriptions.set(symbol, new Set());
+    this._orderBookSubscriptions.get(symbol)!.add(callback);
+    this.updateWebSocketSubscriptions();
+  }
+  unsubscribeFromOrderBook(symbol: string): void { this._orderBookSubscriptions.delete(symbol); this.updateWebSocketSubscriptions(); }
+
+  private ensureConnected(): void {
+    if (this._status !== ConnectionStatus.CONNECTED) throw new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, 'Not connected to Binance', this.exchangeId);
+  }
+
+  protected toExchangeSymbol(symbol: string): string { return symbol.toUpperCase().replace(/[-_/]/g, ''); }
+  protected fromExchangeSymbol(s: string): string { const m = s.match(/^(.+)(USDT?)$/); return m ? `${m[1]}/${m[2]}` : s; }
+
+  private toBinanceOrderType(type: OrderType): string {
+    const map: Record<OrderType, string> = { [OrderType.MARKET]: 'MARKET', [OrderType.LIMIT]: 'LIMIT', [OrderType.STOP_LOSS]: 'STOP_LOSS', [OrderType.STOP_LOSS_LIMIT]: 'STOP_LOSS_LIMIT', [OrderType.TAKE_PROFIT]: 'TAKE_PROFIT', [OrderType.TAKE_PROFIT_LIMIT]: 'TAKE_PROFIT_LIMIT' };
+    return map[type] || 'LIMIT';
+  }
+
+  private parseOrderStatus(s: string): OrderStatus { return { NEW: OrderStatus.NEW, PARTIALLY_FILLED: OrderStatus.PARTIALLY_FILLED, FILLED: OrderStatus.FILLED, CANCELED: OrderStatus.CANCELED, REJECTED: OrderStatus.REJECTED, EXPIRED: OrderStatus.EXPIRED }[s] || OrderStatus.NEW; }
+
+  private parseOrder(o: BinanceOrder): Order { return { orderId: String(o.orderId), clientOrderId: o.clientOrderId, symbol: this.fromExchangeSymbol(o.symbol), side: o.side === 'BUY' ? OrderSide.BUY : OrderSide.SELL, type: OrderType[o.type as keyof typeof OrderType] || OrderType.LIMIT, status: this.parseOrderStatus(o.status), quantity: parseFloat(o.origQty), filledQuantity: parseFloat(o.executedQty), avgPrice: parseFloat(o.cummulativeQuoteQty) / parseFloat(o.executedQty) || 0, price: o.price ? parseFloat(o.price) : undefined, timeInForce: (o as any).timeInForce as TimeInForce, remainingQuantity: parseFloat(o.origQty) - parseFloat(o.executedQty), fee: 0, feeCurrency: '', createdAt: o.time, updatedAt: o.updateTime }; }
+  private parseOrderResult(o: BinanceOrder): OrderResult { return { orderId: String(o.orderId), clientOrderId: o.clientOrderId, symbol: this.fromExchangeSymbol(o.symbol), side: o.side === 'BUY' ? OrderSide.BUY : OrderSide.SELL, type: OrderType[o.type as keyof typeof OrderType] || OrderType.LIMIT, status: this.parseOrderStatus(o.status), quantity: parseFloat(o.origQty), filledQuantity: parseFloat(o.executedQty), avgPrice: parseFloat(o.cummulativeQuoteQty) / parseFloat(o.executedQty) || 0, fee: 0, feeCurrency: '', createdAt: o.time, updatedAt: o.updateTime }; }
+
+  private async request<T>(endpoint: string, method: RequestMethod = 'GET', params: Record<string, string | number> = {}): Promise<T> {
+    const url = new URL(`${this._baseUrl}${endpoint}`);
+    if (method === 'GET') Object.entries(params).forEach(([k, v]) => url.searchParams.append(k, String(v)));
+    const r = await fetch(url.toString(), { method, headers: { 'Content-Type': 'application/json' } });
+    if (!r.ok) { const e = await r.json().catch(() => ({ msg: 'Unknown error' })); throw new ExchangeError(ExchangeErrorType.UNKNOWN, e.msg || `HTTP ${r.status}`, this.exchangeId); }
+    return r.json();
+  }
+
+  private async signedRequest<T>(endpoint: string, method: RequestMethod = 'GET', params: Record<string, string | number> = {}): Promise<T> {
+    if (!this._config) throw new ExchangeError(ExchangeErrorType.AUTHENTICATION_ERROR, 'Not configured', this.exchangeId);
+    params.timestamp = Date.now();
+    const qs = Object.entries(params).map(([k, v]) => `${k}=${v}`).join('&');
+    const sig = await this.hmacSha256(qs, this._config.apiSecret);
+    const url = new URL(`${this._baseUrl}${endpoint}`);
+    url.search = `${qs}&signature=${sig}`;
+    const r = await fetch(url.toString(), { method, headers: { 'Content-Type': 'application/json', 'X-MBX-APIKEY': this._config.apiKey } });
+    if (!r.ok) { const e = await r.json().catch(() => ({ msg: 'Unknown error' })); throw new ExchangeError(ExchangeErrorType.UNKNOWN, e.msg || `HTTP ${r.status}`, this.exchangeId); }
+    return r.json();
+  }
+
+  private async hmacSha256(msg: string, secret: string): Promise<string> {
+    const enc = new TextEncoder();
+    const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const sig = await crypto.subtle.sign('HMAC', key, enc.encode(msg));
+    return Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  private updateWebSocketSubscriptions(): void {
+    const streams: string[] = [];
+    for (const s of Array.from(this._tradeSubscriptions.keys())) streams.push(`${s.toLowerCase()}@trade`);
+    for (const s of Array.from(this._tickerSubscriptions.keys())) streams.push(`${s.toLowerCase()}@ticker`);
+    for (const s of Array.from(this._orderBookSubscriptions.keys())) streams.push(`${s.toLowerCase()}@depth`);
+    if (streams.length > 0) this.connectWebSocket(streams);
+    else if (this._ws) { this._ws.close(); this._ws = null; }
+  }
+
+  private connectWebSocket(streams: string[]): void {
+    if (this._ws) this._ws.close();
+    this._ws = new WebSocket(`${this._wsUrl}/${streams.join('/')}`);
+    this._ws.onopen = () => this.emit('websocketConnected', { timestamp: Date.now() });
+    this._ws.onmessage = (e) => { try { this.handleWebSocketMessage(JSON.parse(e.data)); } catch (err) { this.emit('error', err); } };
+    this._ws.onerror = () => this.emit('error', new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, 'WebSocket error', this.exchangeId));
+    this._ws.onclose = () => this.emit('websocketDisconnected', { timestamp: Date.now() });
+  }
+
+  private handleWebSocketMessage(data: any): void {
+    if (data.e === 'trade') {
+      const t: Trade = { id: String(data.t), orderId: String(data.t), symbol: this.fromExchangeSymbol(data.s), side: data.m ? OrderSide.SELL : OrderSide.BUY, price: parseFloat(data.p), quantity: parseFloat(data.q), fee: 0, feeCurrency: '', timestamp: data.T, isMaker: data.m };
+      const cbs = this._tradeSubscriptions.get(t.symbol); if (cbs) Array.from(cbs).forEach(cb => cb(t));
+    } else if (data.e === '24hrTicker') {
+      const t: Ticker = { symbol: this.fromExchangeSymbol(data.s), last: parseFloat(data.c), bid: parseFloat(data.b), ask: parseFloat(data.a), high: parseFloat(data.h), low: parseFloat(data.l), volume: parseFloat(data.v), quoteVolume: parseFloat(data.q), changePercent: parseFloat(data.P), timestamp: data.E };
+      const cbs = this._tickerSubscriptions.get(t.symbol); if (cbs) Array.from(cbs).forEach(cb => cb(t));
+    }
+  }
+}

--- a/src/exchange/ExchangeManager.ts
+++ b/src/exchange/ExchangeManager.ts
@@ -1,0 +1,136 @@
+/**
+ * Exchange Manager - Manages multiple exchange connections
+ */
+import { EventEmitter } from 'events';
+import {
+  IExchangeAdapter, ExchangeConfig, Balance, Ticker, OrderBook,
+  OrderParams, OrderResult, Order, TradeCallback, TickerCallback,
+  OrderBookCallback, ConnectionStatus, ExchangeError, ExchangeErrorType,
+} from './types';
+import { MockExchangeAdapter } from './MockExchangeAdapter';
+import { BinanceAdapter } from './BinanceAdapter';
+
+export interface ExchangeManagerConfig {
+  defaultExchange?: string;
+  autoReconnect?: boolean;
+  maxReconnectAttempts?: number;
+}
+
+interface ExchangeInfo {
+  adapter: IExchangeAdapter;
+  config: ExchangeConfig;
+  isActive: boolean;
+}
+
+export class ExchangeManager extends EventEmitter {
+  private _exchanges: Map<string, ExchangeInfo> = new Map();
+  private _activeExchange: string | null = null;
+  private _config: ExchangeManagerConfig;
+
+  constructor(config: ExchangeManagerConfig = {}) {
+    super();
+    this._config = { defaultExchange: config.defaultExchange ?? 'mock', autoReconnect: config.autoReconnect ?? true, maxReconnectAttempts: config.maxReconnectAttempts ?? 5 };
+  }
+
+  get activeExchangeId(): string | null { return this._activeExchange; }
+  get registeredExchanges(): string[] { return Array.from(this._exchanges.keys()); }
+  get connectedExchanges(): string[] { return Array.from(this._exchanges.entries()).filter(([, i]) => i.adapter.status === ConnectionStatus.CONNECTED).map(([id]) => id); }
+
+  registerExchange(adapter: IExchangeAdapter): void {
+    if (this._exchanges.has(adapter.exchangeId)) throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, `Exchange already registered: ${adapter.exchangeId}`);
+    this._exchanges.set(adapter.exchangeId, { adapter, config: {} as ExchangeConfig, isActive: false });
+    if (adapter instanceof EventEmitter) {
+      adapter.on('statusChange', (data: any) => this.emit('exchangeStatusChange', { exchangeId: adapter.exchangeId, ...data }));
+      adapter.on('error', (error: Error) => this.emit('exchangeError', { exchangeId: adapter.exchangeId, error }));
+    }
+  }
+
+  async unregisterExchange(exchangeId: string): Promise<void> {
+    const info = this._exchanges.get(exchangeId);
+    if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Exchange not found: ${exchangeId}`);
+    if (info.adapter.status === ConnectionStatus.CONNECTED) await info.adapter.disconnect();
+    this._exchanges.delete(exchangeId);
+    if (this._activeExchange === exchangeId) this._activeExchange = Array.from(this._exchanges.keys())[0] ?? null;
+  }
+
+  async connect(exchangeId: string, config: ExchangeConfig): Promise<void> {
+    let info = this._exchanges.get(exchangeId);
+    if (!info) {
+      const adapter = this.createBuiltInAdapter(exchangeId);
+      if (adapter) { this.registerExchange(adapter); info = this._exchanges.get(exchangeId); }
+      else throw new ExchangeError(ExchangeErrorType.MARKET_NOT_FOUND, `Exchange not found: ${exchangeId}`);
+    }
+    info!.config = config;
+    await info!.adapter.connect(config);
+    if (!this._activeExchange) this._activeExchange = exchangeId;
+    this.emit('exchangeConnected', { exchangeId, timestamp: Date.now() });
+  }
+
+  async disconnect(exchangeId?: string): Promise<void> {
+    if (exchangeId) {
+      const info = this._exchanges.get(exchangeId);
+      if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Exchange not found: ${exchangeId}`);
+      await info.adapter.disconnect();
+      this.emit('exchangeDisconnected', { exchangeId, timestamp: Date.now() });
+    } else {
+      for (const [id, info] of Array.from(this._exchanges)) {
+        if (info.adapter.status === ConnectionStatus.CONNECTED) {
+          await info.adapter.disconnect();
+          this.emit('exchangeDisconnected', { exchangeId: id, timestamp: Date.now() });
+        }
+      }
+      this._activeExchange = null;
+    }
+  }
+
+  setActiveExchange(exchangeId: string): void {
+    const info = this._exchanges.get(exchangeId);
+    if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Exchange not found: ${exchangeId}`);
+    if (info.adapter.status !== ConnectionStatus.CONNECTED) throw new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, `Exchange not connected: ${exchangeId}`);
+    this._activeExchange = exchangeId;
+    this.emit('activeExchangeChanged', { exchangeId, timestamp: Date.now() });
+  }
+
+  getActiveExchange(): IExchangeAdapter {
+    if (!this._activeExchange) throw new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, 'No active exchange set');
+    const info = this._exchanges.get(this._activeExchange);
+    if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Active exchange not found: ${this._activeExchange}`);
+    return info.adapter;
+  }
+
+  getExchange(exchangeId: string): IExchangeAdapter {
+    const info = this._exchanges.get(exchangeId);
+    if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Exchange not found: ${exchangeId}`);
+    return info.adapter;
+  }
+
+  async getBalance(exchangeId?: string): Promise<Balance> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).getBalance(); }
+  async getTicker(symbol: string, exchangeId?: string): Promise<Ticker> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).getTicker(symbol); }
+  async getOrderBook(symbol: string, depth?: number, exchangeId?: string): Promise<OrderBook> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).getOrderBook(symbol, depth); }
+  async placeOrder(order: OrderParams, exchangeId?: string): Promise<OrderResult> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).placeOrder(order); }
+  async cancelOrder(orderId: string, symbol?: string, exchangeId?: string): Promise<void> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).cancelOrder(orderId, symbol); }
+  async getOpenOrders(symbol?: string, exchangeId?: string): Promise<Order[]> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).getOpenOrders(symbol); }
+  async getOrderHistory(symbol?: string, limit?: number, exchangeId?: string): Promise<Order[]> { return (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).getOrderHistory(symbol, limit); }
+
+  subscribeToTrades(symbol: string, callback: TradeCallback, exchangeId?: string): void { (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).subscribeToTrades(symbol, callback); }
+  unsubscribeFromTrades(symbol: string, exchangeId?: string): void { (exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange()).unsubscribeFromTrades(symbol); }
+  subscribeToTicker(symbol: string, callback: TickerCallback, exchangeId?: string): void { const a = exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange(); if (a.subscribeToTicker) a.subscribeToTicker(symbol, callback); }
+  unsubscribeFromTicker(symbol: string, exchangeId?: string): void { const a = exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange(); if (a.unsubscribeFromTicker) a.unsubscribeFromTicker(symbol); }
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback, exchangeId?: string): void { const a = exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange(); if (a.subscribeToOrderBook) a.subscribeToOrderBook(symbol, callback); }
+  unsubscribeFromOrderBook(symbol: string, exchangeId?: string): void { const a = exchangeId ? this.getExchange(exchangeId) : this.getActiveExchange(); if (a.unsubscribeFromOrderBook) a.unsubscribeFromOrderBook(symbol); }
+
+  getExchangeStatus(exchangeId: string): ConnectionStatus { const info = this._exchanges.get(exchangeId); if (!info) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Exchange not found: ${exchangeId}`); return info.adapter.status; }
+  isExchangeConnected(exchangeId: string): boolean { return this.getExchangeStatus(exchangeId) === ConnectionStatus.CONNECTED; }
+
+  private createBuiltInAdapter(exchangeId: string): IExchangeAdapter | null {
+    switch (exchangeId.toLowerCase()) {
+      case 'mock': return new MockExchangeAdapter();
+      case 'binance': return new BinanceAdapter();
+      default: return null;
+    }
+  }
+}
+
+let _instance: ExchangeManager | null = null;
+export function getExchangeManager(): ExchangeManager { if (!_instance) _instance = new ExchangeManager(); return _instance; }
+export function resetExchangeManager(): void { if (_instance) { _instance.disconnect().catch(() => {}); _instance = null; } }

--- a/src/exchange/MockExchangeAdapter.ts
+++ b/src/exchange/MockExchangeAdapter.ts
@@ -1,0 +1,308 @@
+/**
+ * Mock Exchange Adapter - For testing and simulation
+ */
+import { BaseExchangeAdapter } from './BaseExchangeAdapter';
+import {
+  ExchangeConfig, Balance, BalanceItem, Ticker, OrderBook, OrderBookLevel,
+  OrderParams, OrderResult, Order, OrderSide, OrderType, OrderStatus,
+  Trade, TradeCallback, TickerCallback, OrderBookCallback,
+  ConnectionStatus, ExchangeError, ExchangeErrorType, ExchangeCapabilities, TimeInForce,
+} from './types';
+
+interface MockMarket {
+  symbol: string;
+  basePrice: number;
+  volatility: number;
+  tickSize: number;
+}
+
+interface MockOrder extends Order {
+  filledAt?: number[];
+}
+
+export class MockExchangeAdapter extends BaseExchangeAdapter {
+  readonly name = 'Mock Exchange';
+  readonly exchangeId = 'mock';
+  private _balances: Map<string, BalanceItem> = new Map();
+  private _orders: Map<string, MockOrder> = new Map();
+  private _markets: Map<string, MockMarket> = new Map();
+  private _tradeSubscriptions: Map<string, Set<TradeCallback>> = new Map();
+  private _tickerSubscriptions: Map<string, Set<TickerCallback>> = new Map();
+  private _orderBookSubscriptions: Map<string, Set<OrderBookCallback>> = new Map();
+  private _tickerIntervals: Map<string, NodeJS.Timeout> = new Map();
+  private _orderBookIntervals: Map<string, NodeJS.Timeout> = new Map();
+  private _orderIdCounter: number = 1;
+
+  constructor() {
+    super();
+    this.initializeDefaultMarkets();
+    this.initializeDefaultBalances();
+  }
+
+  private initializeDefaultMarkets(): void {
+    const markets: MockMarket[] = [
+      { symbol: 'BTCUSDT', basePrice: 50000, volatility: 0.02, tickSize: 1 },
+      { symbol: 'ETHUSDT', basePrice: 3000, volatility: 0.03, tickSize: 0.01 },
+      { symbol: 'BNBUSDT', basePrice: 400, volatility: 0.025, tickSize: 0.01 },
+    ];
+    markets.forEach(m => this._markets.set(m.symbol, m));
+  }
+
+  private initializeDefaultBalances(): void {
+    const balances: BalanceItem[] = [
+      { asset: 'USDT', total: 100000, available: 100000, locked: 0 },
+      { asset: 'BTC', total: 1.0, available: 1.0, locked: 0 },
+      { asset: 'ETH', total: 10.0, available: 10.0, locked: 0 },
+      { asset: 'BNB', total: 50.0, available: 50.0, locked: 0 },
+    ];
+    balances.forEach(b => this._balances.set(b.asset, b));
+  }
+
+  getCapabilities(): ExchangeCapabilities {
+    return {
+      spot: true, margin: true, futures: false, websocket: true, rest: true,
+      maxOrderBookDepth: 1000,
+      supportedTimeInForce: [TimeInForce.GOOD_TILL_CANCEL, TimeInForce.IMMEDIATE_OR_CANCEL, TimeInForce.FILL_OR_KILL, TimeInForce.GOOD_TILL_DATE],
+      stopLoss: true, takeProfit: true, rateLimit: 1000,
+    };
+  }
+
+  async connect(config: ExchangeConfig): Promise<void> {
+    this.validateConfig(config);
+    this._config = config;
+    this.setStatus(ConnectionStatus.CONNECTING);
+    await this.sleep(100);
+    this.setStatus(ConnectionStatus.CONNECTED);
+    this.emit('connected', { timestamp: Date.now() });
+  }
+
+  async disconnect(): Promise<void> {
+    for (const interval of Array.from(this._tickerIntervals.values())) clearInterval(interval);
+    for (const interval of Array.from(this._orderBookIntervals.values())) clearInterval(interval);
+    this._tickerIntervals.clear();
+    this._orderBookIntervals.clear();
+    this._tradeSubscriptions.clear();
+    this._tickerSubscriptions.clear();
+    this._orderBookSubscriptions.clear();
+    this._config = null;
+    this.setStatus(ConnectionStatus.DISCONNECTED);
+    this.emit('disconnected', { timestamp: Date.now() });
+  }
+
+  async getBalance(): Promise<Balance> {
+    this.ensureConnected();
+    const assets = Array.from(this._balances.values());
+    return { timestamp: Date.now(), assets };
+  }
+
+  async getTicker(symbol: string): Promise<Ticker> {
+    this.ensureConnected();
+    const market = this.getMarket(symbol);
+    const price = this.simulatePrice(market);
+    return {
+      symbol, last: price, bid: price * 0.9999, ask: price * 1.0001,
+      high: price * 1.02, low: price * 0.98, volume: Math.random() * 1000000,
+      quoteVolume: Math.random() * 1000000000, changePercent: (Math.random() - 0.5) * 10,
+      timestamp: Date.now(),
+    };
+  }
+
+  async getOrderBook(symbol: string, depth: number = 20): Promise<OrderBook> {
+    this.ensureConnected();
+    const market = this.getMarket(symbol);
+    const price = this.simulatePrice(market);
+    const bids: OrderBookLevel[] = [];
+    const asks: OrderBookLevel[] = [];
+    for (let i = 0; i < depth; i++) {
+      bids.push({ price: price * (1 - (i + 1) * 0.0001), quantity: Math.random() * 10 });
+      asks.push({ price: price * (1 + (i + 1) * 0.0001), quantity: Math.random() * 10 });
+    }
+    return { symbol, bids, asks, timestamp: Date.now(), sequence: Date.now() };
+  }
+
+  async placeOrder(order: OrderParams): Promise<OrderResult> {
+    this.ensureConnected();
+    this.validateOrderParams(order);
+    const market = this.getMarket(order.symbol);
+    const orderId = `mock-${this._orderIdCounter++}`;
+    const now = Date.now();
+    const isMarketOrder = order.type === OrderType.MARKET;
+    const fillPrice = order.price ?? this.simulatePrice(market);
+    const fillQuantity = isMarketOrder ? order.quantity : 0;
+
+    const mockOrder: MockOrder = {
+      orderId, clientOrderId: order.clientOrderId, symbol: order.symbol,
+      side: order.side, type: order.type, status: isMarketOrder ? OrderStatus.FILLED : OrderStatus.NEW,
+      quantity: order.quantity, filledQuantity: fillQuantity, avgPrice: isMarketOrder ? fillPrice : 0,
+      price: order.price, timeInForce: order.timeInForce,
+      fee: fillQuantity * fillPrice * 0.001, feeCurrency: order.symbol.replace(/USDT?$/, ''),
+      remainingQuantity: isMarketOrder ? 0 : order.quantity,
+      createdAt: now, updatedAt: now,
+    };
+
+    this._orders.set(orderId, mockOrder);
+    this.updateBalanceForOrder(order, fillQuantity, fillPrice);
+
+    if (!isMarketOrder && Math.random() > 0.5) {
+      setTimeout(() => this.simulateFill(orderId), 1000 + Math.random() * 5000);
+    }
+
+    return { ...mockOrder };
+  }
+
+  async cancelOrder(orderId: string, symbol?: string): Promise<void> {
+    this.ensureConnected();
+    const order = this._orders.get(orderId);
+    if (!order) throw new ExchangeError(ExchangeErrorType.ORDER_NOT_FOUND, `Order not found: ${orderId}`, this.exchangeId);
+    if (order.status === OrderStatus.FILLED || order.status === OrderStatus.CANCELED) {
+      throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, `Cannot cancel order in status: ${order.status}`, this.exchangeId);
+    }
+    order.status = OrderStatus.CANCELED;
+    order.updatedAt = Date.now();
+    order.remainingQuantity = order.quantity - order.filledQuantity;
+    this.releaseLockedBalance(order);
+  }
+
+  async getOpenOrders(symbol?: string): Promise<Order[]> {
+    this.ensureConnected();
+    return Array.from(this._orders.values()).filter(
+      o => (o.status === OrderStatus.NEW || o.status === OrderStatus.PARTIALLY_FILLED) && (!symbol || o.symbol === symbol)
+    );
+  }
+
+  async getOrderHistory(symbol?: string, limit: number = 100): Promise<Order[]> {
+    this.ensureConnected();
+    return Array.from(this._orders.values())
+      .filter(o => !symbol || o.symbol === symbol)
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, limit);
+  }
+
+  subscribeToTrades(symbol: string, callback: TradeCallback): void {
+    if (!this._tradeSubscriptions.has(symbol)) this._tradeSubscriptions.set(symbol, new Set());
+    this._tradeSubscriptions.get(symbol)!.add(callback);
+  }
+
+  unsubscribeFromTrades(symbol: string): void { this._tradeSubscriptions.delete(symbol); }
+
+  subscribeToTicker(symbol: string, callback: TickerCallback): void {
+    if (!this._tickerSubscriptions.has(symbol)) this._tickerSubscriptions.set(symbol, new Set());
+    this._tickerSubscriptions.get(symbol)!.add(callback);
+    if (!this._tickerIntervals.has(symbol)) {
+      this._tickerIntervals.set(symbol, setInterval(() => this.emitTickerUpdate(symbol), 1000));
+    }
+  }
+
+  unsubscribeFromTicker(symbol: string): void {
+    this._tickerSubscriptions.delete(symbol);
+    const interval = this._tickerIntervals.get(symbol);
+    if (interval) { clearInterval(interval); this._tickerIntervals.delete(symbol); }
+  }
+
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback): void {
+    if (!this._orderBookSubscriptions.has(symbol)) this._orderBookSubscriptions.set(symbol, new Set());
+    this._orderBookSubscriptions.get(symbol)!.add(callback);
+    if (!this._orderBookIntervals.has(symbol)) {
+      this._orderBookIntervals.set(symbol, setInterval(() => this.emitOrderBookUpdate(symbol), 500));
+    }
+  }
+
+  unsubscribeFromOrderBook(symbol: string): void {
+    this._orderBookSubscriptions.delete(symbol);
+    const interval = this._orderBookIntervals.get(symbol);
+    if (interval) { clearInterval(interval); this._orderBookIntervals.delete(symbol); }
+  }
+
+  setBalance(asset: string, total: number, available?: number, locked: number = 0): void {
+    this._balances.set(asset, { asset, total, available: available ?? total - locked, locked });
+  }
+
+  addMarket(market: MockMarket): void { this._markets.set(market.symbol, market); }
+
+  private ensureConnected(): void {
+    if (this._status !== ConnectionStatus.CONNECTED) {
+      throw new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, 'Not connected to exchange', this.exchangeId);
+    }
+  }
+
+  private getMarket(symbol: string): MockMarket {
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this._markets.get(normalized);
+    if (!market) throw new ExchangeError(ExchangeErrorType.MARKET_NOT_FOUND, `Market not found: ${symbol}`, this.exchangeId);
+    return market;
+  }
+
+  private simulatePrice(market: MockMarket): number {
+    return market.basePrice * (1 + (Math.random() - 0.5) * 2 * market.volatility);
+  }
+
+  private validateOrderParams(order: OrderParams): void {
+    this.getMarket(order.symbol);
+    if (order.quantity <= 0) throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, 'Quantity must be positive', this.exchangeId);
+    if (order.type === OrderType.LIMIT && !order.price) throw new ExchangeError(ExchangeErrorType.INVALID_ORDER, 'Limit orders require a price', this.exchangeId);
+  }
+
+  private updateBalanceForOrder(order: OrderParams, quantity: number, price: number): void {
+    const baseAsset = order.symbol.replace(/USDT?$/, '');
+    const quoteAsset = order.symbol.match(/USDT?$/)?.[0] || 'USDT';
+    if (order.side === OrderSide.BUY) {
+      const qb = this._balances.get(quoteAsset);
+      if (qb) { qb.available -= quantity * price; qb.locked += quantity * price; }
+      let bb = this._balances.get(baseAsset);
+      if (!bb) { bb = { asset: baseAsset, total: 0, available: 0, locked: 0 }; this._balances.set(baseAsset, bb); }
+      bb.total += quantity; bb.available += quantity;
+    } else {
+      const bb = this._balances.get(baseAsset);
+      if (bb) { bb.available -= quantity; bb.locked += quantity; }
+      const qb = this._balances.get(quoteAsset);
+      if (qb) { qb.total += quantity * price; qb.available += quantity * price; }
+    }
+  }
+
+  private releaseLockedBalance(order: MockOrder): void {
+    const baseAsset = order.symbol.replace(/USDT?$/, '');
+    const quoteAsset = order.symbol.match(/USDT?$/)?.[0] || 'USDT';
+    if (order.side === OrderSide.BUY) {
+      const qb = this._balances.get(quoteAsset);
+      if (qb) { const cost = order.remainingQuantity * (order.price || 0); qb.locked -= cost; qb.available += cost; }
+    } else {
+      const bb = this._balances.get(baseAsset);
+      if (bb) { bb.locked -= order.remainingQuantity; bb.available += order.remainingQuantity; }
+    }
+  }
+
+  private simulateFill(orderId: string): void {
+    const order = this._orders.get(orderId);
+    if (!order || order.status !== OrderStatus.NEW) return;
+    const market = this.getMarket(order.symbol);
+    const fillPrice = order.price ?? this.simulatePrice(market);
+    order.status = OrderStatus.FILLED;
+    order.filledQuantity = order.quantity;
+    order.avgPrice = fillPrice;
+    order.remainingQuantity = 0;
+    order.updatedAt = Date.now();
+    order.fee = order.quantity * fillPrice * 0.001;
+
+    const trade: Trade = {
+      id: this.generateTradeId(), orderId: order.orderId, symbol: order.symbol,
+      side: order.side, price: fillPrice, quantity: order.quantity,
+      fee: order.fee, feeCurrency: order.feeCurrency, timestamp: order.updatedAt, isMaker: false,
+    };
+    const callbacks = this._tradeSubscriptions.get(order.symbol);
+    if (callbacks) Array.from(callbacks).forEach(cb => cb(trade));
+  }
+
+  private emitTickerUpdate(symbol: string): void {
+    this.getTicker(symbol).then(ticker => {
+      const callbacks = this._tickerSubscriptions.get(symbol);
+      if (callbacks) Array.from(callbacks).forEach(cb => cb(ticker));
+    }).catch(err => this.emit('error', err));
+  }
+
+  private emitOrderBookUpdate(symbol: string): void {
+    this.getOrderBook(symbol).then(orderBook => {
+      const callbacks = this._orderBookSubscriptions.get(symbol);
+      if (callbacks) Array.from(callbacks).forEach(cb => cb(orderBook));
+    }).catch(err => this.emit('error', err));
+  }
+}

--- a/src/exchange/__tests__/ExchangeManager.test.ts
+++ b/src/exchange/__tests__/ExchangeManager.test.ts
@@ -1,0 +1,43 @@
+import { ExchangeManager, resetExchangeManager } from '../ExchangeManager';
+import { MockExchangeAdapter } from '../MockExchangeAdapter';
+import { ExchangeConfig, OrderSide, OrderType, ConnectionStatus, ExchangeError } from '../types';
+
+describe('ExchangeManager', () => {
+  let manager: ExchangeManager;
+  const testConfig: ExchangeConfig = { exchangeId: 'mock', apiKey: 'test-key', apiSecret: 'test-secret' };
+
+  beforeEach(() => { manager = new ExchangeManager(); });
+  afterEach(async () => { await manager.disconnect(); resetExchangeManager(); });
+
+  describe('Registration', () => {
+    it('should register an exchange adapter', () => { const a = new MockExchangeAdapter(); manager.registerExchange(a); expect(manager.registeredExchanges).toContain('mock'); });
+    it('should throw error when registering duplicate exchange', () => { const a1 = new MockExchangeAdapter(); const a2 = new MockExchangeAdapter(); manager.registerExchange(a1); expect(() => manager.registerExchange(a2)).toThrow(ExchangeError); });
+    it('should unregister an exchange', async () => { const a = new MockExchangeAdapter(); manager.registerExchange(a); await manager.unregisterExchange('mock'); expect(manager.registeredExchanges).not.toContain('mock'); });
+  });
+
+  describe('Connection', () => {
+    it('should connect to a registered exchange', async () => { const a = new MockExchangeAdapter(); manager.registerExchange(a); await manager.connect('mock', testConfig); expect(manager.connectedExchanges).toContain('mock'); });
+    it('should create built-in adapter when connecting', async () => { await manager.connect('mock', testConfig); expect(manager.registeredExchanges).toContain('mock'); });
+    it('should disconnect from an exchange', async () => { await manager.connect('mock', testConfig); await manager.disconnect('mock'); expect(manager.connectedExchanges).not.toContain('mock'); });
+    it('should disconnect all exchanges', async () => { await manager.connect('mock', testConfig); await manager.disconnect(); expect(manager.connectedExchanges.length).toBe(0); });
+  });
+
+  describe('Active Exchange', () => {
+    beforeEach(async () => { await manager.connect('mock', testConfig); });
+    it('should set first connected exchange as active', () => { expect(manager.activeExchangeId).toBe('mock'); });
+    it('should get active exchange adapter', () => { const a = manager.getActiveExchange(); expect(a.exchangeId).toBe('mock'); });
+    it('should throw error when no active exchange', async () => { await manager.disconnect(); expect(() => manager.getActiveExchange()).toThrow(ExchangeError); });
+  });
+
+  describe('Proxy Methods', () => {
+    beforeEach(async () => { await manager.connect('mock', testConfig); });
+    it('should get balance from active exchange', async () => { const b = await manager.getBalance(); expect(b).toHaveProperty('assets'); });
+    it('should get ticker from active exchange', async () => { const t = await manager.getTicker('BTCUSDT'); expect(t.symbol).toBe('BTCUSDT'); });
+    it('should place order on active exchange', async () => { const r = await manager.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.MARKET, quantity: 0.1 }); expect(r.orderId).toBeDefined(); });
+  });
+
+  describe('Status', () => {
+    it('should get exchange status', async () => { await manager.connect('mock', testConfig); expect(manager.getExchangeStatus('mock')).toBe(ConnectionStatus.CONNECTED); });
+    it('should check if exchange is connected', async () => { await manager.connect('mock', testConfig); expect(manager.isExchangeConnected('mock')).toBe(true); });
+  });
+});

--- a/src/exchange/__tests__/MockExchangeAdapter.test.ts
+++ b/src/exchange/__tests__/MockExchangeAdapter.test.ts
@@ -1,0 +1,67 @@
+import { MockExchangeAdapter } from '../MockExchangeAdapter';
+import { ExchangeConfig, OrderSide, OrderType, OrderStatus, ConnectionStatus, ExchangeError, ExchangeErrorType } from '../types';
+
+describe('MockExchangeAdapter', () => {
+  let adapter: MockExchangeAdapter;
+  const testConfig: ExchangeConfig = { exchangeId: 'mock', apiKey: 'test-key', apiSecret: 'test-secret' };
+
+  beforeEach(() => { adapter = new MockExchangeAdapter(); });
+  afterEach(async () => { if (adapter.status === ConnectionStatus.CONNECTED) await adapter.disconnect(); });
+
+  describe('Connection', () => {
+    it('should start in disconnected state', () => { expect(adapter.status).toBe(ConnectionStatus.DISCONNECTED); });
+    it('should connect successfully', async () => { await adapter.connect(testConfig); expect(adapter.status).toBe(ConnectionStatus.CONNECTED); });
+    it('should disconnect successfully', async () => { await adapter.connect(testConfig); await adapter.disconnect(); expect(adapter.status).toBe(ConnectionStatus.DISCONNECTED); });
+    it('should fail connection without API key', async () => { await expect(adapter.connect({ ...testConfig, apiKey: '' })).rejects.toThrow(ExchangeError); });
+  });
+
+  describe('Balance', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should return account balance', async () => { const balance = await adapter.getBalance(); expect(balance).toHaveProperty('assets'); expect(Array.isArray(balance.assets)).toBe(true); });
+    it('should include default assets', async () => { const balance = await adapter.getBalance(); const assets = balance.assets.map(a => a.asset); expect(assets).toContain('USDT'); expect(assets).toContain('BTC'); });
+    it('should allow setting custom balance', async () => { adapter.setBalance('SOL', 100, 80, 20); const balance = await adapter.getBalance(); const sol = balance.assets.find(a => a.asset === 'SOL'); expect(sol).toEqual({ asset: 'SOL', total: 100, available: 80, locked: 20 }); });
+  });
+
+  describe('Ticker', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should return ticker for valid symbol', async () => { const ticker = await adapter.getTicker('BTCUSDT'); expect(ticker.symbol).toBe('BTCUSDT'); expect(ticker.last).toBeGreaterThan(0); });
+    it('should throw error for invalid symbol', async () => { await expect(adapter.getTicker('INVALID')).rejects.toThrow(ExchangeError); });
+    it('should have bid < ask', async () => { const ticker = await adapter.getTicker('ETHUSDT'); expect(ticker.bid).toBeLessThan(ticker.ask); });
+  });
+
+  describe('OrderBook', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should return order book for valid symbol', async () => { const ob = await adapter.getOrderBook('BTCUSDT'); expect(ob.symbol).toBe('BTCUSDT'); expect(ob.bids.length).toBeGreaterThan(0); expect(ob.asks.length).toBeGreaterThan(0); });
+    it('should respect depth parameter', async () => { const ob = await adapter.getOrderBook('BTCUSDT', 10); expect(ob.bids.length).toBe(10); expect(ob.asks.length).toBe(10); });
+  });
+
+  describe('Orders', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should place a market order', async () => { const r = await adapter.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.MARKET, quantity: 0.1 }); expect(r.orderId).toBeDefined(); expect(r.status).toBe(OrderStatus.FILLED); });
+    it('should place a limit order', async () => { const r = await adapter.placeOrder({ symbol: 'ETHUSDT', side: OrderSide.BUY, type: OrderType.LIMIT, quantity: 1, price: 2500 }); expect(r.orderId).toBeDefined(); expect(r.status).toBe(OrderStatus.NEW); });
+    it('should require price for limit orders', async () => { await expect(adapter.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.LIMIT, quantity: 0.1 })).rejects.toThrow(ExchangeError); });
+    it('should cancel an open order', async () => { const o = await adapter.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.LIMIT, quantity: 0.1, price: 40000 }); await adapter.cancelOrder(o.orderId, 'BTCUSDT'); const open = await adapter.getOpenOrders(); expect(open.find(x => x.orderId === o.orderId)).toBeUndefined(); });
+    it('should get open orders', async () => { await adapter.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.LIMIT, quantity: 0.1, price: 40000 }); const orders = await adapter.getOpenOrders(); expect(orders.length).toBeGreaterThan(0); });
+    it('should get order history', async () => { await adapter.placeOrder({ symbol: 'BTCUSDT', side: OrderSide.BUY, type: OrderType.MARKET, quantity: 0.1 }); const history = await adapter.getOrderHistory(); expect(history.length).toBeGreaterThan(0); });
+  });
+
+  describe('Subscriptions', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should subscribe to ticker updates', (done) => { adapter.subscribeToTicker('BTCUSDT', (t) => { expect(t.symbol).toBe('BTCUSDT'); adapter.unsubscribeFromTicker('BTCUSDT'); done(); }); });
+    it('should subscribe to order book updates', (done) => { adapter.subscribeToOrderBook('BTCUSDT', (ob) => { expect(ob.symbol).toBe('BTCUSDT'); adapter.unsubscribeFromOrderBook('BTCUSDT'); done(); }); });
+  });
+
+  describe('Capabilities', () => {
+    it('should return capabilities', () => { const caps = adapter.getCapabilities(); expect(caps.spot).toBe(true); expect(caps.margin).toBe(true); });
+    it('should check feature support', () => { expect(adapter.supportsFeature('spot')).toBe(true); expect(adapter.supportsFeature('futures')).toBe(false); });
+  });
+
+  describe('Error Handling', () => {
+    it('should throw error when not connected', async () => { await expect(adapter.getBalance()).rejects.toThrow(ExchangeError); });
+  });
+
+  describe('Custom Markets', () => {
+    beforeEach(async () => { await adapter.connect(testConfig); });
+    it('should add custom market', async () => { adapter.addMarket({ symbol: 'SOLUSDT', basePrice: 100, volatility: 0.04, tickSize: 0.01 }); const ticker = await adapter.getTicker('SOLUSDT'); expect(ticker.symbol).toBe('SOLUSDT'); });
+  });
+});

--- a/src/exchange/__tests__/types.test.ts
+++ b/src/exchange/__tests__/types.test.ts
@@ -1,0 +1,32 @@
+import { OrderSide, OrderType, OrderStatus, TimeInForce, ConnectionStatus, ExchangeError, ExchangeErrorType } from '../types';
+
+describe('Exchange Types', () => {
+  describe('Enums', () => {
+    it('should define OrderSide values', () => { expect(OrderSide.BUY).toBe('buy'); expect(OrderSide.SELL).toBe('sell'); });
+    it('should define OrderType values', () => { expect(OrderType.MARKET).toBe('market'); expect(OrderType.LIMIT).toBe('limit'); });
+    it('should define OrderStatus values', () => { expect(OrderStatus.NEW).toBe('new'); expect(OrderStatus.FILLED).toBe('filled'); });
+    it('should define TimeInForce values', () => { expect(TimeInForce.GOOD_TILL_CANCEL).toBe('GTC'); });
+    it('should define ConnectionStatus values', () => { expect(ConnectionStatus.CONNECTED).toBe('connected'); });
+    it('should define ExchangeErrorType values', () => { expect(ExchangeErrorType.CONNECTION_ERROR).toBe('connection_error'); });
+  });
+
+  describe('ExchangeError', () => {
+    it('should create an error with type and message', () => {
+      const error = new ExchangeError(ExchangeErrorType.INVALID_ORDER, 'Test error');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ExchangeError);
+      expect(error.name).toBe('ExchangeError');
+      expect(error.message).toBe('Test error');
+      expect(error.type).toBe(ExchangeErrorType.INVALID_ORDER);
+    });
+
+    it('should create an error with exchange ID', () => {
+      const error = new ExchangeError(ExchangeErrorType.CONNECTION_ERROR, 'Connection failed', 'binance');
+      expect(error.exchangeId).toBe('binance');
+    });
+
+    it('should be throwable and catchable', () => {
+      expect(() => { throw new ExchangeError(ExchangeErrorType.RATE_LIMIT_ERROR, 'Rate limited'); }).toThrow(ExchangeError);
+    });
+  });
+});

--- a/src/exchange/index.ts
+++ b/src/exchange/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Exchange Module - Multi-Exchange Support Framework
+ */
+export {
+  ExchangeConfig, ExchangeCapabilities, Balance, BalanceItem,
+  Ticker, OrderBook, OrderBookLevel, OrderParams, OrderResult, Order,
+  OrderSide, OrderType, OrderStatus, TimeInForce, Trade,
+  TradeCallback, TickerCallback, OrderBookCallback, ConnectionStatus,
+  ExchangeError, ExchangeErrorType, IExchangeAdapter,
+} from './types';
+export { BaseExchangeAdapter } from './BaseExchangeAdapter';
+export { MockExchangeAdapter } from './MockExchangeAdapter';
+export { BinanceAdapter } from './BinanceAdapter';
+export { ExchangeManager, ExchangeManagerConfig, getExchangeManager, resetExchangeManager } from './ExchangeManager';

--- a/src/exchange/types.ts
+++ b/src/exchange/types.ts
@@ -1,0 +1,444 @@
+/**
+ * Exchange Types - Multi-Exchange Support Framework
+ *
+ * Provides unified types and interfaces for connecting to multiple cryptocurrency exchanges.
+ */
+
+/**
+ * Exchange configuration - API credentials and settings
+ */
+export interface ExchangeConfig {
+  /** Exchange identifier (e.g., 'binance', 'mock') */
+  exchangeId: string;
+  /** API Key */
+  apiKey: string;
+  /** API Secret */
+  apiSecret: string;
+  /** API Passphrase (for exchanges that require it, e.g., OKX) */
+  passphrase?: string;
+  /** Whether to use testnet/sandbox mode */
+  testnet?: boolean;
+  /** Custom API endpoint (for private deployments) */
+  endpoint?: string;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** Enable rate limiting */
+  rateLimit?: boolean;
+  /** Additional exchange-specific options */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Account balance for a single asset
+ */
+export interface BalanceItem {
+  /** Asset symbol (e.g., 'BTC', 'USDT') */
+  asset: string;
+  /** Total balance */
+  total: number;
+  /** Available balance for trading */
+  available: number;
+  /** Balance locked in open orders */
+  locked: number;
+}
+
+/**
+ * Account balance summary
+ */
+export interface Balance {
+  /** Exchange timestamp */
+  timestamp: number;
+  /** Individual asset balances */
+  assets: BalanceItem[];
+  /** Total account value in quote currency (if calculable) */
+  totalValue?: number;
+}
+
+/**
+ * Ticker data - Current market price information
+ */
+export interface Ticker {
+  /** Trading pair symbol */
+  symbol: string;
+  /** Last trade price */
+  last: number;
+  /** Highest bid price */
+  bid: number;
+  /** Lowest ask price */
+  ask: number;
+  /** 24h high price */
+  high: number;
+  /** 24h low price */
+  low: number;
+  /** 24h volume in base currency */
+  volume: number;
+  /** 24h volume in quote currency */
+  quoteVolume: number;
+  /** Price change percentage in 24h */
+  changePercent: number;
+  /** Timestamp of the ticker */
+  timestamp: number;
+}
+
+/**
+ * Order book level - Single price level
+ */
+export interface OrderBookLevel {
+  /** Price */
+  price: number;
+  /** Quantity at this price level */
+  quantity: number;
+}
+
+/**
+ * Order book snapshot
+ */
+export interface OrderBook {
+  /** Trading pair symbol */
+  symbol: string;
+  /** Bid levels (sorted by price descending) */
+  bids: OrderBookLevel[];
+  /** Ask levels (sorted by price ascending) */
+  asks: OrderBookLevel[];
+  /** Timestamp of the snapshot */
+  timestamp: number;
+  /** Sequence number (for detecting gaps) */
+  sequence?: number;
+}
+
+/**
+ * Order side - buy or sell
+ */
+export enum OrderSide {
+  BUY = 'buy',
+  SELL = 'sell',
+}
+
+/**
+ * Order type - market, limit, etc.
+ */
+export enum OrderType {
+  MARKET = 'market',
+  LIMIT = 'limit',
+  STOP_LOSS = 'stop_loss',
+  STOP_LOSS_LIMIT = 'stop_loss_limit',
+  TAKE_PROFIT = 'take_profit',
+  TAKE_PROFIT_LIMIT = 'take_profit_limit',
+}
+
+/**
+ * Order status
+ */
+export enum OrderStatus {
+  NEW = 'new',
+  PARTIALLY_FILLED = 'partially_filled',
+  FILLED = 'filled',
+  CANCELED = 'canceled',
+  REJECTED = 'rejected',
+  EXPIRED = 'expired',
+}
+
+/**
+ * Time in force options
+ */
+export enum TimeInForce {
+  GOOD_TILL_CANCEL = 'GTC',
+  IMMEDIATE_OR_CANCEL = 'IOC',
+  FILL_OR_KILL = 'FOK',
+  GOOD_TILL_DATE = 'GTD',
+}
+
+/**
+ * Order parameters for placing a new order
+ */
+export interface OrderParams {
+  /** Trading pair symbol */
+  symbol: string;
+  /** Order side (buy/sell) */
+  side: OrderSide;
+  /** Order type */
+  type: OrderType;
+  /** Quantity to trade */
+  quantity: number;
+  /** Limit price (required for limit orders) */
+  price?: number;
+  /** Stop price (for stop orders) */
+  stopPrice?: number;
+  /** Time in force */
+  timeInForce?: TimeInForce;
+  /** Client-provided order ID */
+  clientOrderId?: string;
+  /** Additional notes */
+  notes?: string;
+}
+
+/**
+ * Trade execution record
+ */
+export interface Trade {
+  /** Trade ID */
+  id: string;
+  /** Order ID that generated this trade */
+  orderId: string;
+  /** Trading pair symbol */
+  symbol: string;
+  /** Order side */
+  side: OrderSide;
+  /** Trade price */
+  price: number;
+  /** Trade quantity */
+  quantity: number;
+  /** Trade fee */
+  fee: number;
+  /** Fee currency */
+  feeCurrency: string;
+  /** Execution timestamp */
+  timestamp: number;
+  /** Whether this was a maker or taker order */
+  isMaker?: boolean;
+}
+
+/**
+ * Order result after placing an order
+ */
+export interface OrderResult {
+  /** Exchange-assigned order ID */
+  orderId: string;
+  /** Client-provided order ID */
+  clientOrderId?: string;
+  /** Trading pair symbol */
+  symbol: string;
+  /** Order side */
+  side: OrderSide;
+  /** Order type */
+  type: OrderType;
+  /** Order status */
+  status: OrderStatus;
+  /** Original order quantity */
+  quantity: number;
+  /** Quantity filled so far */
+  filledQuantity: number;
+  /** Average fill price */
+  avgPrice: number;
+  /** Total fee paid */
+  fee: number;
+  /** Fee currency */
+  feeCurrency: string;
+  /** Order creation timestamp */
+  createdAt: number;
+  /** Last update timestamp */
+  updatedAt: number;
+  /** Executed trades */
+  trades?: Trade[];
+}
+
+/**
+ * Order with full details
+ */
+export interface Order extends OrderResult {
+  /** Limit price (for limit orders) */
+  price?: number;
+  /** Stop price (for stop orders) */
+  stopPrice?: number;
+  /** Time in force */
+  timeInForce?: TimeInForce;
+  /** Remaining quantity to fill */
+  remainingQuantity: number;
+}
+
+/**
+ * Trade subscription callback
+ */
+export type TradeCallback = (trade: Trade) => void;
+
+/**
+ * Ticker subscription callback
+ */
+export type TickerCallback = (ticker: Ticker) => void;
+
+/**
+ * Order book subscription callback
+ */
+export type OrderBookCallback = (orderBook: OrderBook) => void;
+
+/**
+ * Exchange connection status
+ */
+export enum ConnectionStatus {
+  DISCONNECTED = 'disconnected',
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  RECONNECTING = 'reconnecting',
+  ERROR = 'error',
+}
+
+/**
+ * Exchange adapter interface
+ *
+ * Defines the common interface for all exchange adapters.
+ * All exchanges must implement this interface to be used in the system.
+ */
+export interface IExchangeAdapter {
+  /** Exchange name */
+  readonly name: string;
+  /** Exchange ID */
+  readonly exchangeId: string;
+  /** Current connection status */
+  readonly status: ConnectionStatus;
+
+  /**
+   * Connect to the exchange
+   * @param config Exchange configuration
+   */
+  connect(config: ExchangeConfig): Promise<void>;
+
+  /**
+   * Disconnect from the exchange
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Get account balance
+   */
+  getBalance(): Promise<Balance>;
+
+  /**
+   * Get ticker for a trading pair
+   * @param symbol Trading pair symbol
+   */
+  getTicker(symbol: string): Promise<Ticker>;
+
+  /**
+   * Get order book for a trading pair
+   * @param symbol Trading pair symbol
+   * @param depth Number of price levels to return (default: 20)
+   */
+  getOrderBook(symbol: string, depth?: number): Promise<OrderBook>;
+
+  /**
+   * Place a new order
+   * @param order Order parameters
+   */
+  placeOrder(order: OrderParams): Promise<OrderResult>;
+
+  /**
+   * Cancel an existing order
+   * @param orderId Order ID to cancel
+   * @param symbol Trading pair symbol (required by some exchanges)
+   */
+  cancelOrder(orderId: string, symbol?: string): Promise<void>;
+
+  /**
+   * Get open orders
+   * @param symbol Trading pair symbol (optional, returns all if not specified)
+   */
+  getOpenOrders(symbol?: string): Promise<Order[]>;
+
+  /**
+   * Get order history
+   * @param symbol Trading pair symbol (optional, returns all if not specified)
+   * @param limit Maximum number of orders to return
+   */
+  getOrderHistory(symbol?: string, limit?: number): Promise<Order[]>;
+
+  /**
+   * Subscribe to trade updates
+   * @param symbol Trading pair symbol
+   * @param callback Function to call when a trade is received
+   */
+  subscribeToTrades(symbol: string, callback: TradeCallback): void;
+
+  /**
+   * Unsubscribe from trade updates
+   * @param symbol Trading pair symbol
+   */
+  unsubscribeFromTrades(symbol: string): void;
+
+  /**
+   * Subscribe to ticker updates
+   * @param symbol Trading pair symbol
+   * @param callback Function to call when a ticker update is received
+   */
+  subscribeToTicker?(symbol: string, callback: TickerCallback): void;
+
+  /**
+   * Unsubscribe from ticker updates
+   * @param symbol Trading pair symbol
+   */
+  unsubscribeFromTicker?(symbol: string): void;
+
+  /**
+   * Subscribe to order book updates
+   * @param symbol Trading pair symbol
+   * @param callback Function to call when order book updates
+   */
+  subscribeToOrderBook?(symbol: string, callback: OrderBookCallback): void;
+
+  /**
+   * Unsubscribe from order book updates
+   * @param symbol Trading pair symbol
+   */
+  unsubscribeFromOrderBook?(symbol: string): void;
+
+  /**
+   * Check if the exchange supports a specific feature
+   * @param feature Feature name
+   */
+  supportsFeature?(feature: string): boolean;
+}
+
+/**
+ * Exchange error types
+ */
+export enum ExchangeErrorType {
+  CONNECTION_ERROR = 'connection_error',
+  AUTHENTICATION_ERROR = 'authentication_error',
+  RATE_LIMIT_ERROR = 'rate_limit_error',
+  INVALID_ORDER = 'invalid_order',
+  INSUFFICIENT_BALANCE = 'insufficient_balance',
+  ORDER_NOT_FOUND = 'order_not_found',
+  MARKET_NOT_FOUND = 'market_not_found',
+  TIMEOUT = 'timeout',
+  UNKNOWN = 'unknown',
+}
+
+/**
+ * Exchange error class
+ */
+export class ExchangeError extends Error {
+  constructor(
+    public readonly type: ExchangeErrorType,
+    message: string,
+    public readonly exchangeId?: string,
+    public readonly originalError?: Error
+  ) {
+    super(message);
+    this.name = 'ExchangeError';
+  }
+}
+
+/**
+ * Exchange capabilities/features
+ */
+export interface ExchangeCapabilities {
+  /** Supports spot trading */
+  spot: boolean;
+  /** Supports margin trading */
+  margin: boolean;
+  /** Supports futures trading */
+  futures: boolean;
+  /** Supports WebSocket subscriptions */
+  websocket: boolean;
+  /** Supports REST API */
+  rest: boolean;
+  /** Maximum order book depth */
+  maxOrderBookDepth: number;
+  /** Supported time in force options */
+  supportedTimeInForce: TimeInForce[];
+  /** Supports stop-loss orders */
+  stopLoss: boolean;
+  /** Supports take-profit orders */
+  takeProfit: boolean;
+  /** Maximum rate limit (requests per second) */
+  rateLimit: number;
+}


### PR DESCRIPTION
## Summary

Implements Issue #246 - Multi-Exchange Support Framework for AlphaArena trading system.

### Changes

- **ExchangeAdapter Interface**: Complete type definitions for exchange operations
- **BaseExchangeAdapter**: Abstract base class with common functionality
- **MockExchangeAdapter**: Simulated exchange for testing
- **BinanceAdapter**: Basic implementation for Binance exchange
- **ExchangeManager**: Manages multiple exchange connections

### Features

- ✅ Unified exchange adapter interface
- ✅ Balance, ticker, order book, and order operations
- ✅ WebSocket subscriptions for real-time data
- ✅ Connection management with auto-reconnect
- ✅ Exchange capabilities and feature detection
- ✅ Standardized data formats across exchanges

### Test Coverage

- types.ts: All enum and error tests passing
- MockExchangeAdapter.ts: Full test coverage
- ExchangeManager.ts: Full test coverage
- Overall: 48 tests passing

### Acceptance Criteria Met

- [x] ExchangeAdapter interface definition complete
- [x] MockExchangeAdapter implemented and tested
- [x] BinanceAdapter basic implementation (supports REST API, WebSocket)
- [x] Unit test coverage > 80% for core components

## Test plan

- [x] All unit tests pass (48 tests)
- [x] TypeScript compiles without errors
- [x] Build succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new order-placement and signed-request logic (including API credential handling) plus WebSocket subscription plumbing, which can affect trading behavior and connectivity if integrated incorrectly. Changes are largely additive and isolated to the new `src/exchange` module with unit tests, reducing blast radius.
> 
> **Overview**
> Adds a new **multi-exchange abstraction layer** under `src/exchange`, defining unified types/interfaces (`IExchangeAdapter`, orders, balances, capabilities, errors) and a shared `BaseExchangeAdapter` with common helpers.
> 
> Implements two adapters: `MockExchangeAdapter` for simulation/testing (balances, markets, order lifecycle, periodic ticker/orderbook callbacks) and `BinanceAdapter` with basic REST + signed REST requests and WebSocket streams for trades/tickers/orderbook.
> 
> Introduces `ExchangeManager` to register/unregister exchanges, connect/disconnect and select an active exchange, proxy common trading/data APIs, and re-export everything via `src/exchange/index.ts`, with Jest tests covering types, manager behavior, and the mock adapter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d771461693776460288dfb27402ad67f9135c82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->