### PR TITLE
fix: Add explicit rewrites for /api/users and /api/signals

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,16 @@
   "framework": "vite",
   "rewrites": [
     {
+      "source": "/api/users",
+      "destination": "https://plnylmnckssnfpwznpwf.supabase.co/functions/v1/users"
+    },
+    {
       "source": "/api/users/:path*",
       "destination": "https://plnylmnckssnfpwznpwf.supabase.co/functions/v1/users/:path*"
+    },
+    {
+      "source": "/api/signals",
+      "destination": "https://plnylmnckssnfpwznpwf.supabase.co/functions/v1/signals"
     },
     {
       "source": "/api/signals/:path*",


### PR DESCRIPTION
## Summary
Follow-up fix for #317 

Vercel rewrites with  parameter don't match routes without path segments like  or .

## Changes
- Added explicit rewrites for  (without trailing path)
- Added explicit rewrites for  (without trailing path)

## Testing
After merging, test:
- `curl https://alphaarena.vercel.app/api/users/search?q=test`
- `curl https://alphaarena.vercel.app/api/signals`

Both should return JSON, not HTML.