### PR TITLE
feat: Add comprehensive API documentation with Swagger UI

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,17 +1,19 @@
 openapi: 3.0.0
 info:
-  title: AlphaArena Trading Bot API
+  title: AlphaArena Trading Platform API
   description: |
-    External API for integrating with AlphaArena trading bot system.
+    Comprehensive API for the AlphaArena algorithmic trading platform.
     
     ## Authentication
-    All API endpoints require authentication via API Key.
-    Include your API key in the `X-API-Key` header.
+    Most API endpoints require authentication. Use one of the following methods:
+    - **API Key**: Include `X-API-Key` header with your API key
+    - **JWT Token**: Include `Authorization: Bearer <token>` header
     
     ## Rate Limits
-    - **read** permission: 60 requests/minute, 10,000 requests/day
-    - **trade** permission: 120 requests/minute, 20,000 requests/day
-    - **admin** permission: 300 requests/minute, 50,000 requests/day
+    Rate limits are based on API key permissions:
+    - **read**: 60 requests/minute, 10,000 requests/day
+    - **trade**: 120 requests/minute, 20,000 requests/day
+    - **admin**: 300 requests/minute, 50,000 requests/day
     
     Rate limit headers are included in every response:
     - `X-RateLimit-Limit-Minute`: Maximum requests per minute
@@ -19,10 +21,23 @@ info:
     - `X-RateLimit-Limit-Day`: Maximum requests per day
     - `X-RateLimit-Remaining-Day`: Remaining requests today
     
+    ## Error Handling
+    All errors follow a consistent format:
+    ```json
+    {
+      "success": false,
+      "error": "Error message",
+      "code": "ERROR_CODE"
+    }
+    ```
+    
   version: 1.0.0
   contact:
     name: AlphaArena Support
     email: support@alphaarena.io
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
 
 servers:
   - url: https://alphaarena-production.up.railway.app/api
@@ -30,230 +45,956 @@ servers:
   - url: http://localhost:3001/api
     description: Development server
 
-security:
-  - ApiKeyAuth: []
-
-components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-      description: API Key for authentication (format: aa_live_xxx or aa_test_xxx)
-
-  schemas:
-    TradingPair:
-      type: object
-      required:
-        - base
-        - quote
-        - symbol
-      properties:
-        base:
-          type: string
-          description: Base currency symbol (e.g., 'BTC')
-          example: BTC
-        quote:
-          type: string
-          description: Quote currency symbol (e.g., 'USDT')
-          example: USDT
-        symbol:
-          type: string
-          description: Full trading pair symbol
-          example: BTCUSDT
-
-    RiskSettings:
-      type: object
-      properties:
-        maxCapitalPerTrade:
-          type: number
-          description: Maximum capital per trade (absolute or percentage)
-          default: 0.1
-        usePercentageCapital:
-          type: boolean
-          description: Use percentage for maxCapitalPerTrade
-          default: true
-        stopLossPercent:
-          type: number
-          description: Stop loss percentage (0-1)
-          default: 0.05
-        takeProfitPercent:
-          type: number
-          description: Take profit percentage (0-1)
-          default: 0.15
-        maxPositionSize:
-          type: number
-          description: Maximum position size
-          default: 1000
-        maxOrdersPerMinute:
-          type: number
-          description: Maximum orders per minute
-          default: 10
-        maxDailyLoss:
-          type: number
-          description: Maximum daily loss (0-1)
-          default: 0.1
-        riskControlEnabled:
-          type: boolean
-          description: Enable risk controls
-          default: true
-
-    BotConfig:
-      type: object
-      required:
-        - id
-        - name
-        - strategy
-        - tradingPair
-        - interval
-        - mode
-        - initialCapital
-      properties:
-        id:
-          type: string
-          description: Unique bot identifier
-        name:
-          type: string
-          description: Bot name
-        description:
-          type: string
-          description: Bot description
-        strategy:
-          type: string
-          enum: [SMA, RSI, MACD, Bollinger, Stochastic, ATR]
-          description: Trading strategy type
-        strategyParams:
-          type: object
-          description: Strategy-specific parameters
-        tradingPair:
-          $ref: '#/components/schemas/TradingPair'
-        interval:
-          type: string
-          enum: [1m, 5m, 15m, 1h, 4h, 1d]
-          description: Time interval for strategy execution
-        mode:
-          type: string
-          enum: [paper, live]
-          description: Trading mode
-        riskSettings:
-          $ref: '#/components/schemas/RiskSettings'
-        initialCapital:
-          type: number
-          description: Initial capital allocation
-        enabled:
-          type: boolean
-          description: Whether bot is enabled
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
-
-    BotState:
-      type: object
-      properties:
-        botId:
-          type: string
-        status:
-          type: string
-          enum: [stopped, running, paused, error]
-        portfolioValue:
-          type: number
-        initialCapital:
-          type: number
-        realizedPnL:
-          type: number
-        unrealizedPnL:
-          type: number
-        totalPnL:
-          type: number
-        tradeCount:
-          type: integer
-        winCount:
-          type: integer
-        lossCount:
-          type: integer
-        positionQuantity:
-          type: number
-        positionAveragePrice:
-          type: number
-        lastSignalTime:
-          type: string
-          format: date-time
-        lastTradeTime:
-          type: string
-          format: date-time
-        lastError:
-          type: string
-        startedAt:
-          type: string
-          format: date-time
-        totalRuntimeMs:
-          type: integer
-
-    CreateBotRequest:
-      type: object
-      required:
-        - name
-        - strategy
-        - tradingPair
-        - initialCapital
-      properties:
-        name:
-          type: string
-          description: Bot name
-        description:
-          type: string
-          description: Bot description
-        strategy:
-          type: string
-          enum: [SMA, RSI, MACD, Bollinger, Stochastic, ATR]
-        strategyParams:
-          type: object
-          description: Strategy-specific parameters
-        tradingPair:
-          $ref: '#/components/schemas/TradingPair'
-        interval:
-          type: string
-          enum: [1m, 5m, 15m, 1h, 4h, 1d]
-          default: 1h
-        mode:
-          type: string
-          enum: [paper, live]
-          default: paper
-        riskSettings:
-          $ref: '#/components/schemas/RiskSettings'
-        initialCapital:
-          type: number
-          minimum: 0
-
-    UpdateBotRequest:
-      type: object
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        strategyParams:
-          type: object
-        riskSettings:
-          $ref: '#/components/schemas/RiskSettings'
-        enabled:
-          type: boolean
-
-    Error:
-      type: object
-      properties:
-        success:
-          type: boolean
-          example: false
-        error:
-          type: string
-        code:
-          type: string
+tags:
+  - name: Health
+    description: System health and status endpoints
+  - name: Authentication
+    description: User authentication and authorization
+  - name: Strategies
+    description: Trading strategy management
+  - name: Trades
+    description: Trade history and execution
+  - name: Orders
+    description: Order management
+  - name: Conditional Orders
+    description: Stop-loss, take-profit, and OCO orders
+  - name: Portfolios
+    description: Portfolio management
+  - name: Market Data
+    description: Market ticker and price data
+  - name: Orderbook
+    description: Order book data
+  - name: Leaderboard
+    description: Strategy performance rankings
+  - name: Backtest
+    description: Strategy backtesting
+  - name: Bot Management
+    description: Trading bot configuration
+  - name: Bot Control
+    description: Trading bot execution control
+  - name: Webhooks
+    description: Webhook configuration
+  - name: API Keys
+    description: API key management
+  - name: Templates
+    description: Strategy templates marketplace
+  - name: Copy Trading
+    description: Copy trading features
+  - name: Notifications
+    description: User notifications
+  - name: Export
+    description: Data export functionality
 
 paths:
+  # =====================================================
+  # Health Endpoints
+  # =====================================================
+  /health:
+    get:
+      summary: Health check
+      description: Check if the API server is running
+      operationId: healthCheck
+      tags:
+        - Health
+      security: []
+      responses:
+        '200':
+          description: Server is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  timestamp:
+                    type: integer
+
+  /health/status:
+    get:
+      summary: Detailed health status
+      description: Get detailed system health status
+      operationId: healthStatus
+      tags:
+        - Health
+      responses:
+        '200':
+          description: System status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  uptime:
+                    type: number
+                  version:
+                    type: string
+
+  /metrics:
+    get:
+      summary: System metrics
+      description: Get system performance metrics
+      operationId: getMetrics
+      tags:
+        - Health
+      responses:
+        '200':
+          description: Metrics data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memory:
+                    type: object
+                  cpu:
+                    type: object
+                  requests:
+                    type: object
+
+  # =====================================================
+  # Authentication Endpoints
+  # =====================================================
+  /auth/register:
+    post:
+      summary: Register new user
+      description: Create a new user account
+      operationId: registerUser
+      tags:
+        - Authentication
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '201':
+          description: User registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      token:
+                        type: string
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /auth/login:
+    post:
+      summary: User login
+      description: Authenticate user and get access token
+      operationId: loginUser
+      tags:
+        - Authentication
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      token:
+                        type: string
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /auth/me:
+    get:
+      summary: Get current user
+      description: Get the authenticated user's profile
+      operationId: getCurrentUser
+      tags:
+        - Authentication
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  # =====================================================
+  # Strategy Endpoints
+  # =====================================================
+  /strategies:
+    get:
+      summary: List all strategies
+      description: Retrieve a list of all trading strategies
+      operationId: listStrategies
+      tags:
+        - Strategies
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Strategy'
+
+  /strategies/{id}:
+    get:
+      summary: Get strategy details
+      description: Retrieve details for a specific strategy
+      operationId: getStrategy
+      tags:
+        - Strategies
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Strategy'
+        '404':
+          description: Strategy not found
+
+  /strategies/compare:
+    get:
+      summary: Compare strategies
+      description: Compare performance metrics across multiple strategies
+      operationId: compareStrategies
+      tags:
+        - Strategies
+      parameters:
+        - name: ids
+          in: query
+          description: Comma-separated list of strategy IDs
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Comparison results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        strategyId:
+                          type: string
+                        metrics:
+                          type: object
+
+  # =====================================================
+  # Trade Endpoints
+  # =====================================================
+  /trades:
+    get:
+      summary: List all trades
+      description: Retrieve a list of all trades with optional filtering
+      operationId: listTrades
+      tags:
+        - Trades
+      parameters:
+        - name: strategyId
+          in: query
+          schema:
+            type: string
+        - name: symbol
+          in: query
+          schema:
+            type: string
+        - name: side
+          in: query
+          schema:
+            type: string
+            enum: [buy, sell]
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Trade'
+                  count:
+                    type: integer
+
+  /trades/export:
+    get:
+      summary: Export trades
+      description: Export trades to CSV or JSON format
+      operationId: exportTrades
+      tags:
+        - Trades
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
+        - name: strategyId
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Exported trades file
+          content:
+            text/csv:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Trade'
+
+  # =====================================================
+  # Portfolio Endpoints
+  # =====================================================
+  /portfolios:
+    get:
+      summary: List portfolios
+      description: Retrieve all portfolios
+      operationId: listPortfolios
+      tags:
+        - Portfolios
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Portfolio'
+
+  /portfolios/history:
+    get:
+      summary: Get portfolio history
+      description: Retrieve portfolio value history over time
+      operationId: getPortfolioHistory
+      tags:
+        - Portfolios
+      parameters:
+        - name: strategyId
+          in: query
+          schema:
+            type: string
+        - name: period
+          in: query
+          schema:
+            type: string
+            enum: [1d, 7d, 30d, 90d, 1y]
+            default: 30d
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        timestamp:
+                          type: string
+                          format: date-time
+                        value:
+                          type: number
+
+  # =====================================================
+  # Order Endpoints
+  # =====================================================
+  /orders:
+    get:
+      summary: List orders
+      description: Retrieve all orders with optional filtering
+      operationId: listOrders
+      tags:
+        - Orders
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, filled, cancelled, all]
+            default: all
+        - name: symbol
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Order'
+
+    post:
+      summary: Create a new order
+      description: Submit a new order
+      operationId: createOrder
+      tags:
+        - Orders
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrderRequest'
+      responses:
+        '201':
+          description: Order created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Order'
+
+  /orders/{orderId}/cancel:
+    post:
+      summary: Cancel an order
+      description: Cancel an open order
+      operationId: cancelOrder
+      tags:
+        - Orders
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Order cancelled successfully
+        '404':
+          description: Order not found
+
+  # =====================================================
+  # Conditional Order Endpoints
+  # =====================================================
+  /conditional-orders:
+    get:
+      summary: List conditional orders
+      description: Retrieve all conditional orders (stop-loss, take-profit, etc.)
+      operationId: listConditionalOrders
+      tags:
+        - Conditional Orders
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [active, triggered, cancelled, all]
+            default: active
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConditionalOrder'
+
+    post:
+      summary: Create conditional order
+      description: Create a new conditional order (stop-loss, take-profit, OCO)
+      operationId: createConditionalOrder
+      tags:
+        - Conditional Orders
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConditionalOrderRequest'
+      responses:
+        '201':
+          description: Conditional order created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/ConditionalOrder'
+
+  /conditional-orders/{orderId}/cancel:
+    post:
+      summary: Cancel conditional order
+      description: Cancel an active conditional order
+      operationId: cancelConditionalOrder
+      tags:
+        - Conditional Orders
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Conditional order cancelled successfully
+        '404':
+          description: Conditional order not found
+
+  /conditional-orders/stats:
+    get:
+      summary: Get conditional order statistics
+      description: Retrieve statistics about conditional orders
+      operationId: getConditionalOrderStats
+      tags:
+        - Conditional Orders
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      active:
+                        type: integer
+                      triggered:
+                        type: integer
+                      cancelled:
+                        type: integer
+
+  # =====================================================
+  # Market Data Endpoints
+  # =====================================================
+  /market/tickers:
+    get:
+      summary: Get all market tickers
+      description: Retrieve ticker data for all trading pairs
+      operationId: getAllTickers
+      tags:
+        - Market Data
+      security: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Ticker'
+
+  /market/tickers/{symbol}:
+    get:
+      summary: Get ticker for symbol
+      description: Retrieve ticker data for a specific trading pair
+      operationId: getTicker
+      tags:
+        - Market Data
+      security: []
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          example: BTCUSDT
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Ticker'
+        '404':
+          description: Symbol not found
+
+  /market/kline/{symbol}:
+    get:
+      summary: Get K-line (candlestick) data
+      description: Retrieve candlestick/OHLCV data for a trading pair
+      operationId: getKlineData
+      tags:
+        - Market Data
+      security: []
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          example: BTCUSDT
+        - name: timeframe
+          in: query
+          schema:
+            type: string
+            enum: [1m, 5m, 15m, 1h, 4h, 1d]
+            default: 1h
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Candle'
+
+  # =====================================================
+  # Orderbook Endpoints
+  # =====================================================
+  /orderbook/{symbol}:
+    get:
+      summary: Get orderbook snapshot
+      description: Retrieve current orderbook (bids and asks) for a trading pair
+      operationId: getOrderbook
+      tags:
+        - Orderbook
+      security: []
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          example: BTCUSDT
+        - name: depth
+          in: query
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/OrderBook'
+
+  /orderbook/{symbol}/best:
+    get:
+      summary: Get best bid/ask prices
+      description: Retrieve the best bid and ask prices for a trading pair
+      operationId: getBestPrices
+      tags:
+        - Orderbook
+      security: []
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          example: BTCUSDT
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      bestBid:
+                        type: number
+                      bestAsk:
+                        type: number
+                      spread:
+                        type: number
+                      timestamp:
+                        type: integer
+
+  # =====================================================
+  # Leaderboard Endpoints
+  # =====================================================
+  /leaderboard:
+    get:
+      summary: Get leaderboard
+      description: Retrieve the strategy leaderboard with rankings
+      operationId: getLeaderboard
+      tags:
+        - Leaderboard
+      security: []
+      parameters:
+        - name: sortBy
+          in: query
+          schema:
+            type: string
+            enum: [totalReturn, winRate, profitFactor, sharpeRatio]
+            default: totalReturn
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaderboardEntry'
+
+  /leaderboard/{strategyId}:
+    get:
+      summary: Get strategy rank
+      description: Get ranking information for a specific strategy
+      operationId: getStrategyRank
+      tags:
+        - Leaderboard
+      security: []
+      parameters:
+        - name: strategyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/LeaderboardEntry'
+
+  /leaderboard/refresh:
+    post:
+      summary: Refresh leaderboard
+      description: Trigger a leaderboard recalculation
+      operationId: refreshLeaderboard
+      tags:
+        - Leaderboard
+      responses:
+        '200':
+          description: Leaderboard refreshed successfully
+
+  /leaderboard/snapshot:
+    get:
+      summary: Get leaderboard snapshot
+      description: Get a historical snapshot of the leaderboard
+      operationId: getLeaderboardSnapshot
+      tags:
+        - Leaderboard
+      security: []
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LeaderboardEntry'
+
+  # =====================================================
+  # Backtest Endpoints
+  # =====================================================
+  /backtest:
+    post:
+      summary: Run backtest
+      description: Run a backtest for a strategy
+      operationId: runBacktest
+      tags:
+        - Backtest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BacktestRequest'
+      responses:
+        '200':
+          description: Backtest completed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/BacktestResult'
+
+  # =====================================================
+  # Bot Management Endpoints
+  # =====================================================
   /bot:
     get:
       summary: List all bots
@@ -572,8 +1313,1290 @@ paths:
         '200':
           description: All bots stopped successfully
 
-tags:
-  - name: Bot Management
-    description: Operations for managing trading bots
-  - name: Bot Control
-    description: Operations for controlling bot execution
+  # =====================================================
+  # Webhook Endpoints
+  # =====================================================
+  /webhooks:
+    get:
+      summary: List webhooks
+      description: Retrieve all registered webhooks
+      operationId: listWebhooks
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Webhook'
+
+    post:
+      summary: Create webhook
+      description: Register a new webhook endpoint
+      operationId: createWebhook
+      tags:
+        - Webhooks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWebhookRequest'
+      responses:
+        '201':
+          description: Webhook created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/Webhook'
+
+  /webhooks/{id}:
+    delete:
+      summary: Delete webhook
+      description: Remove a registered webhook
+      operationId: deleteWebhook
+      tags:
+        - Webhooks
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Webhook deleted successfully
+        '404':
+          description: Webhook not found
+
+  # =====================================================
+  # API Key Endpoints
+  # =====================================================
+  /keys:
+    get:
+      summary: List API keys
+      description: Get all API keys for the authenticated user
+      operationId: listApiKeys
+      tags:
+        - API Keys
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApiKey'
+
+    post:
+      summary: Create API key
+      description: Generate a new API key
+      operationId: createApiKey
+      tags:
+        - API Keys
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApiKeyRequest'
+      responses:
+        '201':
+          description: API key created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      key:
+                        $ref: '#/components/schemas/ApiKey'
+                      secret:
+                        type: string
+                        description: The API key secret (only shown once)
+
+  /keys/{id}:
+    delete:
+      summary: Revoke API key
+      description: Revoke an API key
+      operationId: revokeApiKey
+      tags:
+        - API Keys
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: API key revoked successfully
+        '404':
+          description: API key not found
+
+  # =====================================================
+  # Template Endpoints
+  # =====================================================
+  /templates:
+    get:
+      summary: List strategy templates
+      description: Get all available strategy templates
+      operationId: listTemplates
+      tags:
+        - Templates
+      security: []
+      parameters:
+        - name: category
+          in: query
+          schema:
+            type: string
+        - name: difficulty
+          in: query
+          schema:
+            type: string
+            enum: [beginner, intermediate, advanced]
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StrategyTemplate'
+
+  /templates/{id}:
+    get:
+      summary: Get template details
+      description: Get detailed information about a strategy template
+      operationId: getTemplate
+      tags:
+        - Templates
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/StrategyTemplate'
+        '404':
+          description: Template not found
+
+  # =====================================================
+  # Copy Trading Endpoints
+  # =====================================================
+  /copy-trading/followers:
+    get:
+      summary: List followers
+      description: Get all followers for the authenticated user's strategies
+      operationId: listFollowers
+      tags:
+        - Copy Trading
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Follower'
+
+  /copy-trading/following:
+    get:
+      summary: List following
+      description: Get all strategies the user is following
+      operationId: listFollowing
+      tags:
+        - Copy Trading
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Following'
+
+  # =====================================================
+  # Notification Endpoints
+  # =====================================================
+  /notifications:
+    get:
+      summary: List notifications
+      description: Get all notifications for the authenticated user
+      operationId: listNotifications
+      tags:
+        - Notifications
+      parameters:
+        - name: unreadOnly
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Notification'
+
+  /notifications/{id}/read:
+    post:
+      summary: Mark notification as read
+      description: Mark a specific notification as read
+      operationId: markNotificationRead
+      tags:
+        - Notifications
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Notification marked as read
+        '404':
+          description: Notification not found
+
+  /notifications/read-all:
+    post:
+      summary: Mark all as read
+      description: Mark all notifications as read
+      operationId: markAllNotificationsRead
+      tags:
+        - Notifications
+      responses:
+        '200':
+          description: All notifications marked as read
+
+  # =====================================================
+  # Export Endpoints
+  # =====================================================
+  /export/trades:
+    get:
+      summary: Export trades
+      description: Export trade history to CSV or JSON
+      operationId: exportTradesData
+      tags:
+        - Export
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
+        - name: startDate
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: endDate
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Exported data
+          content:
+            text/csv:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Trade'
+
+  /export/performance:
+    get:
+      summary: Export performance report
+      description: Export performance metrics and analytics
+      operationId: exportPerformance
+      tags:
+        - Export
+      parameters:
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [csv, json, pdf]
+            default: pdf
+        - name: strategyId
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Performance report
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: object
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API Key for authentication (format: aa_live_xxx or aa_test_xxx)
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token obtained from login/register
+
+  schemas:
+    # =====================================================
+    # Error Schema
+    # =====================================================
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        code:
+          type: string
+
+    # =====================================================
+    # Trading Pair Schema
+    # =====================================================
+    TradingPair:
+      type: object
+      required:
+        - base
+        - quote
+        - symbol
+      properties:
+        base:
+          type: string
+          description: Base currency symbol (e.g., 'BTC')
+          example: BTC
+        quote:
+          type: string
+          description: Quote currency symbol (e.g., 'USDT')
+          example: USDT
+        symbol:
+          type: string
+          description: Full trading pair symbol
+          example: BTCUSDT
+
+    # =====================================================
+    # Strategy Schema
+    # =====================================================
+    Strategy:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          enum: [SMA, RSI, MACD, Bollinger, custom]
+        params:
+          type: object
+        status:
+          type: string
+          enum: [active, paused, stopped]
+        capital:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Trade Schema
+    # =====================================================
+    Trade:
+      type: object
+      properties:
+        id:
+          type: string
+        strategyId:
+          type: string
+        symbol:
+          type: string
+        side:
+          type: string
+          enum: [buy, sell]
+        quantity:
+          type: number
+        price:
+          type: number
+        total:
+          type: number
+        fee:
+          type: number
+        timestamp:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Portfolio Schema
+    # =====================================================
+    Portfolio:
+      type: object
+      properties:
+        id:
+          type: string
+        strategyId:
+          type: string
+        totalValue:
+          type: number
+        cashBalance:
+          type: number
+        positions:
+          type: array
+          items:
+            type: object
+            properties:
+              symbol:
+                type: string
+              quantity:
+                type: number
+              averagePrice:
+                type: number
+              currentValue:
+                type: number
+        realizedPnL:
+          type: number
+        unrealizedPnL:
+          type: number
+        updatedAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Order Schemas
+    # =====================================================
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        strategyId:
+          type: string
+        symbol:
+          type: string
+        side:
+          type: string
+          enum: [buy, sell]
+        type:
+          type: string
+          enum: [market, limit, stop_market, stop_limit]
+        quantity:
+          type: number
+        price:
+          type: number
+        stopPrice:
+          type: number
+        status:
+          type: string
+          enum: [open, filled, partially_filled, cancelled]
+        filledQuantity:
+          type: number
+        averageFillPrice:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    CreateOrderRequest:
+      type: object
+      required:
+        - symbol
+        - side
+        - type
+        - quantity
+      properties:
+        symbol:
+          type: string
+          example: BTCUSDT
+        side:
+          type: string
+          enum: [buy, sell]
+        type:
+          type: string
+          enum: [market, limit, stop_market, stop_limit]
+        quantity:
+          type: number
+          minimum: 0
+        price:
+          type: number
+          description: Required for limit and stop_limit orders
+        stopPrice:
+          type: number
+          description: Required for stop orders
+        strategyId:
+          type: string
+
+    # =====================================================
+    # Conditional Order Schemas
+    # =====================================================
+    ConditionalOrder:
+      type: object
+      properties:
+        id:
+          type: string
+        strategyId:
+          type: string
+        symbol:
+          type: string
+        type:
+          type: string
+          enum: [stop_loss, take_profit, oco, trailing_stop]
+        triggerPrice:
+          type: number
+        triggerCondition:
+          type: string
+          enum: [above, below]
+        orderType:
+          type: string
+          enum: [market, limit]
+        quantity:
+          type: number
+        limitPrice:
+          type: number
+        status:
+          type: string
+          enum: [active, triggered, cancelled]
+        createdAt:
+          type: string
+          format: date-time
+        triggeredAt:
+          type: string
+          format: date-time
+
+    CreateConditionalOrderRequest:
+      type: object
+      required:
+        - symbol
+        - type
+        - triggerPrice
+        - quantity
+      properties:
+        symbol:
+          type: string
+        type:
+          type: string
+          enum: [stop_loss, take_profit, oco, trailing_stop]
+        triggerPrice:
+          type: number
+        triggerCondition:
+          type: string
+          enum: [above, below]
+        orderType:
+          type: string
+          enum: [market, limit]
+          default: market
+        quantity:
+          type: number
+        limitPrice:
+          type: number
+        stopLossPrice:
+          type: number
+          description: For OCO orders
+        takeProfitPrice:
+          type: number
+          description: For OCO orders
+        trailingPercent:
+          type: number
+          description: For trailing stop orders
+        strategyId:
+          type: string
+
+    # =====================================================
+    # Market Data Schemas
+    # =====================================================
+    Ticker:
+      type: object
+      properties:
+        symbol:
+          type: string
+        price:
+          type: number
+        priceChange24h:
+          type: number
+        priceChangePercent24h:
+          type: number
+        high24h:
+          type: number
+        low24h:
+          type: number
+        volume24h:
+          type: number
+        quoteVolume24h:
+          type: number
+        bid:
+          type: number
+        ask:
+          type: number
+        timestamp:
+          type: integer
+
+    Candle:
+      type: object
+      properties:
+        time:
+          type: integer
+          description: Unix timestamp in seconds
+        open:
+          type: number
+        high:
+          type: number
+        low:
+          type: number
+        close:
+          type: number
+        volume:
+          type: number
+
+    OrderBook:
+      type: object
+      properties:
+        symbol:
+          type: string
+        bids:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+          description: '[price, quantity] pairs'
+        asks:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+          description: '[price, quantity] pairs'
+        timestamp:
+          type: integer
+
+    # =====================================================
+    # Leaderboard Schema
+    # =====================================================
+    LeaderboardEntry:
+      type: object
+      properties:
+        rank:
+          type: integer
+        strategyId:
+          type: string
+        strategyName:
+          type: string
+        totalReturn:
+          type: number
+        winRate:
+          type: number
+        profitFactor:
+          type: number
+        sharpeRatio:
+          type: number
+        maxDrawdown:
+          type: number
+        tradeCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Backtest Schemas
+    # =====================================================
+    BacktestRequest:
+      type: object
+      required:
+        - strategy
+        - symbol
+        - startDate
+        - endDate
+        - initialCapital
+      properties:
+        strategy:
+          type: string
+        strategyParams:
+          type: object
+        symbol:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        initialCapital:
+          type: number
+        timeframe:
+          type: string
+          enum: [1m, 5m, 15m, 1h, 4h, 1d]
+          default: 1h
+
+    BacktestResult:
+      type: object
+      properties:
+        id:
+          type: string
+        strategy:
+          type: string
+        symbol:
+          type: string
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        initialCapital:
+          type: number
+        finalCapital:
+          type: number
+        totalReturn:
+          type: number
+        totalReturnPercent:
+          type: number
+        maxDrawdown:
+          type: number
+        sharpeRatio:
+          type: number
+        winRate:
+          type: number
+        profitFactor:
+          type: number
+        totalTrades:
+          type: integer
+        winningTrades:
+          type: integer
+        losingTrades:
+          type: integer
+        trades:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trade'
+        equityCurve:
+          type: array
+          items:
+            type: object
+            properties:
+              timestamp:
+                type: string
+                format: date-time
+              value:
+                type: number
+
+    # =====================================================
+    # Bot Schemas
+    # =====================================================
+    RiskSettings:
+      type: object
+      properties:
+        maxCapitalPerTrade:
+          type: number
+          description: Maximum capital per trade (absolute or percentage)
+          default: 0.1
+        usePercentageCapital:
+          type: boolean
+          description: Use percentage for maxCapitalPerTrade
+          default: true
+        stopLossPercent:
+          type: number
+          description: Stop loss percentage (0-1)
+          default: 0.05
+        takeProfitPercent:
+          type: number
+          description: Take profit percentage (0-1)
+          default: 0.15
+        maxPositionSize:
+          type: number
+          description: Maximum position size
+          default: 1000
+        maxOrdersPerMinute:
+          type: number
+          description: Maximum orders per minute
+          default: 10
+        maxDailyLoss:
+          type: number
+          description: Maximum daily loss (0-1)
+          default: 0.1
+        riskControlEnabled:
+          type: boolean
+          description: Enable risk controls
+          default: true
+
+    BotConfig:
+      type: object
+      required:
+        - id
+        - name
+        - strategy
+        - tradingPair
+        - interval
+        - mode
+        - initialCapital
+      properties:
+        id:
+          type: string
+          description: Unique bot identifier
+        name:
+          type: string
+          description: Bot name
+        description:
+          type: string
+          description: Bot description
+        strategy:
+          type: string
+          enum: [SMA, RSI, MACD, Bollinger, Stochastic, ATR]
+          description: Trading strategy type
+        strategyParams:
+          type: object
+          description: Strategy-specific parameters
+        tradingPair:
+          $ref: '#/components/schemas/TradingPair'
+        interval:
+          type: string
+          enum: [1m, 5m, 15m, 1h, 4h, 1d]
+          description: Time interval for strategy execution
+        mode:
+          type: string
+          enum: [paper, live]
+          description: Trading mode
+        riskSettings:
+          $ref: '#/components/schemas/RiskSettings'
+        initialCapital:
+          type: number
+          description: Initial capital allocation
+        enabled:
+          type: boolean
+          description: Whether bot is enabled
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    BotState:
+      type: object
+      properties:
+        botId:
+          type: string
+        status:
+          type: string
+          enum: [stopped, running, paused, error]
+        portfolioValue:
+          type: number
+        initialCapital:
+          type: number
+        realizedPnL:
+          type: number
+        unrealizedPnL:
+          type: number
+        totalPnL:
+          type: number
+        tradeCount:
+          type: integer
+        winCount:
+          type: integer
+        lossCount:
+          type: integer
+        positionQuantity:
+          type: number
+        positionAveragePrice:
+          type: number
+        lastSignalTime:
+          type: string
+          format: date-time
+        lastTradeTime:
+          type: string
+          format: date-time
+        lastError:
+          type: string
+        startedAt:
+          type: string
+          format: date-time
+        totalRuntimeMs:
+          type: integer
+
+    CreateBotRequest:
+      type: object
+      required:
+        - name
+        - strategy
+        - tradingPair
+        - initialCapital
+      properties:
+        name:
+          type: string
+          description: Bot name
+        description:
+          type: string
+          description: Bot description
+        strategy:
+          type: string
+          enum: [SMA, RSI, MACD, Bollinger, Stochastic, ATR]
+        strategyParams:
+          type: object
+          description: Strategy-specific parameters
+        tradingPair:
+          $ref: '#/components/schemas/TradingPair'
+        interval:
+          type: string
+          enum: [1m, 5m, 15m, 1h, 4h, 1d]
+          default: 1h
+        mode:
+          type: string
+          enum: [paper, live]
+          default: paper
+        riskSettings:
+          $ref: '#/components/schemas/RiskSettings'
+        initialCapital:
+          type: number
+          minimum: 0
+
+    UpdateBotRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        strategyParams:
+          type: object
+        riskSettings:
+          $ref: '#/components/schemas/RiskSettings'
+        enabled:
+          type: boolean
+
+    # =====================================================
+    # Webhook Schemas
+    # =====================================================
+    Webhook:
+      type: object
+      properties:
+        id:
+          type: string
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            type: string
+            enum: [trade, order, signal, error, portfolio_update]
+        secret:
+          type: string
+        enabled:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+
+    CreateWebhookRequest:
+      type: object
+      required:
+        - url
+        - events
+      properties:
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            type: string
+            enum: [trade, order, signal, error, portfolio_update]
+          minItems: 1
+        secret:
+          type: string
+          description: Optional secret for webhook signature verification
+
+    # =====================================================
+    # Authentication Schemas
+    # =====================================================
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        username:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    RegisterRequest:
+      type: object
+      required:
+        - email
+        - password
+        - username
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        username:
+          type: string
+          minLength: 3
+
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+
+    # =====================================================
+    # API Key Schemas
+    # =====================================================
+    ApiKey:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        key:
+          type: string
+          description: Partially masked API key
+        permissions:
+          type: array
+          items:
+            type: string
+            enum: [read, trade, admin]
+        rateLimit:
+          type: integer
+          description: Requests per minute
+        dailyLimit:
+          type: integer
+          description: Requests per day
+        lastUsed:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+
+    CreateApiKeyRequest:
+      type: object
+      required:
+        - name
+        - permissions
+      properties:
+        name:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+            enum: [read, trade, admin]
+          minItems: 1
+        expiresAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Template Schema
+    # =====================================================
+    StrategyTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        difficulty:
+          type: string
+          enum: [beginner, intermediate, advanced]
+        strategy:
+          type: string
+        defaultParams:
+          type: object
+        paramSchema:
+          type: object
+          description: JSON Schema for parameters
+        performanceMetrics:
+          type: object
+          properties:
+            avgReturn:
+              type: number
+            winRate:
+              type: number
+            maxDrawdown:
+              type: number
+        tags:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Copy Trading Schemas
+    # =====================================================
+    Follower:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        strategyId:
+          type: string
+        allocation:
+          type: number
+          description: Percentage of portfolio to allocate
+        copyTrades:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+
+    Following:
+      type: object
+      properties:
+        id:
+          type: string
+        strategyId:
+          type: string
+        strategyName:
+          type: string
+        allocation:
+          type: number
+        copyTrades:
+          type: boolean
+        status:
+          type: string
+          enum: [active, paused]
+        createdAt:
+          type: string
+          format: date-time
+
+    # =====================================================
+    # Notification Schema
+    # =====================================================
+    Notification:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [trade, signal, alert, error, system]
+        title:
+          type: string
+        message:
+          type: string
+        data:
+          type: object
+        read:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0",
         "recharts": "^2.12.0",
-        "uuid": "^13.0.0"
+        "swagger-ui-express": "^5.0.1",
+        "uuid": "^13.0.0",
+        "yamljs": "^0.3.0"
       },
       "bin": {
         "alpha-arena": "bin/alpha-arena"
@@ -42,7 +44,9 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@types/supertest": "^7.2.0",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
+        "@types/yamljs": "^0.2.34",
         "@vitejs/plugin-react": "^5.1.4",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
@@ -2538,6 +2542,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -3233,6 +3244,17 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -3255,6 +3277,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yamljs": {
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.34.tgz",
+      "integrity": "sha512-gJvfRlv9ErxdOv7ux7UsJVePtX54NAvQyd8ncoiFqK8G5aeHIfQfGH2fbruvjAQ9657HwAaO54waS+Dsk2QTUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4043,7 +4072,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -4378,7 +4406,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -5019,7 +5046,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -6801,7 +6827,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -7396,7 +7421,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9688,7 +9712,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10926,7 +10949,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -11321,6 +11343,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.1.tgz",
+      "integrity": "sha512-6HQoo7+j8PA2QqP5kgAb9dl1uxUjvR0SAoL/WUp1sTEvm0F6D5npgU2OGCLwl++bIInqGlEUQ2mpuZRZYtyCzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-tree": {
@@ -12626,6 +12672,63 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "json2yaml": "bin/json2yaml",
+        "yaml2json": "bin/yaml2json"
+      }
+    },
+    "node_modules/yamljs/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/yamljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/yamljs/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/supertest": "^7.2.0",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
+    "@types/yamljs": "^0.2.34",
     "@vitejs/plugin-react": "^5.1.4",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
@@ -96,6 +98,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "recharts": "^2.12.0",
-    "uuid": "^13.0.0"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^13.0.0",
+    "yamljs": "^0.3.0"
   }
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,3 +1,6 @@
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+import path from 'path';
 /**
  * AlphaArena API Server
  *
@@ -233,7 +236,22 @@ export class APIServer extends EventEmitter {
    * Setup REST API routes
    */
   private setupRoutes(): void {
-    // Basic health check
+    // API Documentation with Swagger UI
+    try {
+      const swaggerDocument = YAML.load(path.join(__dirname, '../../docs/api/openapi.yaml'));
+      this.app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, {
+        customCss: '.swagger-ui .topbar { display: none }',
+        customSiteTitle: 'AlphaArena API Documentation',
+      }));
+      // Also serve the raw OpenAPI spec
+      this.app.get('/api-docs/openapi.yaml', (req: Request, res: Response) => {
+        res.sendFile(path.join(__dirname, '../../docs/api/openapi.yaml'));
+      });
+      log.info('Swagger UI available at /api-docs');
+    } catch (error: any) {
+      log.warn('Failed to load OpenAPI spec:', error.message);
+    }
+
     this.app.get('/health', (req: Request, res: Response) => {
       res.json({ status: 'ok', timestamp: Date.now() });
     });


### PR DESCRIPTION
## Summary

This PR implements comprehensive API documentation for AlphaArena using OpenAPI/Swagger specification.

### Changes

#### Swagger UI Integration
- Added  endpoint for interactive API documentation
- Added  endpoint for raw spec access
- Integrated swagger-ui-express and yamljs packages

#### OpenAPI Specification
Expanded the OpenAPI spec to cover all API endpoints:

- **Authentication**: Register, login, get current user
- **Strategies**: List, get details, compare
- **Trades**: List with filtering, export to CSV/JSON
- **Orders**: List, create, cancel
- **Conditional Orders**: List, create, cancel, statistics
- **Portfolios**: List, history
- **Market Data**: Tickers (all and per-symbol), K-line data
- **Orderbook**: Snapshot, best bid/ask prices
- **Leaderboard**: Rankings, refresh, historical snapshots
- **Backtest**: Run backtests, get results
- **Bot Management**: CRUD operations, control (start/stop/pause/resume)
- **Webhooks**: List, create, delete
- **API Keys**: List, create, revoke
- **Templates**: Strategy template marketplace
- **Copy Trading**: Followers, following
- **Notifications**: List, mark as read
- **Export**: Trades, performance reports

#### Documentation
- Comprehensive schema definitions for all data models
- Authentication schemes (API Key and JWT Bearer)
- Rate limit documentation
- Error handling documentation
- Request/response examples

### Dependencies Added
- swagger-ui-express: ^5.0.1
- yamljs: ^0.3.0
- @types/swagger-ui-express: ^4.1.8
- @types/yamljs: ^0.2.34

### Testing
- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ Swagger UI accessible at /api-docs

Closes #304

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding documentation endpoints and dependencies, with minimal impact on existing request handling aside from mounting the new `/api-docs` routes.
> 
> **Overview**
> Adds interactive API documentation by mounting Swagger UI at `/api-docs` and serving the raw OpenAPI YAML at `/api-docs/openapi.yaml`.
> 
> Replaces the minimal OpenAPI spec with a much more comprehensive `docs/api/openapi.yaml` covering many platform endpoints, plus documented auth methods (API key + JWT), rate limits, and shared schemas.
> 
> Updates dependencies to include `swagger-ui-express`/`yamljs` (and typings) to load and render the spec at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8b6155679fb9eacd6529b77df3a5bbf5bc7b621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->