### PR TITLE
feat: Add multi-timeframe analysis support (Issue #293)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -36,6 +36,7 @@ import notificationRoutes from './notificationRoutes.js';
 import strategyComparisonRoutes from './strategyComparisonRoutes';
 import exportRoutes from './exportRoutes';
 import { createTemplateRouter } from './templateRoutes';
+import multiTimeframeRoutes from '../multi-timeframe/routes';
 import { createLogger } from '../utils/logger';
 
 // Create logger for this module
@@ -868,6 +869,7 @@ export class APIServer extends EventEmitter {
 
     // Strategy template marketplace routes
     this.app.use('/api/templates', createTemplateRouter());
+    this.app.use('/api/multi-timeframe', multiTimeframeRoutes);
 
     // 404 handler
     this.app.use((req: Request, res: Response) => {

--- a/src/multi-timeframe/MultiTimeframeDataService.ts
+++ b/src/multi-timeframe/MultiTimeframeDataService.ts
@@ -1,0 +1,296 @@
+/**
+ * Multi-Timeframe Data Service
+ * 
+ * Provides K-line data for multiple timeframes with caching and optimization
+ */
+
+import { 
+  Timeframe, 
+  KLineDataPoint, 
+  MultiTimeframeKLineData,
+  ALL_TIMEFRAMES,
+  TIMEFRAME_DURATIONS,
+} from './types';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('MultiTimeframeDataService');
+
+/**
+ * Cache entry for K-line data
+ */
+interface CacheEntry {
+  data: KLineDataPoint[];
+  timestamp: number;
+  symbol: string;
+  timeframe: Timeframe;
+}
+
+/**
+ * Configuration for the data service
+ */
+export interface MultiTimeframeDataServiceConfig {
+  /** Cache TTL in milliseconds (default: 60 seconds for 1m timeframe, scales up for longer timeframes) */
+  cacheTTL?: number;
+  /** Maximum number of candles to keep in memory per timeframe */
+  maxCandles?: number;
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Multi-Timeframe Data Service
+ * 
+ * Manages K-line data for multiple timeframes with intelligent caching
+ */
+export class MultiTimeframeDataService {
+  private cache: Map<string, CacheEntry> = new Map();
+  private config: Required<MultiTimeframeDataServiceConfig>;
+  private dataGenerators: Map<Timeframe, () => KLineDataPoint[]> = new Map();
+
+  constructor(config: MultiTimeframeDataServiceConfig = {}) {
+    this.config = {
+      cacheTTL: config.cacheTTL ?? 60000,
+      maxCandles: config.maxCandles ?? 1000,
+      debug: config.debug ?? false,
+    };
+
+    if (this.config.debug) {
+      log.info('MultiTimeframeDataService initialized', this.config);
+    }
+  }
+
+  /**
+   * Register a data generator for a specific timeframe
+   * This allows external data sources to provide K-line data
+   */
+  registerDataGenerator(timeframe: Timeframe, generator: () => KLineDataPoint[]): void {
+    this.dataGenerators.set(timeframe, generator);
+    log.info(`Registered data generator for timeframe: ${timeframe}`);
+  }
+
+  /**
+   * Get K-line data for a single timeframe
+   */
+  async getKLineData(
+    symbol: string,
+    timeframe: Timeframe,
+    limit?: number
+  ): Promise<KLineDataPoint[]> {
+    const cacheKey = `${symbol}:${timeframe}`;
+    
+    // Check cache
+    const cached = this.cache.get(cacheKey);
+    if (cached && this.isCacheValid(cached)) {
+      if (this.config.debug) {
+        log.debug(`Cache hit for ${cacheKey}`);
+      }
+      return this.limitData(cached.data, limit);
+    }
+
+    // Generate or fetch data
+    const data = await this.fetchOrGenerateData(symbol, timeframe);
+    
+    // Update cache
+    this.cache.set(cacheKey, {
+      data,
+      timestamp: Date.now(),
+      symbol,
+      timeframe,
+    });
+
+    return this.limitData(data, limit);
+  }
+
+  /**
+   * Get K-line data for multiple timeframes
+   */
+  async getMultiTimeframeData(
+    symbol: string,
+    timeframes: Timeframe[],
+    limit?: number
+  ): Promise<MultiTimeframeKLineData> {
+    const dataMap = new Map<Timeframe, KLineDataPoint[]>();
+
+    // Fetch data for all timeframes in parallel
+    const promises = timeframes.map(async (timeframe) => {
+      const data = await this.getKLineData(symbol, timeframe, limit);
+      dataMap.set(timeframe, data);
+    });
+
+    await Promise.all(promises);
+
+    return {
+      symbol,
+      data: dataMap,
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * Clear cache for a specific symbol
+   */
+  clearCache(symbol?: string): void {
+    if (symbol) {
+      // Clear only entries for this symbol
+      for (const key of this.cache.keys()) {
+        if (key.startsWith(`${symbol}:`)) {
+          this.cache.delete(key);
+        }
+      }
+      log.info(`Cleared cache for symbol: ${symbol}`);
+    } else {
+      // Clear all cache
+      this.cache.clear();
+      log.info('Cleared all cache');
+    }
+  }
+
+  /**
+   * Get cache statistics
+   */
+  getCacheStats(): {
+    entries: number;
+    symbols: Set<string>;
+    timeframes: Set<Timeframe>;
+    totalDataPoints: number;
+  } {
+    const symbols = new Set<string>();
+    const timeframes = new Set<Timeframe>();
+    let totalDataPoints = 0;
+
+    for (const entry of this.cache.values()) {
+      symbols.add(entry.symbol);
+      timeframes.add(entry.timeframe);
+      totalDataPoints += entry.data.length;
+    }
+
+    return {
+      entries: this.cache.size,
+      symbols,
+      timeframes,
+      totalDataPoints,
+    };
+  }
+
+  /**
+   * Check if cache entry is still valid
+   */
+  private isCacheValid(entry: CacheEntry): boolean {
+    const timeframeDuration = TIMEFRAME_DURATIONS[entry.timeframe];
+    // Cache TTL scales with timeframe (longer timeframes have longer TTL)
+    const adjustedTTL = Math.max(
+      this.config.cacheTTL,
+      timeframeDuration / 10 // At least 1/10 of the timeframe duration
+    );
+    
+    return Date.now() - entry.timestamp < adjustedTTL;
+  }
+
+  /**
+   * Fetch from generator or generate simulated data
+   */
+  private async fetchOrGenerateData(
+    symbol: string,
+    timeframe: Timeframe
+  ): Promise<KLineDataPoint[]> {
+    // Check if there's a registered generator
+    const generator = this.dataGenerators.get(timeframe);
+    if (generator) {
+      return generator();
+    }
+
+    // Generate simulated data for demo/testing
+    return this.generateSimulatedData(symbol, timeframe);
+  }
+
+  /**
+   * Generate simulated K-line data
+   * Used for testing and demo purposes
+   */
+  private generateSimulatedData(symbol: string, timeframe: Timeframe): KLineDataPoint[] {
+    const duration = TIMEFRAME_DURATIONS[timeframe];
+    const numCandles = this.config.maxCandles;
+    const data: KLineDataPoint[] = [];
+
+    // Use symbol hash as seed for reproducible randomness
+    let seed = this.hashString(symbol + timeframe);
+    const random = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+
+    const now = Math.floor(Date.now() / 1000);
+    let price = 100 + (this.hashString(symbol) % 90000); // Price between 100 and 90100
+
+    for (let i = numCandles - 1; i >= 0; i--) {
+      const timestamp = now - Math.floor((i * duration) / 1000);
+      
+      // Generate OHLCV data
+      const volatility = 0.02 + random() * 0.03; // 2-5% volatility
+      const change = (random() - 0.5) * 2 * volatility * price;
+      
+      const open = price;
+      const close = price + change;
+      const high = Math.max(open, close) + random() * volatility * price * 0.5;
+      const low = Math.min(open, close) - random() * volatility * price * 0.5;
+      const volume = Math.floor(random() * 1000000) + 10000;
+
+      data.push({
+        time: timestamp,
+        open,
+        high,
+        low,
+        close,
+        volume,
+      });
+
+      price = close;
+    }
+
+    if (this.config.debug) {
+      log.debug(`Generated ${data.length} candles for ${symbol} ${timeframe}`);
+    }
+
+    return data;
+  }
+
+  /**
+   * Limit data to specified number of candles
+   */
+  private limitData(data: KLineDataPoint[], limit?: number): KLineDataPoint[] {
+    if (!limit || limit >= data.length) {
+      return data;
+    }
+    return data.slice(-limit);
+  }
+
+  /**
+   * Simple string hash function
+   */
+  private hashString(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash);
+  }
+}
+
+/**
+ * Singleton instance
+ */
+let instance: MultiTimeframeDataService | null = null;
+
+/**
+ * Get singleton instance of the data service
+ */
+export function getMultiTimeframeDataService(
+  config?: MultiTimeframeDataServiceConfig
+): MultiTimeframeDataService {
+  if (!instance) {
+    instance = new MultiTimeframeDataService(config);
+  }
+  return instance;
+}

--- a/src/multi-timeframe/MultiTimeframeStrategy.ts
+++ b/src/multi-timeframe/MultiTimeframeStrategy.ts
@@ -1,0 +1,238 @@
+/**
+ * Multi-Timeframe Strategy Base Class
+ * 
+ * Abstract base class for strategies that analyze multiple timeframes
+ */
+
+import { Strategy } from '../strategy/Strategy';
+import { StrategyContext, OrderSignal } from '../strategy/types';
+import {
+  Timeframe,
+  KLineDataPoint,
+  TimeframeSignal,
+  MultiTimeframeSignal,
+  MultiTimeframeStrategyConfig,
+  MultiTimeframeContext,
+  TimeframeWeight,
+  getDefaultTimeframeWeights,
+  aggregateSignals,
+} from './types';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('MultiTimeframeStrategy');
+
+/**
+ * Extended strategy context with multi-timeframe data
+ */
+export interface MultiTimeframeStrategyContext extends StrategyContext {
+  /** Multi-timeframe context */
+  mtf: MultiTimeframeContext;
+}
+
+/**
+ * Abstract base class for multi-timeframe strategies
+ */
+export abstract class MultiTimeframeStrategy extends Strategy {
+  protected mtfConfig: MultiTimeframeStrategyConfig;
+  protected timeframeWeights: TimeframeWeight[];
+  protected klineData: Map<Timeframe, KLineDataPoint[]> = new Map();
+  protected signals: Map<Timeframe, TimeframeSignal> = new Map();
+  protected lastCombinedSignal: MultiTimeframeSignal | null = null;
+
+  constructor(config: MultiTimeframeStrategyConfig) {
+    super({
+      id: config.id,
+      name: config.name,
+      params: config.params,
+    });
+
+    this.mtfConfig = config;
+    
+    // Initialize timeframe weights
+    if (config.timeframeWeights && config.timeframeWeights.length > 0) {
+      this.timeframeWeights = config.timeframeWeights;
+    } else {
+      this.timeframeWeights = getDefaultTimeframeWeights(config.timeframes);
+    }
+
+    log.info(`MultiTimeframeStrategy initialized: ${config.name}`, {
+      timeframes: config.timeframes,
+      weights: this.timeframeWeights,
+    });
+  }
+
+  /**
+   * Get the timeframes this strategy analyzes
+   */
+  getTimeframes(): Timeframe[] {
+    return this.mtfConfig.timeframes;
+  }
+
+  /**
+   * Get timeframe weights
+   */
+  getTimeframeWeights(): TimeframeWeight[] {
+    return this.timeframeWeights;
+  }
+
+  /**
+   * Update K-line data for a timeframe
+   */
+  updateKLineData(timeframe: Timeframe, data: KLineDataPoint[]): void {
+    this.klineData.set(timeframe, data);
+  }
+
+  /**
+   * Get K-line data for a timeframe
+   */
+  getKLineData(timeframe: Timeframe): KLineDataPoint[] | null {
+    return this.klineData.get(timeframe) ?? null;
+  }
+
+  /**
+   * Get current price from the most recent candle
+   */
+  protected getCurrentPrice(timeframe: Timeframe): number {
+    const data = this.klineData.get(timeframe);
+    if (!data || data.length === 0) return 0;
+    return data[data.length - 1].close;
+  }
+
+  /**
+   * Analyze a specific timeframe and generate a signal
+   * Must be implemented by subclasses
+   */
+  abstract analyzeTimeframe(timeframe: Timeframe): TimeframeSignal | null;
+
+  /**
+   * Analyze all timeframes and generate signals
+   */
+  analyzeAllTimeframes(): TimeframeSignal[] {
+    const signals: TimeframeSignal[] = [];
+
+    for (const timeframe of this.mtfConfig.timeframes) {
+      const signal = this.analyzeTimeframe(timeframe);
+      if (signal) {
+        this.signals.set(timeframe, signal);
+        signals.push(signal);
+      }
+    }
+
+    return signals;
+  }
+
+  /**
+   * Get combined signal from all timeframes
+   */
+  getCombinedSignal(): MultiTimeframeSignal | null {
+    const signals = Array.from(this.signals.values());
+    
+    if (signals.length === 0) {
+      return null;
+    }
+
+    this.lastCombinedSignal = aggregateSignals(signals, this.timeframeWeights);
+    return this.lastCombinedSignal;
+  }
+
+  /**
+   * Create multi-timeframe context
+   */
+  protected createMultiTimeframeContext(symbol: string): MultiTimeframeContext {
+    const self = this;
+
+    return {
+      symbol,
+      getKLineData: (timeframe: Timeframe) => self.getKLineData(timeframe),
+      getCurrentPrice: () => {
+        // Get price from primary timeframe (first in list) or any available
+        const primaryTf = self.mtfConfig.timeframes[0];
+        return self.getCurrentPrice(primaryTf);
+      },
+      getSignal: (timeframe: Timeframe) => self.signals.get(timeframe) ?? null,
+      getAllSignals: () => Array.from(self.signals.values()),
+      getCombinedSignal: () => self.getCombinedSignal(),
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * Check if combined signal meets the threshold
+   */
+  protected isSignalStrongEnough(signal: MultiTimeframeSignal | null): boolean {
+    if (!signal) return false;
+    
+    const threshold = this.mtfConfig.signalThreshold ?? 0.3;
+    return signal.combinedStrength >= threshold;
+  }
+
+  /**
+   * Convert combined signal to order signal
+   */
+  protected createOrderSignalFromCombined(
+    combined: MultiTimeframeSignal
+  ): OrderSignal | null {
+    if (combined.combinedType === 'hold') {
+      return null;
+    }
+
+    const price = this.getCurrentPrice(this.mtfConfig.timeframes[0]);
+    const quantity = this.mtfConfig.params?.tradeQuantity ?? 10;
+
+    return this.createSignal(
+      combined.combinedType,
+      price,
+      quantity,
+      {
+        confidence: combined.confidence,
+        reason: `Multi-timeframe ${combined.combinedType} signal (strength: ${combined.combinedStrength.toFixed(2)}, confidence: ${combined.confidence.toFixed(2)})`,
+      }
+    );
+  }
+
+  /**
+   * Main tick handler - analyzes all timeframes and generates signals
+   */
+  onTick(context: StrategyContext): OrderSignal | null {
+    // Analyze all timeframes
+    this.analyzeAllTimeframes();
+
+    // Get combined signal
+    const combined = this.getCombinedSignal();
+
+    if (!combined) {
+      return null;
+    }
+
+    // Check if signal is strong enough
+    if (!this.isSignalStrongEnough(combined)) {
+      log.debug(`Signal not strong enough: ${combined.combinedStrength.toFixed(2)}`);
+      return null;
+    }
+
+    // Convert to order signal
+    return this.createOrderSignalFromCombined(combined);
+  }
+
+  /**
+   * Get the last combined signal for analysis
+   */
+  getLastCombinedSignal(): MultiTimeframeSignal | null {
+    return this.lastCombinedSignal;
+  }
+
+  /**
+   * Get all timeframe signals
+   */
+  getAllTimeframeSignals(): Map<Timeframe, TimeframeSignal> {
+    return new Map(this.signals);
+  }
+
+  /**
+   * Clear all signals (useful for testing)
+   */
+  clearSignals(): void {
+    this.signals.clear();
+    this.lastCombinedSignal = null;
+  }
+}

--- a/src/multi-timeframe/__tests__/MultiTimeframeDataService.test.ts
+++ b/src/multi-timeframe/__tests__/MultiTimeframeDataService.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for Multi-Timeframe Data Service
+ */
+
+import { MultiTimeframeDataService, getMultiTimeframeDataService } from '../MultiTimeframeDataService';
+import { Timeframe, KLineDataPoint } from '../types';
+
+describe('MultiTimeframeDataService', () => {
+  let service: MultiTimeframeDataService;
+
+  beforeEach(() => {
+    service = new MultiTimeframeDataService({ debug: true });
+  });
+
+  afterEach(() => {
+    service.clearCache();
+  });
+
+  describe('getKLineData', () => {
+    it('should return K-line data for a timeframe', async () => {
+      const data = await service.getKLineData('BTC/USDT', '1h', 100);
+
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeLessThanOrEqual(100);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it('should return data with correct structure', async () => {
+      const data = await service.getKLineData('BTC/USDT', '1h', 10);
+
+      expect(data.length).toBe(10);
+      
+      for (const point of data) {
+        expect(point).toHaveProperty('time');
+        expect(point).toHaveProperty('open');
+        expect(point).toHaveProperty('high');
+        expect(point).toHaveProperty('low');
+        expect(point).toHaveProperty('close');
+        expect(point).toHaveProperty('volume');
+        
+        expect(typeof point.time).toBe('number');
+        expect(typeof point.open).toBe('number');
+        expect(typeof point.high).toBe('number');
+        expect(typeof point.low).toBe('number');
+        expect(typeof point.close).toBe('number');
+        expect(typeof point.volume).toBe('number');
+        
+        // OHLC constraints
+        expect(point.high).toBeGreaterThanOrEqual(point.open);
+        expect(point.high).toBeGreaterThanOrEqual(point.close);
+        expect(point.low).toBeLessThanOrEqual(point.open);
+        expect(point.low).toBeLessThanOrEqual(point.close);
+      }
+    });
+
+    it('should cache data', async () => {
+      const data1 = await service.getKLineData('BTC/USDT', '1h', 100);
+      const data2 = await service.getKLineData('BTC/USDT', '1h', 100);
+
+      // Should return same data (from cache)
+      expect(data1).toEqual(data2);
+    });
+
+    it('should respect limit parameter', async () => {
+      const data = await service.getKLineData('BTC/USDT', '1h', 50);
+      expect(data.length).toBe(50);
+    });
+
+    it('should generate different data for different symbols', async () => {
+      const data1 = await service.getKLineData('BTC/USDT', '1h', 10);
+      const data2 = await service.getKLineData('ETH/USDT', '1h', 10);
+
+      // Prices should be different (different seeds)
+      expect(data1[0].close).not.toBe(data2[0].close);
+    });
+
+    it('should generate different data for different timeframes', async () => {
+      const data1h = await service.getKLineData('BTC/USDT', '1h', 100);
+      const data1d = await service.getKLineData('BTC/USDT', '1d', 100);
+
+      // Both should have data
+      expect(data1h.length).toBeGreaterThan(0);
+      expect(data1d.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getMultiTimeframeData', () => {
+    it('should return data for multiple timeframes', async () => {
+      const timeframes: Timeframe[] = ['1h', '4h', '1d'];
+      const result = await service.getMultiTimeframeData('BTC/USDT', timeframes, 100);
+
+      expect(result.symbol).toBe('BTC/USDT');
+      expect(result.data.size).toBe(3);
+      
+      expect(result.data.has('1h')).toBe(true);
+      expect(result.data.has('4h')).toBe(true);
+      expect(result.data.has('1d')).toBe(true);
+    });
+
+    it('should return data for all requested timeframes', async () => {
+      const timeframes: Timeframe[] = ['1m', '5m', '15m', '1h', '4h', '1d'];
+      const result = await service.getMultiTimeframeData('BTC/USDT', timeframes);
+
+      for (const tf of timeframes) {
+        expect(result.data.has(tf)).toBe(true);
+        const data = result.data.get(tf);
+        expect(data).toBeDefined();
+        expect(data!.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('cache management', () => {
+    it('should clear cache for specific symbol', async () => {
+      await service.getKLineData('BTC/USDT', '1h');
+      await service.getKLineData('ETH/USDT', '1h');
+
+      service.clearCache('BTC/USDT');
+
+      const stats = service.getCacheStats();
+      expect(stats.symbols.has('BTC/USDT')).toBe(false);
+      expect(stats.symbols.has('ETH/USDT')).toBe(true);
+    });
+
+    it('should clear all cache', async () => {
+      await service.getKLineData('BTC/USDT', '1h');
+      await service.getKLineData('ETH/USDT', '1h');
+
+      service.clearCache();
+
+      const stats = service.getCacheStats();
+      expect(stats.entries).toBe(0);
+    });
+
+    it('should report cache statistics', async () => {
+      await service.getKLineData('BTC/USDT', '1h');
+      await service.getKLineData('BTC/USDT', '4h');
+      await service.getKLineData('ETH/USDT', '1h');
+
+      const stats = service.getCacheStats();
+
+      expect(stats.entries).toBe(3);
+      expect(stats.symbols.size).toBe(2);
+      expect(stats.timeframes.size).toBe(2);
+      expect(stats.totalDataPoints).toBeGreaterThan(0);
+    });
+  });
+
+  describe('custom data generator', () => {
+    it('should use registered data generator', async () => {
+      const customData: KLineDataPoint[] = [
+        { time: 1000, open: 100, high: 105, low: 95, close: 102, volume: 1000 },
+        { time: 2000, open: 102, high: 108, low: 100, close: 105, volume: 1200 },
+      ];
+
+      service.registerDataGenerator('1h', () => customData);
+
+      const data = await service.getKLineData('TEST/USDT', '1h');
+      
+      expect(data).toEqual(customData);
+    });
+  });
+});
+
+describe('getMultiTimeframeDataService singleton', () => {
+  it('should return the same instance', () => {
+    const instance1 = getMultiTimeframeDataService();
+    const instance2 = getMultiTimeframeDataService();
+
+    expect(instance1).toBe(instance2);
+  });
+});

--- a/src/multi-timeframe/__tests__/MultiTimeframeSMAStrategy.test.ts
+++ b/src/multi-timeframe/__tests__/MultiTimeframeSMAStrategy.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for Multi-Timeframe SMA Strategy
+ */
+
+import { MultiTimeframeSMAStrategy } from '../strategies/MultiTimeframeSMAStrategy';
+import { Timeframe, KLineDataPoint } from '../types';
+import { StrategyContext } from '../../strategy/types';
+
+// Helper to generate test K-line data
+function generateKLineData(numCandles: number, basePrice: number = 100): KLineDataPoint[] {
+  const data: KLineDataPoint[] = [];
+  const now = Math.floor(Date.now() / 1000);
+
+  for (let i = 0; i < numCandles; i++) {
+    const change = (Math.random() - 0.5) * 2;
+    const open = basePrice;
+    const close = basePrice + change;
+    const high = Math.max(open, close) + Math.random();
+    const low = Math.min(open, close) - Math.random();
+
+    data.push({
+      time: now - (numCandles - i) * 3600,
+      open,
+      high,
+      low,
+      close,
+      volume: Math.floor(Math.random() * 10000) + 1000,
+    });
+
+    basePrice = close;
+  }
+
+  return data;
+}
+
+// Helper to generate trending K-line data
+function generateTrendingKLineData(
+  numCandles: number,
+  trend: 'up' | 'down',
+  basePrice: number = 100
+): KLineDataPoint[] {
+  const data: KLineDataPoint[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const trendMultiplier = trend === 'up' ? 1 : -1;
+
+  for (let i = 0; i < numCandles; i++) {
+    const change = trendMultiplier * (0.5 + Math.random() * 0.5);
+    const open = basePrice;
+    const close = basePrice + change;
+    const high = Math.max(open, close) + Math.random() * 0.2;
+    const low = Math.min(open, close) - Math.random() * 0.2;
+
+    data.push({
+      time: now - (numCandles - i) * 3600,
+      open,
+      high,
+      low,
+      close,
+      volume: Math.floor(Math.random() * 10000) + 1000,
+    });
+
+    basePrice = close;
+  }
+
+  return data;
+}
+
+// Mock strategy context
+function createMockContext(): StrategyContext {
+  return {
+    portfolio: {
+      cash: 10000,
+      positions: [],
+      totalValue: 10000,
+      unrealizedPnL: 0,
+      timestamp: Date.now(),
+    },
+    clock: Date.now(),
+    getMarketData: () => ({
+      orderBook: {} as any,
+      trades: [],
+      timestamp: Date.now(),
+    }),
+    getPosition: () => 0,
+    getCash: () => 10000,
+  };
+}
+
+describe('MultiTimeframeSMAStrategy', () => {
+  describe('constructor', () => {
+    it('should create strategy with default parameters', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h', '4h', '1d'],
+      });
+
+      expect(strategy.getConfig().id).toBe('test-sma');
+      expect(strategy.getConfig().name).toBe('Test SMA Strategy');
+      expect(strategy.getTimeframes()).toEqual(['1h', '4h', '1d']);
+    });
+
+    it('should create strategy with custom parameters', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h', '4h'],
+        shortPeriod: 5,
+        longPeriod: 20,
+        tradeQuantity: 100,
+      });
+
+      expect(strategy.getTimeframes()).toEqual(['1h', '4h']);
+    });
+  });
+
+  describe('analyzeTimeframe', () => {
+    it('should return null when not enough data', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 10,
+        longPeriod: 30,
+      });
+
+      // Only provide 20 candles, but we need 31
+      const data = generateKLineData(20);
+      strategy.updateKLineData('1h', data);
+
+      const signal = strategy.analyzeTimeframe('1h');
+      expect(signal).toBeNull();
+    });
+
+    it('should analyze timeframe and return a valid signal', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      // Generate trending data (consistent trend, no crossover)
+      const data = generateTrendingKLineData(50, 'up');
+      strategy.updateKLineData('1h', data);
+
+      // First analysis - no previous data
+      strategy.analyzeTimeframe('1h');
+      
+      // Second analysis - still trending, should hold
+      const signal = strategy.analyzeTimeframe('1h');
+      expect([ 'buy', 'sell', 'hold' ]).toContain(signal?.type);
+    });
+
+    it('should detect golden cross', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      // Generate data that starts downtrend and then uptrend
+      const downTrendData = generateTrendingKLineData(30, 'down', 100);
+      const upTrendData = generateTrendingKLineData(30, 'up', downTrendData[downTrendData.length - 1].close);
+      
+      const data = [...downTrendData, ...upTrendData];
+      strategy.updateKLineData('1h', data);
+
+      // Analyze multiple times to detect crossover
+      strategy.analyzeTimeframe('1h');
+      const signal = strategy.analyzeTimeframe('1h');
+
+      // After trending up, we should see a buy or hold signal
+      expect(['buy', 'hold']).toContain(signal?.type);
+    });
+  });
+
+  describe('analyzeAllTimeframes', () => {
+    it('should analyze all configured timeframes', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h', '4h', '1d'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      // Provide data for all timeframes
+      strategy.updateKLineData('1h', generateKLineData(50));
+      strategy.updateKLineData('4h', generateKLineData(50));
+      strategy.updateKLineData('1d', generateKLineData(50));
+
+      const signals = strategy.analyzeAllTimeframes();
+
+      expect(signals.length).toBe(3);
+      expect(signals.map(s => s.timeframe)).toEqual(['1h', '4h', '1d']);
+    });
+  });
+
+  describe('getCombinedSignal', () => {
+    it('should return null when no signals', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      const signal = strategy.getCombinedSignal();
+      expect(signal).toBeNull();
+    });
+
+    it('should combine signals from multiple timeframes', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h', '4h', '1d'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      // Provide data and analyze
+      strategy.updateKLineData('1h', generateKLineData(50));
+      strategy.updateKLineData('4h', generateKLineData(50));
+      strategy.updateKLineData('1d', generateKLineData(50));
+
+      strategy.analyzeAllTimeframes();
+
+      const combined = strategy.getCombinedSignal();
+
+      expect(combined).not.toBeNull();
+      expect(combined?.signals.length).toBe(3);
+      expect(['buy', 'sell', 'hold']).toContain(combined?.combinedType);
+    });
+  });
+
+  describe('getSMAValues', () => {
+    it('should return current SMA values', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      const data = generateKLineData(50);
+      strategy.updateKLineData('1h', data);
+
+      // Analyze to calculate SMA
+      strategy.analyzeTimeframe('1h');
+
+      const smaValues = strategy.getSMAValues('1h');
+
+      expect(smaValues.short).toBeGreaterThan(0);
+      expect(smaValues.long).toBeGreaterThan(0);
+    });
+  });
+
+  describe('clearSignals', () => {
+    it('should clear all signals', () => {
+      const strategy = new MultiTimeframeSMAStrategy({
+        id: 'test-sma',
+        name: 'Test SMA Strategy',
+        timeframes: ['1h'],
+        shortPeriod: 5,
+        longPeriod: 10,
+      });
+
+      strategy.updateKLineData('1h', generateKLineData(50));
+      strategy.analyzeAllTimeframes();
+
+      expect(strategy.getAllTimeframeSignals().size).toBeGreaterThan(0);
+
+      strategy.clearSignals();
+
+      expect(strategy.getAllTimeframeSignals().size).toBe(0);
+      expect(strategy.getLastCombinedSignal()).toBeNull();
+    });
+  });
+});

--- a/src/multi-timeframe/__tests__/types.test.ts
+++ b/src/multi-timeframe/__tests__/types.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for Multi-Timeframe Types
+ */
+
+import {
+  Timeframe,
+  ALL_TIMEFRAMES,
+  TIMEFRAME_LABELS,
+  TIMEFRAME_DURATIONS,
+  parseTimeframe,
+  isValidTimeframe,
+  getDefaultTimeframeWeights,
+  aggregateSignals,
+  TimeframeSignal,
+  TimeframeWeight,
+} from '../types';
+
+describe('Multi-Timeframe Types', () => {
+  describe('ALL_TIMEFRAMES', () => {
+    it('should contain all supported timeframes', () => {
+      expect(ALL_TIMEFRAMES).toEqual(['1m', '5m', '15m', '1h', '4h', '1d']);
+    });
+  });
+
+  describe('TIMEFRAME_LABELS', () => {
+    it('should have labels for all timeframes', () => {
+      for (const tf of ALL_TIMEFRAMES) {
+        expect(TIMEFRAME_LABELS[tf]).toBeDefined();
+        expect(typeof TIMEFRAME_LABELS[tf]).toBe('string');
+      }
+    });
+  });
+
+  describe('TIMEFRAME_DURATIONS', () => {
+    it('should have correct durations in milliseconds', () => {
+      expect(TIMEFRAME_DURATIONS['1m']).toBe(60 * 1000);
+      expect(TIMEFRAME_DURATIONS['5m']).toBe(5 * 60 * 1000);
+      expect(TIMEFRAME_DURATIONS['15m']).toBe(15 * 60 * 1000);
+      expect(TIMEFRAME_DURATIONS['1h']).toBe(60 * 60 * 1000);
+      expect(TIMEFRAME_DURATIONS['4h']).toBe(4 * 60 * 60 * 1000);
+      expect(TIMEFRAME_DURATIONS['1d']).toBe(24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('parseTimeframe', () => {
+    it('should return valid timeframe', () => {
+      expect(parseTimeframe('1h')).toBe('1h');
+      expect(parseTimeframe('1d')).toBe('1d');
+      expect(parseTimeframe('15m')).toBe('15m');
+    });
+
+    it('should return null for invalid timeframe', () => {
+      expect(parseTimeframe('2h')).toBeNull();
+      expect(parseTimeframe('invalid')).toBeNull();
+      expect(parseTimeframe('')).toBeNull();
+    });
+  });
+
+  describe('isValidTimeframe', () => {
+    it('should return true for valid timeframes', () => {
+      expect(isValidTimeframe('1m')).toBe(true);
+      expect(isValidTimeframe('1h')).toBe(true);
+      expect(isValidTimeframe('1d')).toBe(true);
+    });
+
+    it('should return false for invalid timeframes', () => {
+      expect(isValidTimeframe('2h')).toBe(false);
+      expect(isValidTimeframe('invalid')).toBe(false);
+    });
+  });
+
+  describe('getDefaultTimeframeWeights', () => {
+    it('should return weights that sum to 1', () => {
+      const weights = getDefaultTimeframeWeights(['1h', '4h', '1d']);
+      const sum = weights.reduce((acc, w) => acc + w.weight, 0);
+      expect(sum).toBeCloseTo(1, 5);
+    });
+
+    it('should return weights for all provided timeframes', () => {
+      const timeframes: Timeframe[] = ['1h', '4h', '1d'];
+      const weights = getDefaultTimeframeWeights(timeframes);
+      
+      expect(weights).toHaveLength(3);
+      expect(weights.map(w => w.timeframe)).toEqual(timeframes);
+    });
+
+    it('should give higher weights to longer timeframes', () => {
+      const weights = getDefaultTimeframeWeights(['1m', '1h', '1d']);
+      
+      const weight1m = weights.find(w => w.timeframe === '1m')?.weight ?? 0;
+      const weight1h = weights.find(w => w.timeframe === '1h')?.weight ?? 0;
+      const weight1d = weights.find(w => w.timeframe === '1d')?.weight ?? 0;
+      
+      expect(weight1h).toBeGreaterThan(weight1m);
+      expect(weight1d).toBeGreaterThan(weight1m);
+    });
+  });
+
+  describe('aggregateSignals', () => {
+    const createMockSignal = (
+      timeframe: Timeframe,
+      type: 'buy' | 'sell' | 'hold',
+      strength: number
+    ): TimeframeSignal => ({
+      timeframe,
+      type,
+      strength,
+      price: 100,
+      timestamp: Date.now(),
+      metadata: { symbol: 'BTC/USDT' },
+    });
+
+    const createMockWeights = (timeframes: Timeframe[]): TimeframeWeight[] => {
+      const weight = 1 / timeframes.length;
+      return timeframes.map(tf => ({ timeframe: tf, weight }));
+    };
+
+    it('should return null for empty signals', () => {
+      const result = aggregateSignals([], []);
+      expect(result).toBeNull();
+    });
+
+    it('should aggregate buy signals correctly', () => {
+      const signals: TimeframeSignal[] = [
+        createMockSignal('1h', 'buy', 0.8),
+        createMockSignal('4h', 'buy', 0.7),
+      ];
+      const weights = createMockWeights(['1h', '4h']);
+
+      const result = aggregateSignals(signals, weights);
+
+      expect(result).not.toBeNull();
+      expect(result?.combinedType).toBe('buy');
+      expect(result?.confidence).toBe(1.0); // All signals agree
+    });
+
+    it('should aggregate sell signals correctly', () => {
+      const signals: TimeframeSignal[] = [
+        createMockSignal('1h', 'sell', 0.6),
+        createMockSignal('4h', 'sell', 0.8),
+      ];
+      const weights = createMockWeights(['1h', '4h']);
+
+      const result = aggregateSignals(signals, weights);
+
+      expect(result).not.toBeNull();
+      expect(result?.combinedType).toBe('sell');
+      expect(result?.confidence).toBe(1.0);
+    });
+
+    it('should handle mixed signals with reduced confidence', () => {
+      const signals: TimeframeSignal[] = [
+        createMockSignal('1h', 'buy', 0.8),
+        createMockSignal('4h', 'sell', 0.6),
+      ];
+      const weights = createMockWeights(['1h', '4h']);
+
+      const result = aggregateSignals(signals, weights);
+
+      expect(result).not.toBeNull();
+      expect(result?.confidence).toBe(0.7); // Two different signal types
+    });
+
+    it('should handle three different signal types', () => {
+      const signals: TimeframeSignal[] = [
+        createMockSignal('1h', 'buy', 0.8),
+        createMockSignal('4h', 'sell', 0.6),
+        createMockSignal('1d', 'hold', 0.5),
+      ];
+      const weights = createMockWeights(['1h', '4h', '1d']);
+
+      const result = aggregateSignals(signals, weights);
+
+      expect(result).not.toBeNull();
+      expect(result?.confidence).toBe(0.4); // Three different signal types
+    });
+  });
+});

--- a/src/multi-timeframe/index.ts
+++ b/src/multi-timeframe/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Multi-Timeframe Analysis Module
+ * 
+ * Provides tools for analyzing multiple timeframes in trading strategies
+ */
+
+// Types
+export * from './types';
+
+// Services
+export { MultiTimeframeDataService, getMultiTimeframeDataService } from './MultiTimeframeDataService';
+
+// Strategy base class
+export { MultiTimeframeStrategy } from './MultiTimeframeStrategy';
+export type { MultiTimeframeStrategyContext } from './MultiTimeframeStrategy';
+
+// Strategy implementations
+export { MultiTimeframeSMAStrategy } from './strategies/MultiTimeframeSMAStrategy';
+export type { MultiTimeframeSMAConfig } from './strategies/MultiTimeframeSMAStrategy';
+
+// Routes
+export { default as multiTimeframeRoutes } from './routes';

--- a/src/multi-timeframe/routes.ts
+++ b/src/multi-timeframe/routes.ts
@@ -1,0 +1,203 @@
+/**
+ * Multi-Timeframe API Routes
+ * 
+ * REST API endpoints for multi-timeframe analysis
+ */
+
+import { Router, Request, Response } from 'express';
+import { 
+  Timeframe, 
+  MultiTimeframeKLineResponse,
+  KLineDataPoint,
+  ALL_TIMEFRAMES,
+  isValidTimeframe,
+} from './types';
+import { getMultiTimeframeDataService } from './MultiTimeframeDataService';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('MultiTimeframeRoutes');
+
+const router = Router();
+
+/**
+ * GET /api/multi-timeframe/kline/:symbol
+ * Get K-line data for multiple timeframes
+ * 
+ * Query params:
+ * - timeframes: comma-separated list of timeframes (e.g., "1h,4h,1d")
+ * - limit: number of candles per timeframe (optional, default: 100)
+ */
+router.get('/kline/:symbol', async (req: Request, res: Response) => {
+  try {
+    const symbolParam = req.params.symbol;
+    const symbol = Array.isArray(symbolParam) ? symbolParam[0] : symbolParam;
+    const timeframesParam = req.query.timeframes as string;
+    const limit = parseInt(req.query.limit as string) || 100;
+
+    if (!symbol) {
+      return res.status(400).json({
+        success: false,
+        error: 'Symbol is required',
+        timestamp: Date.now(),
+      } as MultiTimeframeKLineResponse);
+    }
+
+    // Parse timeframes
+    let timeframes: Timeframe[] = [];
+    if (timeframesParam) {
+      const parsed = timeframesParam.split(',').map(t => t.trim());
+      for (const tf of parsed) {
+        if (!isValidTimeframe(tf)) {
+          return res.status(400).json({
+            success: false,
+            symbol,
+            error: `Invalid timeframe: ${tf}. Valid timeframes: ${ALL_TIMEFRAMES.join(', ')}`,
+            data: {},
+            timestamp: Date.now(),
+          } as MultiTimeframeKLineResponse);
+        }
+        timeframes.push(tf as Timeframe);
+      }
+    } else {
+      // Default to all timeframes
+      timeframes = [...ALL_TIMEFRAMES];
+    }
+
+    log.info(`Fetching multi-timeframe data for ${symbol}`, { timeframes, limit });
+
+    // Get data service
+    const dataService = getMultiTimeframeDataService();
+
+    // Fetch data for all timeframes
+    const mtfData = await dataService.getMultiTimeframeData(symbol, timeframes, limit);
+
+    // Convert Map to Record for JSON response
+    const dataRecord: Record<string, KLineDataPoint[]> = {};
+    for (const [tf, data] of mtfData.data) {
+      dataRecord[tf] = data;
+    }
+
+    const response: MultiTimeframeKLineResponse = {
+      success: true,
+      symbol,
+      data: dataRecord,
+      timestamp: mtfData.timestamp,
+    };
+
+    res.json(response);
+  } catch (error: any) {
+    log.error('Failed to fetch multi-timeframe K-line data', error);
+    const symbolParam = req.params.symbol;
+    const symbol = Array.isArray(symbolParam) ? symbolParam[0] : symbolParam || '';
+    res.status(500).json({
+      success: false,
+      symbol,
+      error: error.message || 'Internal server error',
+      data: {},
+      timestamp: Date.now(),
+    } as MultiTimeframeKLineResponse);
+  }
+});
+
+/**
+ * GET /api/multi-timeframe/timeframes
+ * Get list of supported timeframes
+ */
+router.get('/timeframes', (req: Request, res: Response) => {
+  res.json({
+    success: true,
+    timeframes: ALL_TIMEFRAMES.map(tf => ({
+      id: tf,
+      label: getLabel(tf),
+      duration: getDuration(tf),
+    })),
+    timestamp: Date.now(),
+  });
+});
+
+/**
+ * GET /api/multi-timeframe/cache/stats
+ * Get cache statistics
+ */
+router.get('/cache/stats', (req: Request, res: Response) => {
+  try {
+    const dataService = getMultiTimeframeDataService();
+    const stats = dataService.getCacheStats();
+    
+    res.json({
+      success: true,
+      stats: {
+        ...stats,
+        symbols: Array.from(stats.symbols),
+        timeframes: Array.from(stats.timeframes),
+      },
+      timestamp: Date.now(),
+    });
+  } catch (error: any) {
+    log.error('Failed to get cache stats', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+      timestamp: Date.now(),
+    });
+  }
+});
+
+/**
+ * DELETE /api/multi-timeframe/cache/:symbol?
+ * Clear cache for a specific symbol or all symbols
+ */
+router.delete('/cache/:symbol?', (req: Request, res: Response) => {
+  try {
+    const symbolParam = req.params.symbol;
+    const symbol = symbolParam ? (Array.isArray(symbolParam) ? symbolParam[0] : symbolParam) : undefined;
+    const dataService = getMultiTimeframeDataService();
+    
+    dataService.clearCache(symbol);
+    
+    res.json({
+      success: true,
+      message: symbol ? `Cache cleared for ${symbol}` : 'All cache cleared',
+      timestamp: Date.now(),
+    });
+  } catch (error: any) {
+    log.error('Failed to clear cache', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+      timestamp: Date.now(),
+    });
+  }
+});
+
+/**
+ * Helper function to get timeframe label
+ */
+function getLabel(tf: Timeframe): string {
+  const labels: Record<Timeframe, string> = {
+    '1m': '1分钟',
+    '5m': '5分钟',
+    '15m': '15分钟',
+    '1h': '1小时',
+    '4h': '4小时',
+    '1d': '1天',
+  };
+  return labels[tf];
+}
+
+/**
+ * Helper function to get timeframe duration in milliseconds
+ */
+function getDuration(tf: Timeframe): number {
+  const durations: Record<Timeframe, number> = {
+    '1m': 60 * 1000,
+    '5m': 5 * 60 * 1000,
+    '15m': 15 * 60 * 1000,
+    '1h': 60 * 60 * 1000,
+    '4h': 4 * 60 * 60 * 1000,
+    '1d': 24 * 60 * 60 * 1000,
+  };
+  return durations[tf];
+}
+
+export default router;

--- a/src/multi-timeframe/strategies/MultiTimeframeSMAStrategy.ts
+++ b/src/multi-timeframe/strategies/MultiTimeframeSMAStrategy.ts
@@ -1,0 +1,198 @@
+/**
+ * Multi-Timeframe SMA Strategy
+ * 
+ * A simple moving average crossover strategy that analyzes multiple timeframes
+ * and combines signals to make trading decisions.
+ */
+
+import { MultiTimeframeStrategy } from '../MultiTimeframeStrategy';
+import {
+  Timeframe,
+  KLineDataPoint,
+  TimeframeSignal,
+  TimeframeWeight,
+} from '../types';
+import { createLogger } from '../../utils/logger';
+
+const log = createLogger('MultiTimeframeSMAStrategy');
+
+/**
+ * Configuration for Multi-Timeframe SMA Strategy
+ */
+export interface MultiTimeframeSMAConfig {
+  /** Strategy ID */
+  id: string;
+  /** Strategy name */
+  name: string;
+  /** Timeframes to analyze */
+  timeframes: Timeframe[];
+  /** Short period for SMA */
+  shortPeriod?: number;
+  /** Long period for SMA */
+  longPeriod?: number;
+  /** Trade quantity */
+  tradeQuantity?: number;
+  /** Signal threshold (0-1) */
+  signalThreshold?: number;
+  /** Timeframe weights */
+  timeframeWeights?: TimeframeWeight[];
+}
+
+/**
+ * Multi-Timeframe SMA Strategy Implementation
+ * 
+ * Analyzes SMA crossovers across multiple timeframes and combines signals:
+ * - Golden cross (short SMA > long SMA) -> Buy signal
+ * - Death cross (short SMA < long SMA) -> Sell signal
+ */
+export class MultiTimeframeSMAStrategy extends MultiTimeframeStrategy {
+  private shortPeriod: number;
+  private longPeriod: number;
+  private tradeQuantity: number;
+
+  // Cache for SMA values
+  private shortSMA: Map<Timeframe, number> = new Map();
+  private longSMA: Map<Timeframe, number> = new Map();
+  private previousShortSMA: Map<Timeframe, number> = new Map();
+  private previousLongSMA: Map<Timeframe, number> = new Map();
+
+  constructor(config: MultiTimeframeSMAConfig) {
+    super({
+      id: config.id,
+      name: config.name,
+      timeframes: config.timeframes,
+      timeframeWeights: config.timeframeWeights,
+      signalThreshold: config.signalThreshold,
+      params: {
+        shortPeriod: config.shortPeriod ?? 10,
+        longPeriod: config.longPeriod ?? 30,
+        tradeQuantity: config.tradeQuantity ?? 10,
+      },
+    });
+
+    this.shortPeriod = config.shortPeriod ?? 10;
+    this.longPeriod = config.longPeriod ?? 30;
+    this.tradeQuantity = config.tradeQuantity ?? 10;
+
+    log.info(`MultiTimeframeSMAStrategy created`, {
+      timeframes: config.timeframes,
+      shortPeriod: this.shortPeriod,
+      longPeriod: this.longPeriod,
+    });
+  }
+
+  /**
+   * Calculate SMA for given data
+   */
+  private calculateSMA(data: KLineDataPoint[], period: number): number {
+    if (data.length < period) {
+      return 0;
+    }
+
+    const slice = data.slice(-period);
+    const sum = slice.reduce((acc, d) => acc + d.close, 0);
+    return sum / period;
+  }
+
+  /**
+   * Analyze a specific timeframe for SMA crossover
+   */
+  analyzeTimeframe(timeframe: Timeframe): TimeframeSignal | null {
+    const data = this.getKLineData(timeframe);
+    
+    if (!data || data.length < this.longPeriod + 1) {
+      log.debug(`Not enough data for ${timeframe}`);
+      return null;
+    }
+
+    // Store previous SMA values
+    const prevShort = this.shortSMA.get(timeframe) ?? 0;
+    const prevLong = this.longSMA.get(timeframe) ?? 0;
+
+    // Calculate current SMA values
+    const currentShort = this.calculateSMA(data, this.shortPeriod);
+    const currentLong = this.calculateSMA(data, this.longPeriod);
+
+    // Store for next iteration
+    this.previousShortSMA.set(timeframe, prevShort);
+    this.previousLongSMA.set(timeframe, prevLong);
+    this.shortSMA.set(timeframe, currentShort);
+    this.longSMA.set(timeframe, currentLong);
+
+    // Get current price
+    const price = data[data.length - 1].close;
+
+    // Detect crossover
+    const wasGoldenCross = prevShort <= prevLong;
+    const isGoldenCross = currentShort > currentLong;
+    const wasDeathCross = prevShort >= prevLong;
+    const isDeathCross = currentShort < currentLong;
+
+    // Generate signal
+    if (isGoldenCross && wasGoldenCross === false) {
+      // Golden cross - buy signal
+      const strength = Math.min(1, (currentShort - currentLong) / currentLong * 10 + 0.5);
+      return {
+        timeframe,
+        type: 'buy',
+        strength,
+        price,
+        timestamp: Date.now(),
+        metadata: {
+          symbol: 'unknown',
+          shortSMA: currentShort,
+          longSMA: currentLong,
+          crossover: 'golden',
+        },
+      };
+    } else if (isDeathCross && wasDeathCross === false) {
+      // Death cross - sell signal
+      const strength = Math.min(1, (currentLong - currentShort) / currentLong * 10 + 0.5);
+      return {
+        timeframe,
+        type: 'sell',
+        strength,
+        price,
+        timestamp: Date.now(),
+        metadata: {
+          symbol: 'unknown',
+          shortSMA: currentShort,
+          longSMA: currentLong,
+          crossover: 'death',
+        },
+      };
+    }
+
+    // No crossover - hold
+    return {
+      timeframe,
+      type: 'hold',
+      strength: 0.1,
+      price,
+      timestamp: Date.now(),
+      metadata: {
+        symbol: 'unknown',
+        shortSMA: currentShort,
+        longSMA: currentLong,
+        trend: currentShort > currentLong ? 'up' : 'down',
+      },
+    };
+  }
+
+  /**
+   * Get current SMA values for a timeframe
+   */
+  getSMAValues(timeframe: Timeframe): {
+    short: number;
+    long: number;
+    previousShort: number;
+    previousLong: number;
+  } {
+    return {
+      short: this.shortSMA.get(timeframe) ?? 0,
+      long: this.longSMA.get(timeframe) ?? 0,
+      previousShort: this.previousShortSMA.get(timeframe) ?? 0,
+      previousLong: this.previousLongSMA.get(timeframe) ?? 0,
+    };
+  }
+}

--- a/src/multi-timeframe/types.ts
+++ b/src/multi-timeframe/types.ts
@@ -1,0 +1,337 @@
+/**
+ * Multi-Timeframe Types
+ * 
+ * Type definitions for multi-timeframe analysis functionality
+ * Supports multiple timeframe K-line data and strategy signals
+ */
+
+/**
+ * Supported timeframe values
+ * - 1m: 1 minute
+ * - 5m: 5 minutes
+ * - 15m: 15 minutes
+ * - 1h: 1 hour
+ * - 4h: 4 hours
+ * - 1d: 1 day
+ */
+export type Timeframe = '1m' | '5m' | '15m' | '1h' | '4h' | '1d';
+
+/**
+ * All supported timeframes array for iteration
+ */
+export const ALL_TIMEFRAMES: Timeframe[] = ['1m', '5m', '15m', '1h', '4h', '1d'];
+
+/**
+ * Timeframe display labels in Chinese
+ */
+export const TIMEFRAME_LABELS: Record<Timeframe, string> = {
+  '1m': '1分钟',
+  '5m': '5分钟',
+  '15m': '15分钟',
+  '1h': '1小时',
+  '4h': '4小时',
+  '1d': '1天',
+};
+
+/**
+ * Timeframe duration in milliseconds
+ */
+export const TIMEFRAME_DURATIONS: Record<Timeframe, number> = {
+  '1m': 60 * 1000,
+  '5m': 5 * 60 * 1000,
+  '15m': 15 * 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '4h': 4 * 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+};
+
+/**
+ * K-line data point with timeframe information
+ */
+export interface TimeframeKLineData {
+  /** Timeframe of this data */
+  timeframe: Timeframe;
+  /** Symbol (e.g., 'BTC/USDT') */
+  symbol: string;
+  /** Array of OHLCV data points */
+  data: KLineDataPoint[];
+}
+
+/**
+ * Single K-line OHLCV data point
+ */
+export interface KLineDataPoint {
+  /** Timestamp in seconds (Unix timestamp) */
+  time: number;
+  /** Opening price */
+  open: number;
+  /** Highest price */
+  high: number;
+  /** Lowest price */
+  low: number;
+  /** Closing price */
+  close: number;
+  /** Trading volume */
+  volume: number;
+}
+
+/**
+ * Multi-timeframe K-line data response
+ * Contains K-line data for multiple timeframes
+ */
+export interface MultiTimeframeKLineData {
+  /** Symbol (e.g., 'BTC/USDT') */
+  symbol: string;
+  /** K-line data mapped by timeframe */
+  data: Map<Timeframe, KLineDataPoint[]>;
+  /** Data timestamp */
+  timestamp: number;
+}
+
+/**
+ * Strategy signal from a specific timeframe
+ */
+export interface TimeframeSignal {
+  /** Timeframe that generated this signal */
+  timeframe: Timeframe;
+  /** Signal type */
+  type: 'buy' | 'sell' | 'hold';
+  /** Signal strength (0-1) */
+  strength: number;
+  /** Price when signal was generated */
+  price: number;
+  /** Timestamp of signal */
+  timestamp: number;
+  /** Additional signal metadata */
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Multi-timeframe signal aggregation
+ * Combines signals from multiple timeframes into a unified signal
+ */
+export interface MultiTimeframeSignal {
+  /** Symbol */
+  symbol: string;
+  /** Combined signal type */
+  combinedType: 'buy' | 'sell' | 'hold';
+  /** Combined signal strength (weighted average) */
+  combinedStrength: number;
+  /** Individual timeframe signals */
+  signals: TimeframeSignal[];
+  /** Timestamp of combined signal */
+  timestamp: number;
+  /** Confidence score based on signal alignment */
+  confidence: number;
+}
+
+/**
+ * Timeframe weight configuration
+ * Used for weighted signal aggregation
+ */
+export interface TimeframeWeight {
+  /** Timeframe */
+  timeframe: Timeframe;
+  /** Weight (0-1, weights should sum to 1) */
+  weight: number;
+}
+
+/**
+ * Multi-timeframe strategy configuration
+ */
+export interface MultiTimeframeStrategyConfig {
+  /** Strategy ID */
+  id: string;
+  /** Strategy name */
+  name: string;
+  /** Timeframes to analyze */
+  timeframes: Timeframe[];
+  /** Weight for each timeframe (optional, defaults to equal weights) */
+  timeframeWeights?: TimeframeWeight[];
+  /** Minimum signal threshold to generate combined signal */
+  signalThreshold?: number;
+  /** Strategy-specific parameters */
+  params?: Record<string, any>;
+}
+
+/**
+ * Multi-timeframe data context for strategies
+ * Provides access to data across multiple timeframes
+ */
+export interface MultiTimeframeContext {
+  /** Symbol being analyzed */
+  symbol: string;
+  /** Get K-line data for a specific timeframe */
+  getKLineData(timeframe: Timeframe): KLineDataPoint[] | null;
+  /** Get current price */
+  getCurrentPrice(): number;
+  /** Get signal for a specific timeframe */
+  getSignal(timeframe: Timeframe): TimeframeSignal | null;
+  /** Get all timeframe signals */
+  getAllSignals(): TimeframeSignal[];
+  /** Get combined multi-timeframe signal */
+  getCombinedSignal(): MultiTimeframeSignal | null;
+  /** Timestamp of context */
+  timestamp: number;
+}
+
+/**
+ * Request parameters for multi-timeframe K-line API
+ */
+export interface MultiTimeframeKLineRequest {
+  /** Symbol (e.g., 'BTC/USDT') */
+  symbol: string;
+  /** Timeframes to fetch */
+  timeframes: Timeframe[];
+  /** Number of candles per timeframe (optional, default varies by timeframe) */
+  limit?: number;
+}
+
+/**
+ * Response from multi-timeframe K-line API
+ */
+export interface MultiTimeframeKLineResponse {
+  /** Success flag */
+  success: boolean;
+  /** Symbol */
+  symbol: string;
+  /** K-line data by timeframe */
+  data: Record<string, KLineDataPoint[]>;
+  /** Error message if failed */
+  error?: string;
+  /** Response timestamp */
+  timestamp: number;
+}
+
+/**
+ * Backtest configuration with multi-timeframe support
+ */
+export interface MultiTimeframeBacktestConfig {
+  /** Initial capital */
+  capital: number;
+  /** Trading symbol */
+  symbol: string;
+  /** Backtest start time */
+  startTime: number;
+  /** Backtest end time */
+  endTime: number;
+  /** Strategy to use */
+  strategy: string;
+  /** Strategy parameters */
+  strategyParams?: Record<string, any>;
+  /** Timeframes to use in analysis */
+  timeframes: Timeframe[];
+  /** Primary timeframe for trade execution */
+  primaryTimeframe: Timeframe;
+  /** Timeframe weights for signal aggregation */
+  timeframeWeights?: TimeframeWeight[];
+  /** Tick interval in milliseconds */
+  tickInterval?: number;
+}
+
+/**
+ * Utility function to parse timeframe string
+ */
+export function parseTimeframe(tf: string): Timeframe | null {
+  if (ALL_TIMEFRAMES.includes(tf as Timeframe)) {
+    return tf as Timeframe;
+  }
+  return null;
+}
+
+/**
+ * Utility function to validate timeframe
+ */
+export function isValidTimeframe(tf: string): tf is Timeframe {
+  return ALL_TIMEFRAMES.includes(tf as Timeframe);
+}
+
+/**
+ * Utility function to get default timeframe weights
+ * Higher timeframes get higher weights by default
+ */
+export function getDefaultTimeframeWeights(timeframes: Timeframe[]): TimeframeWeight[] {
+  const weights: Record<Timeframe, number> = {
+    '1m': 0.05,
+    '5m': 0.10,
+    '15m': 0.15,
+    '1h': 0.25,
+    '4h': 0.25,
+    '1d': 0.20,
+  };
+
+  const totalWeight = timeframes.reduce((sum, tf) => sum + weights[tf], 0);
+  
+  return timeframes.map(tf => ({
+    timeframe: tf,
+    weight: weights[tf] / totalWeight, // Normalize weights
+  }));
+}
+
+/**
+ * Utility function to aggregate signals from multiple timeframes
+ */
+export function aggregateSignals(
+  signals: TimeframeSignal[],
+  weights: TimeframeWeight[]
+): MultiTimeframeSignal | null {
+  if (signals.length === 0) return null;
+
+  // Filter valid signals and map to weights
+  const weightedSignals = signals.map(signal => {
+    const weight = weights.find(w => w.timeframe === signal.timeframe);
+    return {
+      signal,
+      weight: weight?.weight ?? 0,
+    };
+  });
+
+  // Calculate weighted strength for each signal type
+  let buyStrength = 0;
+  let sellStrength = 0;
+  let holdStrength = 0;
+
+  for (const { signal, weight } of weightedSignals) {
+    const weightedValue = signal.strength * weight;
+    switch (signal.type) {
+      case 'buy':
+        buyStrength += weightedValue;
+        break;
+      case 'sell':
+        sellStrength += weightedValue;
+        break;
+      case 'hold':
+        holdStrength += weightedValue;
+        break;
+    }
+  }
+
+  // Determine combined signal type and strength
+  let combinedType: 'buy' | 'sell' | 'hold';
+  let combinedStrength: number;
+
+  if (buyStrength > sellStrength && buyStrength > holdStrength) {
+    combinedType = 'buy';
+    combinedStrength = buyStrength;
+  } else if (sellStrength > buyStrength && sellStrength > holdStrength) {
+    combinedType = 'sell';
+    combinedStrength = sellStrength;
+  } else {
+    combinedType = 'hold';
+    combinedStrength = holdStrength;
+  }
+
+  // Calculate confidence based on signal alignment
+  const signalTypes = new Set(signals.map(s => s.type));
+  const confidence = signalTypes.size === 1 ? 1.0 : 
+                     signalTypes.size === 2 ? 0.7 : 0.4;
+
+  return {
+    symbol: signals[0].metadata?.symbol ?? '',
+    combinedType,
+    combinedStrength,
+    signals,
+    timestamp: Date.now(),
+    confidence,
+  };
+}


### PR DESCRIPTION
## Summary

Implements Issue #293: Multi-Timeframe Analysis

This PR adds comprehensive support for analyzing multiple timeframes in trading strategies.

## Features

### 1. Multi-Timeframe Type System
- Support for 6 timeframes: 1m, 5m, 15m, 1h, 4h, 1d
- Type definitions for K-line data, signals, and strategy configurations
- Utility functions for timeframe parsing, validation, and weight calculation

### 2. MultiTimeframeDataService
- Intelligent caching with timeframe-aware TTL
- Support for custom data generators
- Parallel data fetching for multiple timeframes
- Cache statistics and management

### 3. MultiTimeframeStrategy Base Class
- Abstract base class for multi-timeframe strategies
- Weighted signal aggregation
- Confidence scoring based on signal alignment
- Easy-to-extend interface

### 4. MultiTimeframeSMAStrategy Implementation
- SMA crossover detection across multiple timeframes
- Golden cross (buy) and death cross (sell) signals
- Configurable short and long periods

### 5. REST API Endpoints
- `GET /api/multi-timeframe/kline/:symbol` - Get K-line data for multiple timeframes
- `GET /api/multi-timeframe/timeframes` - Get list of supported timeframes
- `GET /api/multi-timeframe/cache/stats` - Get cache statistics
- `DELETE /api/multi-timeframe/cache/:symbol?` - Clear cache

### 6. Test Coverage
- Unit tests for all type utilities
- Unit tests for MultiTimeframeDataService
- Unit tests for MultiTimeframeSMAStrategy
- All 38 tests passing

## Technical Details

- **Default Timeframe Weights**: Higher timeframes get higher weights by default (1h: 0.36, 4h: 0.36, 1d: 0.29)
- **Signal Aggregation**: Weighted average of signals from all timeframes
- **Confidence Score**: Based on signal alignment (1.0 = all agree, 0.7 = two types, 0.4 = three types)
- **Cache TTL**: Scales with timeframe duration (minimum 60s, up to 1/10 of timeframe duration)

## Usage Example

```typescript
import { MultiTimeframeSMAStrategy } from './multi-timeframe';

const strategy = new MultiTimeframeSMAStrategy({
  id: 'mtf-sma',
  name: 'Multi-Timeframe SMA',
  timeframes: ['1h', '4h', '1d'],
  shortPeriod: 10,
  longPeriod: 30,
});

// Update K-line data
strategy.updateKLineData('1h', klineData1h);
strategy.updateKLineData('4h', klineData4h);
strategy.updateKLineData('1d', klineData1d);

// Analyze and get combined signal
const signals = strategy.analyzeAllTimeframes();
const combined = strategy.getCombinedSignal();
```

## Test Results

```
Test Suites: 3 passed, 3 total
Tests:       38 passed, 38 total
```

Closes #293

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-timeframe module and publicly exposed `/api/multi-timeframe/*` endpoints, introducing new caching/data-generation and signal-aggregation logic that could affect trading decisions if integrated incorrectly.
> 
> **Overview**
> Adds a new **multi-timeframe analysis** module that defines timeframe/K-line/signal types plus utilities for validating timeframes, computing default weights, and aggregating per-timeframe signals into a combined signal with a confidence score.
> 
> Introduces `MultiTimeframeDataService` with in-memory caching (timeframe-aware TTL), optional custom data generators, cache stats/clearing, and a singleton accessor; and adds `MultiTimeframeStrategy` as an abstract base to manage per-timeframe K-line inputs, generate/aggregate signals, and emit an `OrderSignal` when the combined signal exceeds a threshold.
> 
> Adds a reference implementation `MultiTimeframeSMAStrategy` (SMA crossover across timeframes) and wires up new REST endpoints under `server.ts` at `GET /api/multi-timeframe/kline/:symbol`, `GET /timeframes`, `GET /cache/stats`, and `DELETE /cache/:symbol?`, with accompanying unit tests for the service, types, and SMA strategy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26925297b8ab723a240d2e82c57f392bccbf9f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->