### PR TITLE
feat: Add revenue analytics dashboard for admin

### DIFF
--- a/src/api/revenueRoutes.ts
+++ b/src/api/revenueRoutes.ts
@@ -1,0 +1,338 @@
+/**
+ * Revenue Analytics Routes
+ * Admin-only endpoints for revenue analytics and reporting
+ */
+
+import { Router, Request, Response } from 'express';
+import { 
+  getRevenueDAO,
+  RevenueMetrics,
+  RevenueTrend,
+  SubscriptionDistribution,
+  ConversionFunnel,
+  ChurnData,
+} from '../database/revenue.dao';
+import { authMiddleware } from './authMiddleware';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('RevenueRoutes');
+
+const router = Router();
+
+/**
+ * Admin middleware - checks if user has admin role
+ */
+const adminMiddleware = async (req: Request, res: Response, next: Function) => {
+  const user = req.user;
+  
+  // Check if user has admin role
+  // This can be customized based on your auth system
+  const isAdmin = (user as any)?.role === 'admin' || 
+                  (user as any)?.user_metadata?.role === 'admin' ||
+                  process.env.ADMIN_EMAILS?.split(',').includes((user as any)?.email);
+  
+  if (!isAdmin) {
+    return res.status(403).json({
+      success: false,
+      error: 'Admin access required',
+    });
+  }
+  
+  next();
+};
+
+/**
+ * GET /api/revenue/metrics
+ * Get overall revenue metrics (MRR, ARR, ARPU, etc.)
+ */
+router.get('/metrics', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dao = getRevenueDAO();
+    const metrics = await dao.getRevenueMetrics();
+    
+    res.json({
+      success: true,
+      data: metrics,
+    });
+  } catch (error) {
+    log.error('Failed to get revenue metrics:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve revenue metrics',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/trend
+ * Get revenue trend data over time
+ * Query params:
+ * - startDate: ISO date string (default: 30 days ago)
+ * - endDate: ISO date string (default: now)
+ * - granularity: 'day' | 'week' | 'month' (default: 'day')
+ */
+router.get('/trend', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { startDate, endDate, granularity = 'day' } = req.query;
+    
+    const start = startDate ? new Date(startDate as string) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const end = endDate ? new Date(endDate as string) : new Date();
+    
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid date format. Use ISO format (YYYY-MM-DDTHH:mm:ss.sssZ)',
+      });
+    }
+    
+    const dao = getRevenueDAO();
+    const trend = await dao.getRevenueTrend(
+      { startDate: start, endDate: end },
+      granularity as 'day' | 'week' | 'month'
+    );
+    
+    res.json({
+      success: true,
+      data: trend,
+    });
+  } catch (error) {
+    log.error('Failed to get revenue trend:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve revenue trend',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/distribution
+ * Get subscription distribution by plan
+ */
+router.get('/distribution', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dao = getRevenueDAO();
+    const distribution = await dao.getSubscriptionDistribution();
+    
+    res.json({
+      success: true,
+      data: distribution,
+    });
+  } catch (error) {
+    log.error('Failed to get subscription distribution:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve subscription distribution',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/funnel
+ * Get conversion funnel data
+ */
+router.get('/funnel', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dao = getRevenueDAO();
+    const funnel = await dao.getConversionFunnel();
+    
+    res.json({
+      success: true,
+      data: funnel,
+    });
+  } catch (error) {
+    log.error('Failed to get conversion funnel:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve conversion funnel',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/churn
+ * Get churn analysis data
+ * Query params:
+ * - months: number of months to analyze (default: 12)
+ */
+router.get('/churn', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { months = 12 } = req.query;
+    const monthsNum = parseInt(months as string, 10);
+    
+    if (isNaN(monthsNum) || monthsNum < 1 || monthsNum > 24) {
+      return res.status(400).json({
+        success: false,
+        error: 'months must be a number between 1 and 24',
+      });
+    }
+    
+    const dao = getRevenueDAO();
+    const churn = await dao.getChurnAnalysis(monthsNum);
+    
+    res.json({
+      success: true,
+      data: churn,
+    });
+  } catch (error) {
+    log.error('Failed to get churn analysis:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve churn analysis',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/export/payments
+ * Export revenue data as CSV
+ * Query params:
+ * - startDate: ISO date string
+ * - endDate: ISO date string
+ */
+router.get('/export/payments', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { startDate, endDate } = req.query;
+    
+    if (!startDate || !endDate) {
+      return res.status(400).json({
+        success: false,
+        error: 'startDate and endDate are required',
+      });
+    }
+    
+    const start = new Date(startDate as string);
+    const end = new Date(endDate as string);
+    
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid date format. Use ISO format (YYYY-MM-DDTHH:mm:ss.sssZ)',
+      });
+    }
+    
+    const dao = getRevenueDAO();
+    const data = await dao.exportRevenueData({ startDate: start, endDate: end });
+    
+    // Convert to CSV
+    const headers = ['Date', 'User ID', 'User Name', 'User Email', 'Plan', 'Amount', 'Currency', 'Status', 'Payment Method'];
+    const csvRows = [headers.join(',')];
+    
+    data.forEach(row => {
+      csvRows.push([
+        row.date,
+        row.userId,
+        `"${row.userName.replace(/"/g, '""')}"`,
+        row.userEmail,
+        row.planName,
+        row.amount,
+        row.currency,
+        row.status,
+        row.paymentMethod,
+      ].join(','));
+    });
+    
+    const csv = csvRows.join('\n');
+    const filename = `revenue-report-${start.toISOString().slice(0, 10)}-${end.toISOString().slice(0, 10)}.csv`;
+    
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    // Add BOM for Excel UTF-8 compatibility
+    res.send('\ufeff' + csv);
+  } catch (error) {
+    log.error('Failed to export revenue data:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to export revenue data',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/export/subscribers
+ * Export subscriber list as CSV
+ */
+router.get('/export/subscribers', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dao = getRevenueDAO();
+    const data = await dao.exportSubscriberList();
+    
+    // Convert to CSV
+    const headers = ['User ID', 'User Name', 'User Email', 'Plan', 'Status', 'Period Start', 'Period End', 'Stripe Customer ID', 'Total Payments', 'Total Revenue'];
+    const csvRows = [headers.join(',')];
+    
+    data.forEach(row => {
+      csvRows.push([
+        row.userId,
+        `"${row.userName.replace(/"/g, '""')}"`,
+        row.userEmail,
+        row.planName,
+        row.status,
+        row.currentPeriodStart,
+        row.currentPeriodEnd,
+        row.stripeCustomerId,
+        row.totalPayments,
+        row.totalRevenue,
+      ].join(','));
+    });
+    
+    const csv = csvRows.join('\n');
+    const filename = `subscribers-${new Date().toISOString().slice(0, 10)}.csv`;
+    
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send('\ufeff' + csv);
+  } catch (error) {
+    log.error('Failed to export subscriber list:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to export subscriber list',
+    });
+  }
+});
+
+/**
+ * GET /api/revenue/summary
+ * Get a summary dashboard of all metrics
+ */
+router.get('/summary', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
+  try {
+    const dao = getRevenueDAO();
+    
+    // Fetch all data in parallel
+    const [metrics, distribution, funnel, churn] = await Promise.all([
+      dao.getRevenueMetrics(),
+      dao.getSubscriptionDistribution(),
+      dao.getConversionFunnel(),
+      dao.getChurnAnalysis(6), // Last 6 months
+    ]);
+    
+    // Get trend for last 30 days
+    const trend = await dao.getRevenueTrend({
+      startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      endDate: new Date(),
+    }, 'day');
+    
+    res.json({
+      success: true,
+      data: {
+        metrics,
+        distribution,
+        funnel,
+        churn,
+        trend,
+      },
+    });
+  } catch (error) {
+    log.error('Failed to get revenue summary:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to retrieve revenue summary',
+    });
+  }
+});
+
+export function createRevenueRouter(): Router {
+  return router;
+}
+
+export default router;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -45,6 +45,7 @@ import userDashboardRoutes from './userDashboardRoutes';
 import { createRiskMonitorRouter } from './riskMonitorRoutes';
 import subscriptionRoutes from './subscriptionRoutes';
 import promoCodeRoutes from './promoCodeRoutes';
+import revenueRoutes from './revenueRoutes';
 import socialRoutes from './socialRoutes';
 import commentRoutes from './commentRoutes';
 import multiTimeframeRoutes from '../multi-timeframe/routes';
@@ -910,6 +911,7 @@ export class APIServer extends EventEmitter {
     this.app.use('/api/risk', createRiskMonitorRouter());
     this.app.use('/api/subscriptions', subscriptionRoutes);
     this.app.use('/api/promo-codes', promoCodeRoutes);
+    this.app.use('/api/revenue', revenueRoutes);
     this.app.use('/api/schedules', createSchedulerRouter());
     this.app.use('/api/alerts', alertRoutes);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -66,6 +66,7 @@ const RebalancePage = lazyWithRetry(() => import('./pages/RebalancePage'));
 const SubscriptionPage = lazyWithRetry(() => import('./pages/SubscriptionPage'));
 const SubscriptionSuccessPage = lazyWithRetry(() => import('./pages/SubscriptionSuccessPage'));
 const SubscriptionCancelPage = lazyWithRetry(() => import('./pages/SubscriptionCancelPage'));
+const AdminDashboardPage = lazyWithRetry(() => import('./pages/AdminDashboardPage'));
 
 // Loading component for lazy routes
 const PageLoader: React.FC = () => (
@@ -434,6 +435,7 @@ const AppRoutes: React.FC = () => {
         <Route path="/subscription" element={<SubscriptionPage />} />
         <Route path="/subscription/success" element={<SubscriptionSuccessPage />} />
         <Route path="/subscription/cancel" element={<SubscriptionCancelPage />} />
+        <Route path="/admin/revenue" element={<AdminDashboardPage />} />
       </Routes>
     </Suspense>
   );

--- a/src/client/pages/AdminDashboardPage.tsx
+++ b/src/client/pages/AdminDashboardPage.tsx
@@ -1,0 +1,634 @@
+/**
+ * AdminDashboardPage - Revenue Analytics Dashboard
+ * Admin-only page for monitoring revenue, subscriptions, and business metrics
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  Typography,
+  Card,
+  Grid,
+  Spin,
+  Message,
+  DatePicker,
+  Select,
+  Button,
+  Space,
+  Tag,
+  Statistic,
+  Divider,
+  Table,
+  Progress,
+  Tooltip,
+  Modal,
+  Empty,
+} from '@arco-design/web-react';
+import {
+  IconDownload,
+  IconRefresh,
+  IconArrowRise,
+  IconUser,
+  IconTrophy,
+  IconExclamationCircle,
+  IconDashboard,
+  IconApps,
+  IconFire,
+} from '@arco-design/web-react/icon';
+import {
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  Legend,
+  ResponsiveContainer,
+  FunnelChart,
+  Funnel,
+  LabelList,
+  Treemap,
+} from 'recharts';
+import { ErrorBoundary } from '../components/ErrorBoundary';
+
+const { Title, Text, Paragraph } = Typography;
+const { Row, Col } = Grid;
+const { RangePicker } = DatePicker;
+
+// Types
+interface RevenueMetrics {
+  mrr: number;
+  arr: number;
+  arpu: number;
+  totalRevenue: number;
+  activeSubscribers: number;
+  trialUsers: number;
+  churnRate: number;
+  ltv: number;
+  conversionRate: number;
+}
+
+interface RevenueTrend {
+  date: string;
+  revenue: number;
+  subscriptions: number;
+  churned: number;
+  newSubscribers: number;
+}
+
+interface SubscriptionDistribution {
+  planId: string;
+  planName: string;
+  count: number;
+  percentage: number;
+  revenue: number;
+}
+
+interface ConversionFunnel {
+  stage: string;
+  count: number;
+  percentage: number;
+}
+
+interface ChurnData {
+  month: string;
+  churnedUsers: number;
+  totalUsers: number;
+  churnRate: number;
+  topReasons: string[];
+}
+
+interface SummaryData {
+  metrics: RevenueMetrics;
+  distribution: SubscriptionDistribution[];
+  funnel: ConversionFunnel[];
+  churn: ChurnData[];
+  trend: RevenueTrend[];
+}
+
+// Colors for charts
+const COLORS = ['#165DFF', '#14C9C9', '#F7BA1E', '#F53F3F', '#722ED1', '#00B42A'];
+
+const AdminDashboardPage: React.FC = () => {
+  const [summary, setSummary] = useState<SummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [dateRange, setDateRange] = useState<[Date, Date]>([
+    new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    new Date(),
+  ]);
+  const [granularity, setGranularity] = useState<'day' | 'week' | 'month'>('day');
+  const [trendData, setTrendData] = useState<RevenueTrend[]>([]);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  useEffect(() => {
+    fetchSummary();
+    fetchTrend();
+  }, []);
+
+  const fetchSummary = async () => {
+    setLoading(true);
+    try {
+      const token = localStorage.getItem('token') || localStorage.getItem('supabase_token');
+      const response = await fetch('/api/revenue/summary', {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        if (response.status === 403) {
+          Message.error('您没有访问此页面的权限');
+          return;
+        }
+        throw new Error('Failed to fetch summary');
+      }
+
+      const data = await response.json();
+      setSummary(data.data);
+    } catch (error) {
+      console.error('Failed to fetch summary:', error);
+      Message.error('加载收入数据失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchTrend = async () => {
+    try {
+      const token = localStorage.getItem('token') || localStorage.getItem('supabase_token');
+      const start = dateRange[0].toISOString();
+      const end = dateRange[1].toISOString();
+      
+      const response = await fetch(
+        `/api/revenue/trend?startDate=${start}&endDate=${end}&granularity=${granularity}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) throw new Error('Failed to fetch trend');
+
+      const data = await response.json();
+      setTrendData(data.data);
+    } catch (error) {
+      console.error('Failed to fetch trend:', error);
+    }
+  };
+
+  const exportPayments = async () => {
+    try {
+      const token = localStorage.getItem('token') || localStorage.getItem('supabase_token');
+      const start = dateRange[0].toISOString();
+      const end = dateRange[1].toISOString();
+      
+      const response = await fetch(
+        `/api/revenue/export/payments?startDate=${start}&endDate=${end}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) throw new Error('Failed to export payments');
+
+      const csv = await response.text();
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `revenue-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+      
+      Message.success('导出成功');
+    } catch (error) {
+      console.error('Failed to export payments:', error);
+      Message.error('导出失败');
+    }
+  };
+
+  const exportSubscribers = async () => {
+    try {
+      const token = localStorage.getItem('token') || localStorage.getItem('supabase_token');
+      
+      const response = await fetch('/api/revenue/export/subscribers', {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) throw new Error('Failed to export subscribers');
+
+      const csv = await response.text();
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `subscribers-${new Date().toISOString().slice(0, 10)}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+      
+      Message.success('导出成功');
+    } catch (error) {
+      console.error('Failed to export subscribers:', error);
+      Message.error('导出失败');
+    }
+  };
+
+  const formatCurrency = (value: number): string => {
+    return `¥${value.toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  };
+
+  const formatPercent = (value: number): string => {
+    return `${value.toFixed(2)}%`;
+  };
+
+  // Render metric card
+  const MetricCard = ({ title, value, suffix, icon, color, trend }: {
+    title: string;
+    value: string | number;
+    suffix?: string;
+    icon: React.ReactNode;
+    color: string;
+    trend?: number;
+  }) => (
+    <Card style={{ height: '100%' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 8,
+            background: `${color}20`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: color,
+          }}
+        >
+          {icon}
+        </div>
+        <div style={{ flex: 1 }}>
+          <Text type="secondary" style={{ fontSize: 13 }}>{title}</Text>
+          <div style={{ marginTop: 4 }}>
+            <Text style={{ fontSize: 24, fontWeight: 'bold' }}>{value}</Text>
+            {suffix && <Text type="secondary" style={{ marginLeft: 4 }}>{suffix}</Text>}
+          </div>
+          {trend !== undefined && (
+            <div style={{ marginTop: 4 }}>
+              <Tag color={trend >= 0 ? 'green' : 'red'}>
+                {trend >= 0 ? '↑' : '↓'} {Math.abs(trend).toFixed(1)}%
+              </Tag>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+
+  // Render pie chart for subscription distribution
+  const renderDistributionChart = () => {
+    if (!summary?.distribution?.length) return <Empty />;
+
+    const data = summary.distribution.map(d => ({
+      name: d.planName,
+      value: d.count,
+      revenue: d.revenue,
+    }));
+
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={60}
+            outerRadius={100}
+            paddingAngle={2}
+            dataKey="value"
+            label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+          >
+            {data.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <RechartsTooltip
+            formatter={(value: any, name: string, props: any) => [
+              `${value} 用户 (¥${props.payload.revenue.toFixed(2)} 收入)`,
+              name,
+            ]}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  // Render funnel chart
+  const renderFunnelChart = () => {
+    if (!summary?.funnel?.length) return <Empty />;
+
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <FunnelChart>
+          <Funnel
+            dataKey="count"
+            data={summary.funnel}
+            isAnimationActive
+          >
+            <LabelList
+              position="right"
+              fill="#000"
+              stroke="none"
+              dataKey="stage"
+              formatter={(value: string, entry: any) => `${value} (${entry.payload.percentage.toFixed(1)}%)`}
+            />
+            {summary.funnel.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Funnel>
+        </FunnelChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  // Render churn analysis
+  const renderChurnChart = () => {
+    if (!summary?.churn?.length) return <Empty />;
+
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={summary.churn}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="month" />
+          <YAxis yAxisId="left" />
+          <YAxis yAxisId="right" orientation="right" />
+          <RechartsTooltip />
+          <Legend />
+          <Bar yAxisId="left" dataKey="churnedUsers" name="流失用户" fill="#F53F3F" />
+          <Bar yAxisId="left" dataKey="totalUsers" name="总用户" fill="#165DFF" />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  // Render revenue trend
+  const renderTrendChart = () => {
+    if (!trendData?.length) return <Empty />;
+
+    return (
+      <ResponsiveContainer width="100%" height={350}>
+        <AreaChart data={trendData}>
+          <defs>
+            <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#165DFF" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="#165DFF" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis />
+          <RechartsTooltip formatter={(value: any) => formatCurrency(value)} />
+          <Legend />
+          <Area
+            type="monotone"
+            dataKey="revenue"
+            name="收入"
+            stroke="#165DFF"
+            fillOpacity={1}
+            fill="url(#colorRevenue)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  return (
+    <ErrorBoundary>
+      <div style={{ padding: isMobile ? '16px' : '24px', maxWidth: 1400, margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24, flexWrap: 'wrap', gap: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <IconDashboard style={{ fontSize: 28, color: '#165DFF' }} />
+            <Title heading={3} style={{ margin: 0 }}>收入分析仪表板</Title>
+          </div>
+          <Space>
+            <RangePicker
+              value={dateRange}
+              onChange={(dates) => dates && setDateRange(dates as [Date, Date])}
+              style={{ width: 280 }}
+            />
+            <Select
+              value={granularity}
+              onChange={(value) => setGranularity(value)}
+              style={{ width: 120 }}
+            >
+              <Select.Option value="day">按日</Select.Option>
+              <Select.Option value="week">按周</Select.Option>
+              <Select.Option value="month">按月</Select.Option>
+            </Select>
+            <Button
+              type="primary"
+              icon={<IconRefresh />}
+              onClick={() => { fetchSummary(); fetchTrend(); }}
+            >
+              刷新
+            </Button>
+          </Space>
+        </div>
+
+        <Spin loading={loading} style={{ display: 'block' }}>
+          {/* Key Metrics */}
+          <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="MRR (月经常性收入)"
+                value={formatCurrency(summary?.metrics?.mrr || 0)}
+                icon={<IconArrowRise style={{ fontSize: 24 }} />}
+                color="#165DFF"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="ARR (年经常性收入)"
+                value={formatCurrency(summary?.metrics?.arr || 0)}
+                icon={<IconDashboard style={{ fontSize: 24 }} />}
+                color="#14C9C9"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="ARPU (每用户平均收入)"
+                value={formatCurrency(summary?.metrics?.arpu || 0)}
+                icon={<IconUser style={{ fontSize: 24 }} />}
+                color="#F7BA1E"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="LTV (用户终身价值)"
+                value={formatCurrency(summary?.metrics?.ltv || 0)}
+                icon={<IconTrophy style={{ fontSize: 24 }} />}
+                color="#722ED1"
+              />
+            </Col>
+          </Row>
+
+          {/* Secondary Metrics */}
+          <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="活跃订阅者"
+                value={summary?.metrics?.activeSubscribers || 0}
+                suffix="人"
+                icon={<IconUser style={{ fontSize: 24 }} />}
+                color="#00B42A"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="试用用户"
+                value={summary?.metrics?.trialUsers || 0}
+                suffix="人"
+                icon={<IconUser style={{ fontSize: 24 }} />}
+                color="#86909C"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="流失率"
+                value={formatPercent(summary?.metrics?.churnRate || 0)}
+                icon={<IconExclamationCircle style={{ fontSize: 24 }} />}
+                color="#F53F3F"
+              />
+            </Col>
+            <Col xs={24} sm={12} lg={6}>
+              <MetricCard
+                title="转化率"
+                value={formatPercent(summary?.metrics?.conversionRate || 0)}
+                icon={<IconApps style={{ fontSize: 24 }} />}
+                color="#165DFF"
+              />
+            </Col>
+          </Row>
+
+          {/* Charts Row 1 */}
+          <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+            <Col xs={24} lg={16}>
+              <Card title="收入趋势">
+                {renderTrendChart()}
+              </Card>
+            </Col>
+            <Col xs={24} lg={8}>
+              <Card title="订阅分布">
+                {renderDistributionChart()}
+              </Card>
+            </Col>
+          </Row>
+
+          {/* Charts Row 2 */}
+          <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
+            <Col xs={24} lg={12}>
+              <Card title="转化漏斗">
+                {renderFunnelChart()}
+              </Card>
+            </Col>
+            <Col xs={24} lg={12}>
+              <Card title="流失分析 (最近 6 个月)">
+                {renderChurnChart()}
+              </Card>
+            </Col>
+          </Row>
+
+          {/* Export Section */}
+          <Card title="数据导出">
+            <Space wrap>
+              <Button
+                icon={<IconDownload />}
+                onClick={exportPayments}
+              >
+                导出收入报表 (CSV)
+              </Button>
+              <Button
+                icon={<IconDownload />}
+                onClick={exportSubscribers}
+              >
+                导出订阅用户列表 (CSV)
+              </Button>
+            </Space>
+            <Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>
+              导出数据将包含选定时间范围内的所有交易和订阅信息
+            </Paragraph>
+          </Card>
+
+          {/* Distribution Table */}
+          {summary?.distribution && summary.distribution.length > 0 && (
+            <Card title="订阅计划详情" style={{ marginTop: 16 }}>
+              <Table
+                data={summary.distribution}
+                columns={[
+                  {
+                    title: '计划名称',
+                    dataIndex: 'planName',
+                    key: 'planName',
+                  },
+                  {
+                    title: '用户数',
+                    dataIndex: 'count',
+                    key: 'count',
+                    sorter: (a, b) => a.count - b.count,
+                  },
+                  {
+                    title: '占比',
+                    dataIndex: 'percentage',
+                    key: 'percentage',
+                    render: (value: number) => (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <Progress
+                          percent={value}
+                          size="small"
+                          style={{ width: 100 }}
+                          showText={false}
+                        />
+                        <Text>{value.toFixed(1)}%</Text>
+                      </div>
+                    ),
+                  },
+                  {
+                    title: '月收入',
+                    dataIndex: 'revenue',
+                    key: 'revenue',
+                    render: (value: number) => formatCurrency(value),
+                    sorter: (a, b) => a.revenue - b.revenue,
+                  },
+                ]}
+                rowKey="planId"
+                pagination={false}
+              />
+            </Card>
+          )}
+        </Spin>
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default AdminDashboardPage;

--- a/src/database/__tests__/revenue.dao.test.ts
+++ b/src/database/__tests__/revenue.dao.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Revenue DAO Tests
+ */
+
+import { RevenueDAO } from '../revenue.dao';
+
+// Mock Supabase client
+jest.mock('../client', () => ({
+  getSupabaseAdminClient: jest.fn(() => {
+    const mockChain = {
+      select: jest.fn(() => mockChain),
+      eq: jest.fn(() => mockChain),
+      in: jest.fn(() => mockChain),
+      neq: jest.fn(() => mockChain),
+      gte: jest.fn(() => mockChain),
+      lte: jest.fn(() => mockChain),
+      lt: jest.fn(() => mockChain),
+      order: jest.fn(() => mockChain),
+      limit: jest.fn(() => mockChain),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    
+    return {
+      from: jest.fn(() => mockChain),
+    };
+  }),
+}));
+
+describe('RevenueDAO', () => {
+  let dao: RevenueDAO;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { getSupabaseAdminClient } = require('../client');
+    const mockClient = getSupabaseAdminClient();
+    dao = new RevenueDAO(mockClient);
+  });
+
+  describe('constructor', () => {
+    it('should create instance', () => {
+      expect(dao).toBeDefined();
+    });
+  });
+
+  describe('getRevenueMetrics', () => {
+    it('should return metrics object with all required properties', async () => {
+      const result = await dao.getRevenueMetrics();
+      
+      expect(result).toHaveProperty('mrr');
+      expect(result).toHaveProperty('arr');
+      expect(result).toHaveProperty('arpu');
+      expect(result).toHaveProperty('totalRevenue');
+      expect(result).toHaveProperty('activeSubscribers');
+      expect(result).toHaveProperty('trialUsers');
+      expect(result).toHaveProperty('churnRate');
+      expect(result).toHaveProperty('ltv');
+      expect(result).toHaveProperty('conversionRate');
+      
+      // When no data, metrics should be 0
+      expect(result.mrr).toBe(0);
+      expect(result.arr).toBe(0);
+      expect(result.totalRevenue).toBe(0);
+      expect(result.activeSubscribers).toBe(0);
+    });
+  });
+
+  describe('getRevenueTrend', () => {
+    it('should return array of trends', async () => {
+      const startDate = new Date('2024-01-01');
+      const endDate = new Date('2024-01-07');
+      const result = await dao.getRevenueTrend({ startDate, endDate }, 'day');
+      
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getSubscriptionDistribution', () => {
+    it('should return distribution array', async () => {
+      const result = await dao.getSubscriptionDistribution();
+      
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getConversionFunnel', () => {
+    it('should return funnel stages', async () => {
+      const result = await dao.getConversionFunnel();
+      
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getChurnAnalysis', () => {
+    it('should return churn data for requested months', async () => {
+      const result = await dao.getChurnAnalysis(3);
+      
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(3);
+    });
+  });
+});

--- a/src/database/revenue.dao.ts
+++ b/src/database/revenue.dao.ts
@@ -1,0 +1,729 @@
+/**
+ * Revenue Analytics Data Access Object
+ * Handles database operations for revenue analytics, metrics, and reporting
+ */
+
+import { getSupabaseAdminClient } from './client';
+import { createLogger } from '../utils/logger';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+const log = createLogger('RevenueDAO');
+
+// Type definitions
+export interface RevenueMetrics {
+  mrr: number; // Monthly Recurring Revenue
+  arr: number; // Annual Recurring Revenue
+  arpu: number; // Average Revenue Per User
+  totalRevenue: number;
+  activeSubscribers: number;
+  trialUsers: number;
+  churnRate: number;
+  ltv: number; // Lifetime Value
+  conversionRate: number;
+}
+
+export interface RevenueTrend {
+  date: string;
+  revenue: number;
+  subscriptions: number;
+  churned: number;
+  newSubscribers: number;
+}
+
+export interface SubscriptionDistribution {
+  planId: string;
+  planName: string;
+  count: number;
+  percentage: number;
+  revenue: number;
+}
+
+export interface ConversionFunnel {
+  stage: string;
+  count: number;
+  percentage: number;
+}
+
+export interface ChurnData {
+  month: string;
+  churnedUsers: number;
+  totalUsers: number;
+  churnRate: number;
+  topReasons: string[];
+}
+
+export interface RevenueExport {
+  date: string;
+  userId: string;
+  userName: string;
+  userEmail: string;
+  planId: string;
+  planName: string;
+  amount: number;
+  currency: string;
+  status: string;
+  paymentMethod: string;
+}
+
+export interface SubscriberExport {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  planId: string;
+  planName: string;
+  status: string;
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  stripeCustomerId: string;
+  totalPayments: number;
+  totalRevenue: number;
+}
+
+export interface DateRange {
+  startDate: Date;
+  endDate: Date;
+}
+
+/**
+ * Revenue DAO Class
+ * Uses admin client for all operations (admin-only data)
+ */
+export class RevenueDAO {
+  private adminClient: SupabaseClient;
+
+  constructor(adminClient: SupabaseClient) {
+    this.adminClient = adminClient;
+  }
+
+  /**
+   * Get overall revenue metrics
+   */
+  async getRevenueMetrics(): Promise<RevenueMetrics> {
+    try {
+      // Get active subscriptions
+      const { data: activeSubs, error: subError } = await this.adminClient
+        .from('user_subscriptions')
+        .select('plan_id, status')
+        .in('status', ['active', 'trialing']);
+
+      if (subError) throw subError;
+
+      // Get plan prices
+      const { data: plans, error: planError } = await this.adminClient
+        .from('subscription_plans')
+        .select('id, name, price');
+
+      if (planError) throw planError;
+
+      const planMap = new Map(plans?.map(p => [p.id, { name: p.name, price: parseFloat(p.price) || 0 }]) || []);
+
+      // Calculate MRR
+      let mrr = 0;
+      let activeCount = 0;
+      let trialCount = 0;
+
+      (activeSubs || []).forEach(sub => {
+        const plan = planMap.get(sub.plan_id);
+        if (plan) {
+          if (sub.status === 'active') {
+            mrr += plan.price;
+            activeCount++;
+          } else if (sub.status === 'trialing') {
+            trialCount++;
+          }
+        }
+      });
+
+      // Get total revenue from payments
+      const { data: payments, error: payError } = await this.adminClient
+        .from('payment_history')
+        .select('amount')
+        .eq('status', 'succeeded');
+
+      if (payError) throw payError;
+
+      const totalRevenue = (payments || []).reduce((sum, p) => sum + (parseFloat(p.amount as any) || 0), 0);
+
+      // Calculate ARPU
+      const arpu = activeCount > 0 ? mrr / activeCount : 0;
+
+      // Calculate ARR
+      const arr = mrr * 12;
+
+      // Get churn rate (users who canceled in the last 30 days / total active at start)
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const { data: churned, error: churnError } = await this.adminClient
+        .from('subscription_history')
+        .select('user_id')
+        .eq('action', 'canceled')
+        .gte('created_at', thirtyDaysAgo.toISOString());
+
+      if (churnError) throw churnError;
+
+      // Get total users at start of period
+      const { count: totalUsersAtStart, error: countError } = await this.adminClient
+        .from('user_subscriptions')
+        .select('*', { count: 'exact', head: true })
+        .neq('status', 'expired');
+
+      if (countError) throw countError;
+
+      const churnRate = (totalUsersAtStart || 0) > 0 
+        ? ((churned?.length || 0) / totalUsersAtStart!) * 100 
+        : 0;
+
+      // Calculate LTV (average customer lifetime in months * ARPU)
+      // Average customer lifetime = 1 / churn rate (if churn rate > 0)
+      const avgLifetimeMonths = churnRate > 0 ? 100 / churnRate : 12; // Default to 12 months if no churn
+      const ltv = arpu * avgLifetimeMonths;
+
+      // Calculate conversion rate (trial to paid)
+      const { data: trials, error: trialError } = await this.adminClient
+        .from('subscription_history')
+        .select('user_id')
+        .eq('action', 'trial_started');
+
+      if (trialError) throw trialError;
+
+      const { data: converted, error: convError } = await this.adminClient
+        .from('subscription_history')
+        .select('user_id')
+        .in('action', ['upgraded', 'created'])
+        .neq('to_plan', 'free');
+
+      if (convError) throw convError;
+
+      const conversionRate = (trials?.length || 0) > 0 
+        ? ((converted?.length || 0) / trials!.length) * 100 
+        : 0;
+
+      return {
+        mrr: Math.round(mrr * 100) / 100,
+        arr: Math.round(arr * 100) / 100,
+        arpu: Math.round(arpu * 100) / 100,
+        totalRevenue: Math.round(totalRevenue * 100) / 100,
+        activeSubscribers: activeCount,
+        trialUsers: trialCount,
+        churnRate: Math.round(churnRate * 100) / 100,
+        ltv: Math.round(ltv * 100) / 100,
+        conversionRate: Math.round(conversionRate * 100) / 100,
+      };
+    } catch (error) {
+      log.error('Failed to get revenue metrics:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get revenue trend data
+   */
+  async getRevenueTrend(range: DateRange, granularity: 'day' | 'week' | 'month' = 'day'): Promise<RevenueTrend[]> {
+    try {
+      const { startDate, endDate } = range;
+      
+      // Get all payments in range
+      const { data: payments, error: payError } = await this.adminClient
+        .from('payment_history')
+        .select('amount, paid_at, status')
+        .eq('status', 'succeeded')
+        .gte('paid_at', startDate.toISOString())
+        .lte('paid_at', endDate.toISOString())
+        .order('paid_at', { ascending: true });
+
+      if (payError) throw payError;
+
+      // Get subscription history
+      const { data: history, error: histError } = await this.adminClient
+        .from('subscription_history')
+        .select('action, created_at')
+        .in('action', ['created', 'upgraded', 'canceled'])
+        .gte('created_at', startDate.toISOString())
+        .lte('created_at', endDate.toISOString())
+        .order('created_at', { ascending: true });
+
+      if (histError) throw histError;
+
+      // Group by date based on granularity
+      const groupedData = new Map<string, { revenue: number; subscriptions: number; churned: number; newSubscribers: number }>();
+
+      const formatDate = (date: Date): string => {
+        if (granularity === 'month') {
+          return date.toISOString().slice(0, 7); // YYYY-MM
+        } else if (granularity === 'week') {
+          const d = new Date(date);
+          d.setDate(d.getDate() - d.getDay()); // Start of week
+          return d.toISOString().slice(0, 10);
+        }
+        return date.toISOString().slice(0, 10); // YYYY-MM-DD
+      };
+
+      // Initialize all dates in range
+      const currentDate = new Date(startDate);
+      while (currentDate <= endDate) {
+        const key = formatDate(currentDate);
+        if (!groupedData.has(key)) {
+          groupedData.set(key, { revenue: 0, subscriptions: 0, churned: 0, newSubscribers: 0 });
+        }
+        if (granularity === 'month') {
+          currentDate.setMonth(currentDate.getMonth() + 1);
+        } else if (granularity === 'week') {
+          currentDate.setDate(currentDate.getDate() + 7);
+        } else {
+          currentDate.setDate(currentDate.getDate() + 1);
+        }
+      }
+
+      // Aggregate payments
+      (payments || []).forEach(payment => {
+        if (payment.paid_at) {
+          const key = formatDate(new Date(payment.paid_at));
+          const data = groupedData.get(key);
+          if (data) {
+            data.revenue += parseFloat(payment.amount as any) || 0;
+            data.subscriptions++;
+          }
+        }
+      });
+
+      // Aggregate subscription events
+      (history || []).forEach(event => {
+        if (event.created_at) {
+          const key = formatDate(new Date(event.created_at));
+          const data = groupedData.get(key);
+          if (data) {
+            if (event.action === 'canceled') {
+              data.churned++;
+            } else {
+              data.newSubscribers++;
+            }
+          }
+        }
+      });
+
+      // Convert to array and sort
+      const result = Array.from(groupedData.entries())
+        .map(([date, data]) => ({
+          date,
+          revenue: Math.round(data.revenue * 100) / 100,
+          subscriptions: data.subscriptions,
+          churned: data.churned,
+          newSubscribers: data.newSubscribers,
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+      return result;
+    } catch (error) {
+      log.error('Failed to get revenue trend:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get subscription distribution by plan
+   */
+  async getSubscriptionDistribution(): Promise<SubscriptionDistribution[]> {
+    try {
+      // Get active subscriptions grouped by plan
+      const { data: subs, error: subError } = await this.adminClient
+        .from('user_subscriptions')
+        .select('plan_id, status')
+        .neq('status', 'expired');
+
+      if (subError) throw subError;
+
+      // Get plan details
+      const { data: plans, error: planError } = await this.adminClient
+        .from('subscription_plans')
+        .select('id, name, price');
+
+      if (planError) throw planError;
+
+      const planMap = new Map(plans?.map(p => [p.id, { name: p.name, price: parseFloat(p.price) || 0 }]) || []);
+      const totalUsers = (subs || []).length;
+
+      // Count by plan
+      const planCounts = new Map<string, { count: number; revenue: number }>();
+      (subs || []).forEach(sub => {
+        const plan = planMap.get(sub.plan_id);
+        if (!planCounts.has(sub.plan_id)) {
+          planCounts.set(sub.plan_id, { count: 0, revenue: 0 });
+        }
+        const data = planCounts.get(sub.plan_id)!;
+        data.count++;
+        if (plan && sub.status === 'active') {
+          data.revenue += plan.price;
+        }
+      });
+
+      // Convert to array
+      const result: SubscriptionDistribution[] = [];
+      planCounts.forEach((data, planId) => {
+        const plan = planMap.get(planId);
+        result.push({
+          planId,
+          planName: plan?.name || planId,
+          count: data.count,
+          percentage: totalUsers > 0 ? Math.round((data.count / totalUsers) * 10000) / 100 : 0,
+          revenue: Math.round(data.revenue * 100) / 100,
+        });
+      });
+
+      return result.sort((a, b) => b.count - a.count);
+    } catch (error) {
+      log.error('Failed to get subscription distribution:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get conversion funnel data
+   */
+  async getConversionFunnel(): Promise<ConversionFunnel[]> {
+    try {
+      // Get total registered users
+      const { count: totalUsers, error: userError } = await this.adminClient
+        .from('users')
+        .select('*', { count: 'exact', head: true });
+
+      if (userError) throw userError;
+
+      // Get users who started a trial
+      const { data: trialStarts, error: trialError } = await this.adminClient
+        .from('subscription_history')
+        .select('user_id')
+        .eq('action', 'trial_started');
+
+      if (trialError) throw trialError;
+
+      const uniqueTrialUsers = new Set(trialStarts?.map(t => t.user_id) || []);
+
+      // Get users who became active subscribers
+      const { data: activeSubs, error: subError } = await this.adminClient
+        .from('user_subscriptions')
+        .select('user_id')
+        .eq('status', 'active');
+
+      if (subError) throw subError;
+
+      const uniqueSubscribers = new Set(activeSubs?.map(s => s.user_id) || []);
+
+      // Get users who are on paid plans
+      const { data: paidSubs, error: paidError } = await this.adminClient
+        .from('user_subscriptions')
+        .select('user_id, plan_id')
+        .eq('status', 'active')
+        .neq('plan_id', 'free');
+
+      if (paidError) throw paidError;
+
+      const uniquePaidSubscribers = new Set(paidSubs?.map(s => s.user_id) || []);
+
+      const total = totalUsers || 1;
+
+      return [
+        {
+          stage: '注册用户',
+          count: totalUsers || 0,
+          percentage: 100,
+        },
+        {
+          stage: '试用用户',
+          count: uniqueTrialUsers.size,
+          percentage: Math.round((uniqueTrialUsers.size / total) * 10000) / 100,
+        },
+        {
+          stage: '活跃订阅',
+          count: uniqueSubscribers.size,
+          percentage: Math.round((uniqueSubscribers.size / total) * 10000) / 100,
+        },
+        {
+          stage: '付费用户',
+          count: uniquePaidSubscribers.size,
+          percentage: Math.round((uniquePaidSubscribers.size / total) * 10000) / 100,
+        },
+      ];
+    } catch (error) {
+      log.error('Failed to get conversion funnel:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get churn analysis data
+   */
+  async getChurnAnalysis(months: number = 12): Promise<ChurnData[]> {
+    try {
+      const result: ChurnData[] = [];
+      const now = new Date();
+
+      for (let i = 0; i < months; i++) {
+        const monthEnd = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const monthStart = new Date(now.getFullYear(), now.getMonth() - i - 1, 1);
+        const monthKey = monthEnd.toISOString().slice(0, 7);
+
+        // Get churned users for this month
+        const { data: churned, error: churnError } = await this.adminClient
+          .from('subscription_history')
+          .select('user_id, reason')
+          .eq('action', 'canceled')
+          .gte('created_at', monthStart.toISOString())
+          .lt('created_at', monthEnd.toISOString());
+
+        if (churnError) throw churnError;
+
+        // Get total users at start of month
+        const { count: totalUsers, error: countError } = await this.adminClient
+          .from('user_subscriptions')
+          .select('*', { count: 'exact', head: true })
+          .lt('created_at', monthEnd.toISOString())
+          .neq('status', 'expired');
+
+        if (countError) throw countError;
+
+        // Get top cancellation reasons
+        const reasons = (churned || [])
+          .map(c => c.reason)
+          .filter(Boolean) as string[];
+
+        const reasonCounts = new Map<string, number>();
+        reasons.forEach(r => {
+          reasonCounts.set(r, (reasonCounts.get(r) || 0) + 1);
+        });
+
+        const topReasons = Array.from(reasonCounts.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 5)
+          .map(([reason]) => reason);
+
+        result.push({
+          month: monthKey,
+          churnedUsers: churned?.length || 0,
+          totalUsers: totalUsers || 0,
+          churnRate: (totalUsers ?? 0) > 0 
+            ? Math.round(((churned?.length || 0) / (totalUsers ?? 1)) * 10000) / 100 
+            : 0,
+          topReasons,
+        });
+      }
+
+      return result.reverse();
+    } catch (error) {
+      log.error('Failed to get churn analysis:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Export revenue data as CSV
+   */
+  async exportRevenueData(range: DateRange): Promise<RevenueExport[]> {
+    try {
+      const { startDate, endDate } = range;
+
+      // Get payments with user info
+      const { data: payments, error: payError } = await this.adminClient
+        .from('payment_history')
+        .select(`
+          id,
+          user_id,
+          amount,
+          currency,
+          status,
+          plan_id,
+          paid_at,
+          stripe_customer_id,
+          stripe_invoice_id
+        `)
+        .gte('paid_at', startDate.toISOString())
+        .lte('paid_at', endDate.toISOString())
+        .order('paid_at', { ascending: false });
+
+      if (payError) throw payError;
+
+      // Get user info
+      const userIds = [...new Set((payments || []).map(p => p.user_id))];
+      const { data: users, error: userError } = await this.adminClient
+        .from('users')
+        .select('id, name, email')
+        .in('id', userIds);
+
+      if (userError) throw userError;
+
+      const userMap = new Map(users?.map(u => [u.id, u]) || []);
+
+      // Get plan info
+      const { data: plans, error: planError } = await this.adminClient
+        .from('subscription_plans')
+        .select('id, name');
+
+      if (planError) throw planError;
+
+      const planMap = new Map(plans?.map(p => [p.id, p.name]) || []);
+
+      return (payments || []).map(payment => {
+        const user = userMap.get(payment.user_id);
+        return {
+          date: payment.paid_at ? new Date(payment.paid_at).toISOString() : '',
+          userId: payment.user_id,
+          userName: user?.name || '',
+          userEmail: user?.email || '',
+          planId: payment.plan_id || '',
+          planName: planMap.get(payment.plan_id || '') || payment.plan_id || '',
+          amount: parseFloat(payment.amount as any) || 0,
+          currency: payment.currency || 'CNY',
+          status: payment.status,
+          paymentMethod: payment.stripe_customer_id ? 'Stripe' : 'Unknown',
+        };
+      });
+    } catch (error) {
+      log.error('Failed to export revenue data:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Export subscriber list
+   */
+  async exportSubscriberList(): Promise<SubscriberExport[]> {
+    try {
+      // Get all active subscriptions
+      const { data: subs, error: subError } = await this.adminClient
+        .from('user_subscriptions')
+        .select(`
+          user_id,
+          plan_id,
+          status,
+          current_period_start,
+          current_period_end,
+          stripe_customer_id
+        `)
+        .neq('status', 'expired');
+
+      if (subError) throw subError;
+
+      // Get user info
+      const userIds = [...new Set((subs || []).map(s => s.user_id))];
+      const { data: users, error: userError } = await this.adminClient
+        .from('users')
+        .select('id, name, email')
+        .in('id', userIds);
+
+      if (userError) throw userError;
+
+      const userMap = new Map(users?.map(u => [u.id, u]) || []);
+
+      // Get plan info
+      const { data: plans, error: planError } = await this.adminClient
+        .from('subscription_plans')
+        .select('id, name');
+
+      if (planError) throw planError;
+
+      const planMap = new Map(plans?.map(p => [p.id, p.name]) || []);
+
+      // Get payment totals per user
+      const { data: payments, error: payError } = await this.adminClient
+        .from('payment_history')
+        .select('user_id, amount, status')
+        .eq('status', 'succeeded');
+
+      if (payError) throw payError;
+
+      const paymentTotals = new Map<string, { count: number; total: number }>();
+      (payments || []).forEach(p => {
+        const existing = paymentTotals.get(p.user_id) || { count: 0, total: 0 };
+        existing.count++;
+        existing.total += parseFloat(p.amount as any) || 0;
+        paymentTotals.set(p.user_id, existing);
+      });
+
+      return (subs || []).map(sub => {
+        const user = userMap.get(sub.user_id);
+        const paymentData = paymentTotals.get(sub.user_id) || { count: 0, total: 0 };
+        
+        return {
+          userId: sub.user_id,
+          userName: user?.name || '',
+          userEmail: user?.email || '',
+          planId: sub.plan_id,
+          planName: planMap.get(sub.plan_id) || sub.plan_id,
+          status: sub.status,
+          currentPeriodStart: sub.current_period_start,
+          currentPeriodEnd: sub.current_period_end,
+          stripeCustomerId: sub.stripe_customer_id || '',
+          totalPayments: paymentData.count,
+          totalRevenue: Math.round(paymentData.total * 100) / 100,
+        };
+      });
+    } catch (error) {
+      log.error('Failed to export subscriber list:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get revenue by time period (for charts)
+   */
+  async getRevenueByPeriod(
+    range: DateRange,
+    groupBy: 'day' | 'week' | 'month' = 'day'
+  ): Promise<{ period: string; revenue: number; count: number }[]> {
+    try {
+      const { startDate, endDate } = range;
+      
+      const { data: payments, error } = await this.adminClient
+        .from('payment_history')
+        .select('amount, paid_at')
+        .eq('status', 'succeeded')
+        .gte('paid_at', startDate.toISOString())
+        .lte('paid_at', endDate.toISOString())
+        .order('paid_at', { ascending: true });
+
+      if (error) throw error;
+
+      const grouped = new Map<string, { revenue: number; count: number }>();
+
+      const getPeriodKey = (date: Date): string => {
+        if (groupBy === 'month') {
+          return date.toISOString().slice(0, 7);
+        } else if (groupBy === 'week') {
+          const d = new Date(date);
+          d.setDate(d.getDate() - d.getDay());
+          return d.toISOString().slice(0, 10);
+        }
+        return date.toISOString().slice(0, 10);
+      };
+
+      (payments || []).forEach(payment => {
+        if (payment.paid_at) {
+          const key = getPeriodKey(new Date(payment.paid_at));
+          const existing = grouped.get(key) || { revenue: 0, count: 0 };
+          existing.revenue += parseFloat(payment.amount as any) || 0;
+          existing.count++;
+          grouped.set(key, existing);
+        }
+      });
+
+      return Array.from(grouped.entries())
+        .map(([period, data]) => ({
+          period,
+          revenue: Math.round(data.revenue * 100) / 100,
+          count: data.count,
+        }))
+        .sort((a, b) => a.period.localeCompare(b.period));
+    } catch (error) {
+      log.error('Failed to get revenue by period:', error);
+      throw error;
+    }
+  }
+}
+
+// Singleton instance
+let revenueDAO: RevenueDAO | null = null;
+
+export function getRevenueDAO(): RevenueDAO {
+  if (!revenueDAO) {
+    revenueDAO = new RevenueDAO(getSupabaseAdminClient());
+  }
+  return revenueDAO;
+}


### PR DESCRIPTION
## Issue
Closes #344

## 功能描述
为管理员提供收入和订阅数据的可视化仪表板。

## 实现内容

### 核心指标
- ✅ MRR (月经常性收入)
- ✅ ARR (年经常性收入)
- ✅ ARPU (每用户平均收入)
- ✅ 订阅转化率
- ✅ 流失率 (Churn Rate)
- ✅ LTV (用户终身价值)

### 可视化图表
- ✅ 收入趋势图（支持日/周/月粒度）
- ✅ 订阅分布饼图（按计划分类）
- ✅ 转化漏斗图
- ✅ 流失分析柱状图

### 数据导出
- ✅ 收入报表 CSV 导出
- ✅ 订阅用户列表导出

## 后端 API
- `GET /api/revenue/metrics` - 获取核心指标
- `GET /api/revenue/trend` - 获取收入趋势
- `GET /api/revenue/distribution` - 获取订阅分布
- `GET /api/revenue/funnel` - 获取转化漏斗
- `GET /api/revenue/churn` - 获取流失分析
- `GET /api/revenue/summary` - 获取仪表板汇总数据
- `GET /api/revenue/export/payments` - 导出收入报表
- `GET /api/revenue/export/subscribers` - 导出订阅用户列表

## 验收标准
- [x] 管理员可以查看实时收入数据
- [x] 图表正确显示各项指标
- [x] 可以按时间范围筛选数据
- [x] 支持导出报表

## 测试
- 添加了 RevenueDAO 的单元测试

## 截图
仪表板包含：
- 关键指标卡片（MRR, ARR, ARPU, LTV）
- 订阅统计卡片（活跃订阅者、试用用户、流失率、转化率）
- 收入趋势图
- 订阅分布饼图
- 转化漏斗图
- 流失分析图
- 数据导出按钮
- 订阅计划详情表格

## 访问路径
管理员可通过 `/admin/revenue` 路由访问此仪表板。