### PR TITLE
fix: add advanced order types (TWAP, Iceberg, OCO) to order type selector

### DIFF
--- a/src/client/components/TradingOrder.tsx
+++ b/src/client/components/TradingOrder.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Card,
   Tabs,
@@ -20,6 +21,7 @@ import {
   IconCheckCircle, 
   IconInfoCircle,
   IconDelete,
+  IconExperiment,
 } from '@arco-design/web-react/icon';
 import { useOrderBook } from '../hooks/useData';
 import { usePortfolio } from '../hooks/useData';
@@ -28,7 +30,7 @@ import { api } from '../utils/api';
 const { Text } = Typography;
 const { TabPane } = Tabs;
 
-export type OrderType = 'limit' | 'market' | 'stop_loss' | 'take_profit';
+export type OrderType = 'limit' | 'market' | 'stop_loss' | 'take_profit' | 'advanced';
 export type OrderSide = 'buy' | 'sell';
 
 interface OrderFormData {
@@ -157,6 +159,7 @@ const TradingOrder: React.FC<TradingOrderProps> = ({
   const [orderSuccess, setOrderSuccess] = useState(false);
   const [successOrderId, setSuccessOrderId] = useState<string | null>(null);
   const [formPrice, setFormPrice] = useState<number | undefined>(undefined);
+  const navigate = useNavigate();
   const formRef = React.useRef<FormInstance>(null);
 
   // Inject success animation style
@@ -751,6 +754,7 @@ const TradingOrder: React.FC<TradingOrderProps> = ({
               { label: '限价单', value: 'limit' },
               { label: '止损单', value: 'stop_loss' },
               { label: '止盈单', value: 'take_profit' },
+              { label: '高级订单', value: 'advanced' },
             ]}
             direction={isMobile ? 'vertical' : 'horizontal'}
           />
@@ -769,6 +773,58 @@ const TradingOrder: React.FC<TradingOrderProps> = ({
               direction={isMobile ? 'vertical' : 'horizontal'}
             />
           </Form.Item>
+        )}
+
+        {/* Advanced Order Selection */}
+        {orderType === 'advanced' && (
+          <Card 
+            style={{ 
+              marginTop: 16, 
+              background: 'var(--color-fill-1)', 
+              border: '1px dashed var(--color-border)' 
+            }}
+          >
+            <Space direction="vertical" size="medium" style={{ width: '100%' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <IconExperiment style={{ fontSize: 20, color: 'var(--color-primary)' }} />
+                <Text bold>高级订单类型</Text>
+              </div>
+              <Text type="secondary">
+                使用专业工具优化大额交易执行，减少市场冲击
+              </Text>
+              <Space wrap>
+                <Button 
+                  type="outline" 
+                  size="small"
+                  onClick={() => navigate('/advanced-orders?tab=iceberg')}
+                >
+                  冰山订单
+                </Button>
+                <Button 
+                  type="outline" 
+                  size="small"
+                  onClick={() => navigate('/advanced-orders?tab=twap')}
+                >
+                  TWAP 订单
+                </Button>
+                <Button 
+                  type="outline" 
+                  size="small"
+                  onClick={() => navigate('/advanced-orders?tab=oco')}
+                >
+                  OCO 订单
+                </Button>
+              </Space>
+              <Divider style={{ margin: '8px 0' }} />
+              <Button 
+                type="primary" 
+                long
+                onClick={() => navigate('/advanced-orders')}
+              >
+                前往高级订单页面
+              </Button>
+            </Space>
+          </Card>
         )}
 
         {/* Price Input (for limit orders) */}

--- a/src/client/pages/AdvancedOrdersPage.tsx
+++ b/src/client/pages/AdvancedOrdersPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Typography, Space, Tabs, Card, Grid } from '@arco-design/web-react';
 const { Row, Col } = Grid;
 import { IconExperiment, IconClockCircle } from '@arco-design/web-react/icon';
@@ -14,7 +15,18 @@ const { Title, Text } = Typography;
 const { TabPane } = Tabs;
 
 const AdvancedOrdersPage: React.FC = () => {
-  const [activeTab, setActiveTab] = useState('iceberg');
+  const [searchParams] = useSearchParams();
+  
+  // Get initial tab from URL parameter
+  const getInitialTab = (): string => {
+    const tab = searchParams.get('tab');
+    if (tab && ['iceberg', 'twap', 'oco', 'conditional'].includes(tab)) {
+      return tab;
+    }
+    return 'iceberg';
+  };
+  
+  const [activeTab, setActiveTab] = useState(getInitialTab);
   const [symbol] = useState('BTC/USD');
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes the issue where advanced order types (TWAP, Iceberg, OCO) were not accessible from the main trading panel.

## Changes

1. **TradingOrder.tsx**:
   - Added 'advanced' option to  type
   - Added  icon import
   - Added  hook for navigation
   - Added navigation card when '高级订单' is selected, showing:
     - Iceberg Order button
     - TWAP Order button
     - OCO Order button
     - Link to Advanced Orders page

2. **AdvancedOrdersPage.tsx**:
   - Added URL parameter support ()
   - Users can now directly navigate to specific advanced order types

## Testing

- TypeScript compilation: ✅
- Build: ✅
- Lint: ✅ (for modified files)

## Screenshots

When selecting '高级订单' in the order type selector:
- A card appears with buttons for Iceberg, TWAP, and OCO orders
- Users can click to navigate to the specific advanced order type

Fixes #299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds navigation to existing advanced-order workflows and reads a `tab` query param to set initial view; minimal impact on order placement logic.
> 
> **Overview**
> Adds an `advanced` option to the main `TradingOrder` type selector that shows a small *advanced orders* card and deep-links users to `/advanced-orders` (including `?tab=iceberg|twap|oco`).
> 
> Updates `AdvancedOrdersPage` to initialize its active tab from the `tab` URL query parameter, enabling direct linking to specific advanced order forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8720d6e2619ace6b32351aa6e1c6a37392a4b518. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->