### PR TITLE
fix: Deploy missing Supabase functions and add orders endpoint mapping

### DIFF
--- a/src/client/utils/api.ts
+++ b/src/client/utils/api.ts
@@ -39,6 +39,7 @@ const FUNCTION_MAP: Record<string, string> = {
   '/api/market/tickers': 'get-market-tickers',
   '/api/market/kline': 'get-market-kline',
   '/api/conditional-orders': 'conditional-orders',
+  '/api/orders': 'get-orders'
 };
 
 // Helper to map API paths to Supabase function names

--- a/supabase/functions/get-orders/index.ts
+++ b/supabase/functions/get-orders/index.ts
@@ -1,0 +1,54 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.99.0';
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type'
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', {
+      headers: corsHeaders
+    });
+  }
+
+  try {
+    // Get query parameters for filtering
+    const { searchParams } = new URL(req.url);
+    const symbol = searchParams.get('symbol');
+    const status = searchParams.get('status');
+    const limit = parseInt(searchParams.get('limit') || '100');
+
+    // For now, return empty array as orders are not fully implemented
+    // The orders table would need to be created and the create-order function
+    // would need to be updated to persist orders
+    
+    console.log('get-orders called with params:', { symbol, status, limit });
+
+    // Return empty orders array
+    return new Response(JSON.stringify({
+      success: true,
+      data: []
+    }), {
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json'
+      },
+      status: 200
+    });
+  } catch (error) {
+    console.error('Error in get-orders:', error);
+    return new Response(JSON.stringify({
+      success: false,
+      error: error.message
+    }), {
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json'
+      },
+      status: 500
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Deploy `price-alerts` function to Supabase (was not deployed)
- Create and deploy `get-orders` function for orders panel
- Add `/api/orders` to FUNCTION_MAP to route to get-orders function

## Root Cause
The Dashboard page was failing to load price alerts and orders because:
1. The `price-alerts` Supabase Edge Function existed locally but was not deployed to production
2. The `orders` endpoint had no corresponding Supabase function

## Changes
1. Deployed `price-alerts` function to Supabase
2. Created new `get-orders` function that returns an empty array (orders not fully implemented yet)
3. Updated FUNCTION_MAP in api.ts to route `/api/orders` to `get-orders`

## Testing
- Verified both endpoints return successful responses:
  - `GET /functions/v1/price-alerts` → `{"success":true,"data":[]}`
  - `GET /functions/v1/get-orders` → `{"success":true,"data":[]}`

Fixes #284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Supabase Edge Function stub and a simple client-side endpoint mapping; behavior is additive and currently returns an empty orders list.
> 
> **Overview**
> Adds a new Supabase Edge Function `get-orders` to back the orders panel, including basic CORS handling and query param parsing (`symbol`, `status`, `limit`), but currently returns an empty `data` array.
> 
> Updates the client API path-to-function routing so `/api/orders` is mapped to `get-orders` when running against Supabase Edge Functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa7b939347801796a99aa9ebc69f773f8aeb09fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->