### PR TITLE
fix(nav): add rebalance entry to mobile bottom navigation

### DIFF
--- a/src/client/components/MobileBottomNav.tsx
+++ b/src/client/components/MobileBottomNav.tsx
@@ -7,6 +7,7 @@ import {
   IconSafe,
   IconUser,
   IconApps,
+  IconExperiment,
 } from '@arco-design/web-react/icon';
 import { useLocation, useNavigate } from 'react-router-dom';
 import './MobileBottomNav.css';
@@ -24,6 +25,7 @@ const navItems: NavItem[] = [
   { key: '/trades', icon: <IconSwap />, label: '交易' },
   { key: '/holdings', icon: <IconSafe />, label: '持仓' },
   { key: '/strategies', icon: <IconApps />, label: '策略' },
+  { key: '/rebalance', icon: <IconExperiment />, label: '再平衡' },
   { key: '/user-dashboard', icon: <IconUser />, label: '我的' },
 ];
 


### PR DESCRIPTION
## Summary
- Fixes #325: Add '再平衡' menu item to MobileBottomNav component
- Users can now access /rebalance page from mobile bottom navigation bar
- Desktop sidebar and mobile drawer menu already have the entry, this adds it to the most-used mobile navigation

## Changes
- Added IconExperiment import
- Added rebalance entry to navItems array in MobileBottomNav.tsx

## Test Plan
- [ ] Open app on mobile device or resize browser to mobile width
- [ ] Verify '再平衡' appears in bottom navigation bar
- [ ] Click the entry and verify it navigates to /rebalance page
- [ ] Verify active state highlights correctly

🤖 Generated by VirtuCorp Dev Agent