### PR TITLE
feat: 数据源抽象层

### DIFF
--- a/src/datasource/DataSourceManager.ts
+++ b/src/datasource/DataSourceManager.ts
@@ -1,0 +1,436 @@
+/**
+ * Data Source Manager
+ *
+ * Singleton manager for handling multiple data providers.
+ * Supports dynamic switching between providers, configuration management,
+ * and unified access to market data.
+ */
+
+import { EventEmitter } from 'events';
+import {
+  Quote,
+  Bar,
+  Trade,
+  OrderBook,
+  Ticker,
+  BarInterval,
+  DataSourceStatus,
+  DataSourceConfig,
+  DataSourceCapabilities,
+  DataSourceError,
+  DataSourceErrorType,
+  QuoteCallback,
+  BarCallback,
+  TradeCallback,
+  OrderBookCallback,
+  TickerCallback,
+  MarketInfo,
+} from './types';
+import { IStockDataProvider, BaseStockDataProvider } from './interface';
+
+/**
+ * Provider factory function type
+ */
+export type ProviderFactory = () => IStockDataProvider;
+
+/**
+ * Data source manager events
+ */
+export interface DataSourceManagerEvents {
+  'provider-registered': { providerId: string };
+  'provider-unregistered': { providerId: string };
+  'provider-switched': { from: string | null; to: string };
+  'provider-connected': { providerId: string };
+  'provider-disconnected': { providerId: string };
+  'provider-error': { providerId: string; error: Error };
+  'status-change': { status: DataSourceStatus };
+}
+
+/**
+ * Data Source Manager - Singleton
+ *
+ * Manages multiple data providers and provides a unified interface
+ * for accessing market data from different sources.
+ */
+export class DataSourceManager extends EventEmitter {
+  private static _instance: DataSourceManager | null = null;
+
+  /** Registered providers */
+  private _providers: Map<string, IStockDataProvider> = new Map();
+
+  /** Provider factories for lazy initialization */
+  private _factories: Map<string, ProviderFactory> = new Map();
+
+  /** Currently active provider */
+  private _activeProvider: IStockDataProvider | null = null;
+
+  /** Active provider ID */
+  private _activeProviderId: string | null = null;
+
+  /** Provider configurations */
+  private _configs: Map<string, DataSourceConfig> = new Map();
+
+  private constructor() {
+    super();
+  }
+
+  /**
+   * Get the singleton instance
+   */
+  static getInstance(): DataSourceManager {
+    if (!DataSourceManager._instance) {
+      DataSourceManager._instance = new DataSourceManager();
+    }
+    return DataSourceManager._instance;
+  }
+
+  /**
+   * Reset the singleton (useful for testing)
+   */
+  static resetInstance(): void {
+    if (DataSourceManager._instance) {
+      DataSourceManager._instance.disconnectAll();
+      DataSourceManager._instance = null;
+    }
+  }
+
+  // ========== Provider Registration ==========
+
+  /**
+   * Register a data provider
+   * @param provider The provider instance
+   * @param config Optional default configuration
+   */
+  registerProvider(provider: IStockDataProvider, config?: DataSourceConfig): void {
+    if (this._providers.has(provider.providerId)) {
+      console.warn(`[DataSourceManager] Provider "${provider.providerId}" already registered. Replacing.`);
+    }
+
+    this._providers.set(provider.providerId, provider);
+
+    if (config) {
+      this._configs.set(provider.providerId, config);
+    }
+
+    // Set up event forwarding
+    this.forwardProviderEvents(provider);
+
+    this.emit('provider-registered', { providerId: provider.providerId });
+
+    // If this is the first provider, auto-activate it (without auto-connect)
+    if (this._providers.size === 1 && !this._activeProvider) {
+      // Synchronously set the active provider without connecting
+      this._activeProvider = provider;
+      this._activeProviderId = provider.providerId;
+      this.emit('provider-switched', { from: null, to: provider.providerId });
+    }
+  }
+
+  /**
+   * Register a provider factory for lazy initialization
+   * @param providerId Provider identifier
+   * @param factory Factory function that creates the provider
+   * @param config Configuration to use when initializing
+   */
+  registerProviderFactory(
+    providerId: string,
+    factory: ProviderFactory,
+    config?: DataSourceConfig
+  ): void {
+    this._factories.set(providerId, factory);
+
+    if (config) {
+      this._configs.set(providerId, config);
+    }
+
+    this.emit('provider-registered', { providerId });
+  }
+
+  /**
+   * Unregister a provider
+   * @param providerId Provider identifier
+   */
+  async unregisterProvider(providerId: string): Promise<void> {
+    const provider = this._providers.get(providerId);
+
+    if (provider) {
+      await provider.disconnect();
+      this._providers.delete(providerId);
+    }
+
+    this._factories.delete(providerId);
+    this._configs.delete(providerId);
+
+    // If this was the active provider, clear it
+    if (this._activeProviderId === providerId) {
+      this._activeProvider = null;
+      this._activeProviderId = null;
+    }
+
+    this.emit('provider-unregistered', { providerId });
+  }
+
+  // ========== Provider Access ==========
+
+  /**
+   * Get all registered provider IDs
+   */
+  getProviderIds(): string[] {
+    const providerIds = new Set<string>();
+    Array.from(this._providers.keys()).forEach(id => providerIds.add(id));
+    Array.from(this._factories.keys()).forEach(id => providerIds.add(id));
+    return Array.from(providerIds);
+  }
+
+  /**
+   * Get a specific provider by ID
+   * @param providerId Provider identifier
+   * @param autoInitialize Whether to initialize lazy providers
+   */
+  async getProvider(providerId: string, autoInitialize: boolean = true): Promise<IStockDataProvider | null> {
+    // Check active providers first
+    const provider = this._providers.get(providerId);
+    if (provider) {
+      return provider;
+    }
+
+    // Try to initialize from factory
+    if (autoInitialize) {
+      const factory = this._factories.get(providerId);
+      if (factory) {
+        const newProvider = factory();
+        const config = this._configs.get(providerId);
+        this.registerProvider(newProvider, config);
+        return newProvider;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the currently active provider
+   */
+  getActiveProvider(): IStockDataProvider | null {
+    return this._activeProvider;
+  }
+
+  /**
+   * Get the active provider ID
+   */
+  getActiveProviderId(): string | null {
+    return this._activeProviderId;
+  }
+
+  // ========== Provider Switching ==========
+
+  /**
+   * Set the active provider
+   * @param providerId Provider identifier
+   * @param autoConnect Whether to automatically connect if not connected
+   */
+  async setActiveProvider(providerId: string, autoConnect: boolean = true): Promise<void> {
+    const provider = await this.getProvider(providerId);
+    if (!provider) {
+      throw new DataSourceError(
+        DataSourceErrorType.UNKNOWN,
+        `Provider "${providerId}" not found`,
+        providerId
+      );
+    }
+
+    const previousProviderId = this._activeProviderId;
+
+    // Disconnect previous provider if it's different
+    if (this._activeProvider && previousProviderId !== providerId) {
+      try {
+        await this._activeProvider.disconnect();
+      } catch (err) {
+        console.error(`[DataSourceManager] Error disconnecting ${previousProviderId}:`, err);
+      }
+    }
+
+    this._activeProvider = provider;
+    this._activeProviderId = providerId;
+
+    // Connect the new provider if needed
+    if (autoConnect && provider.status === DataSourceStatus.DISCONNECTED) {
+      const config = this._configs.get(providerId);
+      if (config) {
+        await provider.connect(config);
+      }
+    }
+
+    this.emit('provider-switched', { from: previousProviderId, to: providerId });
+  }
+
+  // ========== Configuration ==========
+
+  /**
+   * Set configuration for a provider
+   * @param providerId Provider identifier
+   * @param config Configuration
+   */
+  setConfig(providerId: string, config: DataSourceConfig): void {
+    this._configs.set(providerId, config);
+  }
+
+  /**
+   * Get configuration for a provider
+   * @param providerId Provider identifier
+   */
+  getConfig(providerId: string): DataSourceConfig | undefined {
+    return this._configs.get(providerId);
+  }
+
+  // ========== Connection Management ==========
+
+  /**
+   * Connect the active provider
+   */
+  async connect(): Promise<void> {
+    if (!this._activeProvider) {
+      throw new DataSourceError(
+        DataSourceErrorType.CONNECTION_ERROR,
+        'No active provider set',
+        this._activeProviderId ?? undefined
+      );
+    }
+
+    const config = this._configs.get(this._activeProviderId!);
+    if (!config) {
+      throw new DataSourceError(
+        DataSourceErrorType.AUTHENTICATION_ERROR,
+        'No configuration set for active provider',
+        this._activeProviderId ?? undefined
+      );
+    }
+
+    await this._activeProvider.connect(config);
+    this.emit('provider-connected', { providerId: this._activeProviderId! });
+  }
+
+  /**
+   * Disconnect all providers
+   */
+  async disconnectAll(): Promise<void> {
+    const disconnectPromises = Array.from(this._providers.values()).map(
+      provider => provider.disconnect().catch(err => {
+        console.error(`[DataSourceManager] Error disconnecting ${provider.providerId}:`, err);
+      })
+    );
+    await Promise.all(disconnectPromises);
+    this._activeProvider = null;
+    this._activeProviderId = null;
+  }
+
+  // ========== Proxy Methods to Active Provider ==========
+
+  private getProviderOrThrow(): IStockDataProvider {
+    if (!this._activeProvider) {
+      throw new DataSourceError(
+        DataSourceErrorType.CONNECTION_ERROR,
+        'No active provider. Call setActiveProvider() first.',
+        this._activeProviderId ?? undefined
+      );
+    }
+    return this._activeProvider;
+  }
+
+  get status(): DataSourceStatus {
+    return this._activeProvider?.status ?? DataSourceStatus.DISCONNECTED;
+  }
+
+  getCapabilities(): DataSourceCapabilities {
+    return this.getProviderOrThrow().getCapabilities();
+  }
+
+  async getQuote(symbol: string): Promise<Quote> {
+    return this.getProviderOrThrow().getQuote(symbol);
+  }
+
+  async getQuotes(symbols: string[]): Promise<Quote[]> {
+    return this.getProviderOrThrow().getQuotes(symbols);
+  }
+
+  async getBars(symbol: string, interval: BarInterval, limit?: number): Promise<Bar[]> {
+    return this.getProviderOrThrow().getBars(symbol, interval, limit);
+  }
+
+  async getBarsByRange(
+    symbol: string,
+    interval: BarInterval,
+    startTime: number,
+    endTime: number
+  ): Promise<Bar[]> {
+    return this.getProviderOrThrow().getBarsByRange(symbol, interval, startTime, endTime);
+  }
+
+  async getOrderBook(symbol: string, depth?: number): Promise<OrderBook> {
+    return this.getProviderOrThrow().getOrderBook(symbol, depth);
+  }
+
+  async getRecentTrades(symbol: string, limit?: number): Promise<Trade[]> {
+    return this.getProviderOrThrow().getRecentTrades(symbol, limit);
+  }
+
+  async getMarketInfo(symbol: string): Promise<MarketInfo> {
+    return this.getProviderOrThrow().getMarketInfo(symbol);
+  }
+
+  async getAvailableMarkets(): Promise<MarketInfo[]> {
+    return this.getProviderOrThrow().getAvailableMarkets();
+  }
+
+  subscribeToQuotes(symbol: string, callback: QuoteCallback): () => void {
+    return this.getProviderOrThrow().subscribeToQuotes(symbol, callback);
+  }
+
+  subscribeToBars(symbol: string, interval: BarInterval, callback: BarCallback): () => void {
+    return this.getProviderOrThrow().subscribeToBars(symbol, interval, callback);
+  }
+
+  subscribeToTrades(symbol: string, callback: TradeCallback): () => void {
+    return this.getProviderOrThrow().subscribeToTrades(symbol, callback);
+  }
+
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback): () => void {
+    return this.getProviderOrThrow().subscribeToOrderBook(symbol, callback);
+  }
+
+  subscribeToTicker(symbol: string, callback: TickerCallback): () => void {
+    return this.getProviderOrThrow().subscribeToTicker(symbol, callback);
+  }
+
+  subscribeToMultiQuotes(symbols: string[], onQuote: QuoteCallback): () => void {
+    return this.getProviderOrThrow().subscribeToMultiQuotes(symbols, onQuote);
+  }
+
+  unsubscribeAll(symbol: string): void {
+    this.getProviderOrThrow().unsubscribeAll(symbol);
+  }
+
+  unsubscribeFromAll(): void {
+    this.getProviderOrThrow().unsubscribeFromAll();
+  }
+
+  // ========== Event Handling ==========
+
+  private forwardProviderEvents(provider: IStockDataProvider): void {
+    // Check if provider is an EventEmitter
+    if ('on' in provider && typeof provider.on === 'function') {
+      // Forward status changes
+      (provider as any).on('statusChange', (data: any) => {
+        this.emit('status-change', data);
+      });
+
+      // Forward errors
+      (provider as any).on('error', (error: Error) => {
+        this.emit('provider-error', { providerId: provider.providerId, error });
+      });
+    }
+  }
+}
+
+// Export singleton getter
+export const getDataSourceManager = (): DataSourceManager => DataSourceManager.getInstance();

--- a/src/datasource/__tests__/DataSourceManager.test.ts
+++ b/src/datasource/__tests__/DataSourceManager.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for DataSourceManager
+ */
+
+import { DataSourceManager, getDataSourceManager } from '../DataSourceManager';
+import { MockDataProvider } from '../providers/MockDataProvider';
+import { DataSourceStatus } from '../types';
+
+describe('DataSourceManager', () => {
+  let manager: DataSourceManager;
+
+  beforeEach(() => {
+    // Reset singleton for each test
+    DataSourceManager.resetInstance();
+    manager = DataSourceManager.getInstance();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAll();
+    DataSourceManager.resetInstance();
+  });
+
+  describe('Singleton', () => {
+    it('should return the same instance', () => {
+      const instance1 = DataSourceManager.getInstance();
+      const instance2 = DataSourceManager.getInstance();
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should return the same instance via getDataSourceManager', () => {
+      const instance = getDataSourceManager();
+      expect(instance).toBe(manager);
+    });
+  });
+
+  describe('Provider Registration', () => {
+    it('should register a provider', () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+
+      const providerIds = manager.getProviderIds();
+      expect(providerIds).toContain('mock');
+    });
+
+    it('should register provider with config', () => {
+      const provider = new MockDataProvider();
+      const config = { providerId: 'mock', testnet: true };
+      manager.registerProvider(provider, config);
+
+      expect(manager.getConfig('mock')).toEqual(config);
+    });
+
+    it('should register provider factory', () => {
+      manager.registerProviderFactory('mock', () => new MockDataProvider());
+
+      const providerIds = manager.getProviderIds();
+      expect(providerIds).toContain('mock');
+    });
+
+    it('should emit provider-registered event', () => {
+      const listener = jest.fn();
+      manager.on('provider-registered', listener);
+
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+
+      expect(listener).toHaveBeenCalledWith({ providerId: 'mock' });
+    });
+  });
+
+  describe('Provider Unregistration', () => {
+    it('should unregister a provider', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+      await manager.unregisterProvider('mock');
+
+      const providerIds = manager.getProviderIds();
+      expect(providerIds).not.toContain('mock');
+    });
+
+    it('should emit provider-unregistered event', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+
+      const listener = jest.fn();
+      manager.on('provider-unregistered', listener);
+
+      await manager.unregisterProvider('mock');
+
+      expect(listener).toHaveBeenCalledWith({ providerId: 'mock' });
+    });
+
+    it('should clear active provider when unregistering it', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+      await manager.setActiveProvider('mock');
+
+      await manager.unregisterProvider('mock');
+
+      expect(manager.getActiveProvider()).toBeNull();
+      expect(manager.getActiveProviderId()).toBeNull();
+    });
+  });
+
+  describe('Active Provider', () => {
+    it('should set active provider', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider, { providerId: 'mock' });
+
+      await manager.setActiveProvider('mock', false);
+
+      expect(manager.getActiveProvider()).toBe(provider);
+      expect(manager.getActiveProviderId()).toBe('mock');
+    });
+
+    it('should auto-activate first registered provider', () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+
+      expect(manager.getActiveProviderId()).toBe('mock');
+    });
+
+    it('should emit provider-switched event', async () => {
+      // Reset to ensure clean state
+      DataSourceManager.resetInstance();
+      manager = DataSourceManager.getInstance();
+      
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider, { providerId: 'mock' });
+
+      const listener = jest.fn();
+      manager.on('provider-switched', listener);
+
+      // Since registerProvider already set it as active, we need to set it again
+      // which will emit the event with from: 'mock'
+      await manager.setActiveProvider('mock', false);
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('should throw error when setting non-existent provider', async () => {
+      await expect(manager.setActiveProvider('nonexistent')).rejects.toThrow();
+    });
+  });
+
+  describe('Connection', () => {
+    it('should connect to active provider', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider, { providerId: 'mock' });
+      await manager.setActiveProvider('mock', false);
+
+      await manager.connect();
+
+      expect(manager.status).toBe(DataSourceStatus.CONNECTED);
+    });
+
+    it('should throw error when connecting without active provider', async () => {
+      await expect(manager.connect()).rejects.toThrow('No active provider');
+    });
+
+    it('should throw error when connecting without config', async () => {
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider);
+      (manager as any)._activeProvider = provider;
+      (manager as any)._activeProviderId = 'mock';
+
+      await expect(manager.connect()).rejects.toThrow('No configuration');
+    });
+  });
+
+  describe('Provider Methods', () => {
+    beforeEach(async () => {
+      // Reset for clean state
+      DataSourceManager.resetInstance();
+      manager = DataSourceManager.getInstance();
+      
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider, { providerId: 'mock' });
+      await manager.connect();
+    });
+
+    afterEach(async () => {
+      await manager.disconnectAll();
+    });
+
+    it('should get quote', async () => {
+      const quote = await manager.getQuote('BTC/USDT');
+      expect(quote.symbol).toBe('BTC/USDT');
+      expect(quote.lastPrice).toBeGreaterThan(0);
+    });
+
+    it('should get quotes', async () => {
+      const quotes = await manager.getQuotes(['BTC/USDT', 'ETH/USDT']);
+      expect(quotes).toHaveLength(2);
+    });
+
+    it('should get bars', async () => {
+      const bars = await manager.getBars('BTC/USDT', '1m', 10);
+      expect(bars.length).toBeLessThanOrEqual(10);
+    });
+
+    it('should get order book', async () => {
+      const orderBook = await manager.getOrderBook('BTC/USDT', 5);
+      expect(orderBook.bids.length).toBe(5);
+      expect(orderBook.asks.length).toBe(5);
+    });
+
+    it('should get market info', async () => {
+      const marketInfo = await manager.getMarketInfo('BTC/USDT');
+      expect(marketInfo.symbol).toBe('BTC/USDT');
+      expect(marketInfo.baseCurrency).toBe('BTC');
+    });
+
+    it('should get available markets', async () => {
+      const markets = await manager.getAvailableMarkets();
+      expect(markets.length).toBeGreaterThan(0);
+    });
+
+    it('should throw error when no active provider', async () => {
+      await manager.disconnectAll();
+
+      expect(() => manager.getCapabilities()).toThrow('No active provider');
+    });
+  });
+
+  describe('Subscriptions', () => {
+    beforeEach(async () => {
+      // Reset for clean state
+      DataSourceManager.resetInstance();
+      manager = DataSourceManager.getInstance();
+      
+      const provider = new MockDataProvider();
+      manager.registerProvider(provider, { providerId: 'mock' });
+      await manager.connect();
+    });
+
+    afterEach(async () => {
+      await manager.disconnectAll();
+    });
+
+    it('should subscribe to quotes', () => {
+      const callback = jest.fn();
+      const unsubscribe = manager.subscribeToQuotes('BTC/USDT', callback);
+
+      expect(typeof unsubscribe).toBe('function');
+      unsubscribe();
+    });
+
+    it('should subscribe to order book', () => {
+      const callback = jest.fn();
+      const unsubscribe = manager.subscribeToOrderBook('BTC/USDT', callback);
+
+      expect(typeof unsubscribe).toBe('function');
+      unsubscribe();
+    });
+
+    it('should unsubscribe from all', () => {
+      manager.subscribeToQuotes('BTC/USDT', () => {});
+      manager.subscribeToOrderBook('BTC/USDT', () => {});
+
+      expect(() => manager.unsubscribeAll('BTC/USDT')).not.toThrow();
+    });
+  });
+});

--- a/src/datasource/__tests__/MockDataProvider.test.ts
+++ b/src/datasource/__tests__/MockDataProvider.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for MockDataProvider
+ */
+
+import { MockDataProvider } from '../providers/MockDataProvider';
+import { DataSourceStatus } from '../types';
+
+describe('MockDataProvider', () => {
+  let provider: MockDataProvider;
+
+  beforeEach(() => {
+    provider = new MockDataProvider();
+  });
+
+  afterEach(async () => {
+    if (provider.status === DataSourceStatus.CONNECTED) {
+      await provider.disconnect();
+    }
+  });
+
+  describe('Properties', () => {
+    it('should have correct name and id', () => {
+      expect(provider.name).toBe('Mock Data Provider');
+      expect(provider.providerId).toBe('mock');
+    });
+
+    it('should start disconnected', () => {
+      expect(provider.status).toBe(DataSourceStatus.DISCONNECTED);
+    });
+
+    it('should return capabilities', () => {
+      const caps = provider.getCapabilities();
+
+      expect(caps.realtimeQuotes).toBe(true);
+      expect(caps.historicalBars).toBe(true);
+      expect(caps.realtimeTrades).toBe(true);
+      expect(caps.realtimeOrderBook).toBe(true);
+      expect(caps.maxBarHistory).toBe(1000);
+    });
+  });
+
+  describe('Connection', () => {
+    it('should connect successfully', async () => {
+      await provider.connect({ providerId: 'mock' });
+      expect(provider.status).toBe(DataSourceStatus.CONNECTED);
+    });
+
+    it('should disconnect successfully', async () => {
+      await provider.connect({ providerId: 'mock' });
+      await provider.disconnect();
+      expect(provider.status).toBe(DataSourceStatus.DISCONNECTED);
+    });
+
+    it('should emit status change events', async () => {
+      const listener = jest.fn();
+      provider.on('statusChange', listener);
+
+      await provider.connect({ providerId: 'mock' });
+      // Status changes: DISCONNECTED -> CONNECTING -> CONNECTED
+      await provider.disconnect();
+      // Status changes: CONNECTED -> DISCONNECTED
+
+      // Should have at least 2 status changes
+      expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('Quote Data', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should get quote for BTC/USDT', async () => {
+      const quote = await provider.getQuote('BTC/USDT');
+
+      expect(quote.symbol).toBe('BTC/USDT');
+      expect(quote.lastPrice).toBeGreaterThan(0);
+      expect(quote.bid).toBeLessThan(quote.ask);
+      expect(quote.timestamp).toBeGreaterThan(0);
+    });
+
+    it('should get quotes for multiple symbols', async () => {
+      const quotes = await provider.getQuotes(['BTC/USDT', 'ETH/USDT']);
+
+      expect(quotes).toHaveLength(2);
+      expect(quotes[0].symbol).toBe('BTC/USDT');
+      expect(quotes[1].symbol).toBe('ETH/USDT');
+    });
+
+    it('should throw error for invalid symbol', async () => {
+      await expect(provider.getQuote('INVALID/PAIR')).rejects.toThrow();
+    });
+
+    it('should normalize symbol format', async () => {
+      const quote1 = await provider.getQuote('btc-usdt');
+      const quote2 = await provider.getQuote('BTC/USDT');
+
+      expect(quote1.symbol).toBe(quote2.symbol);
+    });
+  });
+
+  describe('Bar Data', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should get bars with default limit', async () => {
+      const bars = await provider.getBars('BTC/USDT', '1m');
+
+      expect(bars.length).toBe(100);
+    });
+
+    it('should get bars with custom limit', async () => {
+      const bars = await provider.getBars('BTC/USDT', '5m', 50);
+
+      expect(bars.length).toBe(50);
+    });
+
+    it('should return bars in correct order', async () => {
+      const bars = await provider.getBars('BTC/USDT', '1h', 10);
+
+      for (let i = 1; i < bars.length; i++) {
+        expect(bars[i].openTime).toBeGreaterThan(bars[i - 1].openTime);
+      }
+    });
+
+    it('should include OHLCV data', async () => {
+      const bars = await provider.getBars('BTC/USDT', '1d', 1);
+      const bar = bars[0];
+
+      expect(bar.open).toBeGreaterThan(0);
+      expect(bar.high).toBeGreaterThanOrEqual(bar.open);
+      expect(bar.high).toBeGreaterThanOrEqual(bar.close);
+      expect(bar.low).toBeLessThanOrEqual(bar.open);
+      expect(bar.low).toBeLessThanOrEqual(bar.close);
+      expect(bar.volume).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should get bars by time range', async () => {
+      const now = Date.now();
+      const startTime = now - 3600000; // 1 hour ago
+      const endTime = now;
+
+      const bars = await provider.getBarsByRange('BTC/USDT', '1m', startTime, endTime);
+
+      expect(bars.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Order Book', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should get order book with default depth', async () => {
+      const orderBook = await provider.getOrderBook('BTC/USDT');
+
+      expect(orderBook.symbol).toBe('BTC/USDT');
+      expect(orderBook.bids.length).toBe(20);
+      expect(orderBook.asks.length).toBe(20);
+    });
+
+    it('should get order book with custom depth', async () => {
+      const orderBook = await provider.getOrderBook('BTC/USDT', 5);
+
+      expect(orderBook.bids.length).toBe(5);
+      expect(orderBook.asks.length).toBe(5);
+    });
+
+    it('should have bids sorted by price descending', async () => {
+      const orderBook = await provider.getOrderBook('BTC/USDT', 10);
+
+      for (let i = 1; i < orderBook.bids.length; i++) {
+        expect(orderBook.bids[i].price).toBeLessThan(orderBook.bids[i - 1].price);
+      }
+    });
+
+    it('should have asks sorted by price ascending', async () => {
+      const orderBook = await provider.getOrderBook('BTC/USDT', 10);
+
+      for (let i = 1; i < orderBook.asks.length; i++) {
+        expect(orderBook.asks[i].price).toBeGreaterThan(orderBook.asks[i - 1].price);
+      }
+    });
+  });
+
+  describe('Trade Data', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should get recent trades', async () => {
+      const trades = await provider.getRecentTrades('BTC/USDT', 50);
+
+      expect(trades.length).toBe(50);
+      trades.forEach(trade => {
+        expect(trade.symbol).toBe('BTC/USDT');
+        expect(trade.price).toBeGreaterThan(0);
+        expect(['buy', 'sell']).toContain(trade.side);
+      });
+    });
+
+    it('should return trades in chronological order', async () => {
+      const trades = await provider.getRecentTrades('BTC/USDT', 10);
+
+      // Trades should generally be in order, but timestamps have some randomness
+      // Just verify the first and last are in expected order
+      expect(trades[trades.length - 1].timestamp).toBeGreaterThanOrEqual(trades[0].timestamp - 60000);
+    });
+  });
+
+  describe('Market Info', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should get market info', async () => {
+      const info = await provider.getMarketInfo('BTC/USDT');
+
+      expect(info.symbol).toBe('BTC/USDT');
+      expect(info.baseCurrency).toBe('BTC');
+      expect(info.quoteCurrency).toBe('USDT');
+      expect(info.isActive).toBe(true);
+    });
+
+    it('should get available markets', async () => {
+      const markets = await provider.getAvailableMarkets();
+
+      expect(markets.length).toBeGreaterThan(0);
+      const btcMarket = markets.find(m => m.symbol === 'BTC/USDT');
+      expect(btcMarket).toBeDefined();
+    });
+  });
+
+  describe('Subscriptions', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should subscribe to quotes', async () => {
+      const callback = jest.fn();
+      const unsubscribe = provider.subscribeToQuotes('BTC/USDT', callback);
+
+      // Wait for at least one update
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      expect(callback).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it('should unsubscribe from quotes', async () => {
+      const callback = jest.fn();
+      const unsubscribe = provider.subscribeToQuotes('BTC/USDT', callback);
+
+      unsubscribe();
+
+      // Wait to ensure no more updates
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      const callCount = callback.mock.calls.length;
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      // Should not have more calls after unsubscribe
+      expect(callback.mock.calls.length).toBe(callCount);
+    });
+
+    it('should subscribe to order book', async () => {
+      const callback = jest.fn();
+      const unsubscribe = provider.subscribeToOrderBook('BTC/USDT', callback);
+
+      // Wait for at least one update
+      await new Promise(resolve => setTimeout(resolve, 600));
+
+      expect(callback).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it('should unsubscribe from all', async () => {
+      provider.subscribeToQuotes('BTC/USDT', () => {});
+      provider.subscribeToOrderBook('BTC/USDT', () => {});
+
+      expect(() => provider.unsubscribeAll('BTC/USDT')).not.toThrow();
+    });
+
+    it('should unsubscribe from all symbols', async () => {
+      provider.subscribeToQuotes('BTC/USDT', () => {});
+      provider.subscribeToQuotes('ETH/USDT', () => {});
+
+      expect(() => provider.unsubscribeFromAll()).not.toThrow();
+    });
+  });
+
+  describe('Multi-Symbol Subscription', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should subscribe to multiple symbols', async () => {
+      const quotes: any[] = [];
+      const unsubscribe = provider.subscribeToMultiQuotes(
+        ['BTC/USDT', 'ETH/USDT'],
+        quote => quotes.push(quote)
+      );
+
+      // Wait for updates
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      expect(quotes.length).toBeGreaterThan(0);
+      unsubscribe();
+    });
+  });
+
+  describe('Custom Markets', () => {
+    beforeEach(async () => {
+      await provider.connect({ providerId: 'mock' });
+    });
+
+    it('should add custom market', async () => {
+      provider.addMarket({
+        symbol: 'CUSTOM/USDT',
+        basePrice: 100,
+        volatility: 0.02,
+        tickSize: 0.01,
+        baseCurrency: 'CUSTOM',
+        quoteCurrency: 'USDT',
+      });
+
+      const quote = await provider.getQuote('CUSTOM/USDT');
+      expect(quote.symbol).toBe('CUSTOM/USDT');
+    });
+
+    it('should set custom price', async () => {
+      provider.setPrice('BTC/USDT', 55000);
+
+      const quote = await provider.getQuote('BTC/USDT');
+      // Allow larger variance due to volatility simulation (up to 10%)
+      expect(quote.lastPrice).toBeGreaterThan(45000);
+      expect(quote.lastPrice).toBeLessThan(65000);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should throw error when not connected', async () => {
+      await expect(provider.getQuote('BTC/USDT')).rejects.toThrow('Not connected');
+    });
+
+    it('should throw error for invalid symbol when connected', async () => {
+      await provider.connect({ providerId: 'mock' });
+      await expect(provider.getQuote('INVALID')).rejects.toThrow('Market not found');
+    });
+  });
+});

--- a/src/datasource/__tests__/types.test.ts
+++ b/src/datasource/__tests__/types.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for Data Source Types
+ */
+
+import {
+  DataSourceStatus,
+  DataSourceErrorType,
+  DataSourceError,
+} from '../types';
+
+describe('DataSourceStatus', () => {
+  it('should have correct status values', () => {
+    expect(DataSourceStatus.DISCONNECTED).toBe('disconnected');
+    expect(DataSourceStatus.CONNECTING).toBe('connecting');
+    expect(DataSourceStatus.CONNECTED).toBe('connected');
+    expect(DataSourceStatus.RECONNECTING).toBe('reconnecting');
+    expect(DataSourceStatus.ERROR).toBe('error');
+  });
+});
+
+describe('DataSourceErrorType', () => {
+  it('should have correct error types', () => {
+    expect(DataSourceErrorType.CONNECTION_ERROR).toBe('connection_error');
+    expect(DataSourceErrorType.AUTHENTICATION_ERROR).toBe('authentication_error');
+    expect(DataSourceErrorType.RATE_LIMIT_ERROR).toBe('rate_limit_error');
+    expect(DataSourceErrorType.INVALID_SYMBOL).toBe('invalid_symbol');
+    expect(DataSourceErrorType.INVALID_INTERVAL).toBe('invalid_interval');
+    expect(DataSourceErrorType.TIMEOUT).toBe('timeout');
+    expect(DataSourceErrorType.SUBSCRIPTION_ERROR).toBe('subscription_error');
+    expect(DataSourceErrorType.UNKNOWN).toBe('unknown');
+  });
+});
+
+describe('DataSourceError', () => {
+  it('should create error with all properties', () => {
+    const originalError = new Error('Original error');
+    const error = new DataSourceError(
+      DataSourceErrorType.CONNECTION_ERROR,
+      'Connection failed',
+      'mock',
+      originalError
+    );
+
+    expect(error.name).toBe('DataSourceError');
+    expect(error.type).toBe(DataSourceErrorType.CONNECTION_ERROR);
+    expect(error.message).toBe('Connection failed');
+    expect(error.providerId).toBe('mock');
+    expect(error.originalError).toBe(originalError);
+  });
+
+  it('should create error with minimal properties', () => {
+    const error = new DataSourceError(
+      DataSourceErrorType.UNKNOWN,
+      'Unknown error'
+    );
+
+    expect(error.name).toBe('DataSourceError');
+    expect(error.type).toBe(DataSourceErrorType.UNKNOWN);
+    expect(error.message).toBe('Unknown error');
+    expect(error.providerId).toBeUndefined();
+    expect(error.originalError).toBeUndefined();
+  });
+});

--- a/src/datasource/index.ts
+++ b/src/datasource/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Data Source Module
+ *
+ * Provides a unified interface for accessing market data from multiple sources.
+ * Supports switching between different data providers (Mock, Binance, Alpaca, etc.)
+ */
+
+// Core types
+export * from './types';
+
+// Interface
+export * from './interface';
+
+// Manager
+export { DataSourceManager, getDataSourceManager, ProviderFactory } from './DataSourceManager';
+
+// Providers
+export { MockDataProvider } from './providers/MockDataProvider';
+
+// Convenience exports for common use cases
+import { getDataSourceManager } from './DataSourceManager';
+import { MockDataProvider } from './providers/MockDataProvider';
+import { DataSourceConfig } from './types';
+
+/**
+ * Initialize the default mock data source
+ * Convenience function for quick setup
+ */
+export async function initializeMockDataSource(config?: Partial<DataSourceConfig>): Promise<void> {
+  const manager = getDataSourceManager();
+  const provider = new MockDataProvider();
+  
+  const fullConfig: DataSourceConfig = {
+    providerId: 'mock',
+    ...config,
+  };
+  
+  manager.registerProvider(provider, fullConfig);
+  await manager.connect();
+}
+
+/**
+ * Get the current active provider
+ * Convenience function for direct access
+ */
+export function getActiveProvider() {
+  return getDataSourceManager().getActiveProvider();
+}

--- a/src/datasource/interface.ts
+++ b/src/datasource/interface.ts
@@ -1,0 +1,336 @@
+/**
+ * Stock Data Provider Interface
+ *
+ * Defines the unified interface that all data providers must implement.
+ * This enables seamless switching between different data sources
+ * (mock, Binance, Alpaca, Polygon.io, etc.)
+ */
+
+import {
+  Quote,
+  Bar,
+  Trade,
+  OrderBook,
+  Ticker,
+  BarInterval,
+  DataSourceStatus,
+  DataSourceConfig,
+  DataSourceCapabilities,
+  DataSourceError,
+  DataSourceErrorType,
+  QuoteCallback,
+  BarCallback,
+  TradeCallback,
+  OrderBookCallback,
+  TickerCallback,
+  MarketInfo,
+} from './types';
+
+/**
+ * Stock Data Provider Interface
+ *
+ * All data providers (Mock, Binance, Alpaca, etc.) must implement this interface.
+ */
+export interface IStockDataProvider {
+  /** Provider name for display purposes */
+  readonly name: string;
+
+  /** Provider identifier (e.g., 'mock', 'binance', 'alpaca') */
+  readonly providerId: string;
+
+  /** Current connection status */
+  readonly status: DataSourceStatus;
+
+  /** Provider capabilities */
+  getCapabilities(): DataSourceCapabilities;
+
+  /**
+   * Connect to the data source
+   * @param config Configuration options (API keys, endpoints, etc.)
+   */
+  connect(config: DataSourceConfig): Promise<void>;
+
+  /**
+   * Disconnect from the data source
+   */
+  disconnect(): Promise<void>;
+
+  // ========== Quote Data ==========
+
+  /**
+   * Get current quote for a symbol
+   * @param symbol Trading symbol (e.g., 'BTC/USDT', 'AAPL')
+   */
+  getQuote(symbol: string): Promise<Quote>;
+
+  /**
+   * Get quotes for multiple symbols
+   * @param symbols Array of trading symbols
+   */
+  getQuotes(symbols: string[]): Promise<Quote[]>;
+
+  // ========== Bar Data ==========
+
+  /**
+   * Get historical bar data
+   * @param symbol Trading symbol
+   * @param interval Bar interval (e.g., '1m', '5m', '1h', '1d')
+   * @param limit Number of bars to return (max: capabilities.maxBarHistory)
+   */
+  getBars(symbol: string, interval: BarInterval, limit?: number): Promise<Bar[]>;
+
+  /**
+   * Get historical bar data for a time range
+   * @param symbol Trading symbol
+   * @param interval Bar interval
+   * @param startTime Start timestamp (inclusive)
+   * @param endTime End timestamp (inclusive)
+   */
+  getBarsByRange(
+    symbol: string,
+    interval: BarInterval,
+    startTime: number,
+    endTime: number
+  ): Promise<Bar[]>;
+
+  // ========== Order Book ==========
+
+  /**
+   * Get order book snapshot
+   * @param symbol Trading symbol
+   * @param depth Number of price levels (default: 20, max: capabilities.maxOrderBookDepth)
+   */
+  getOrderBook(symbol: string, depth?: number): Promise<OrderBook>;
+
+  // ========== Trade Data ==========
+
+  /**
+   * Get recent trades
+   * @param symbol Trading symbol
+   * @param limit Number of trades to return
+   */
+  getRecentTrades(symbol: string, limit?: number): Promise<Trade[]>;
+
+  // ========== Market Info ==========
+
+  /**
+   * Get market information for a symbol
+   * @param symbol Trading symbol
+   */
+  getMarketInfo(symbol: string): Promise<MarketInfo>;
+
+  /**
+   * Get all available markets/symbols
+   */
+  getAvailableMarkets(): Promise<MarketInfo[]>;
+
+  // ========== Real-time Subscriptions ==========
+
+  /**
+   * Subscribe to quote updates for a symbol
+   * @param symbol Trading symbol
+   * @param callback Function to call when quote updates
+   * @returns Unsubscribe function
+   */
+  subscribeToQuotes(symbol: string, callback: QuoteCallback): () => void;
+
+  /**
+   * Subscribe to bar updates for a symbol
+   * @param symbol Trading symbol
+   * @param interval Bar interval
+   * @param callback Function to call when bar updates
+   * @returns Unsubscribe function
+   */
+  subscribeToBars(
+    symbol: string,
+    interval: BarInterval,
+    callback: BarCallback
+  ): () => void;
+
+  /**
+   * Subscribe to trade stream for a symbol
+   * @param symbol Trading symbol
+   * @param callback Function to call when a trade occurs
+   * @returns Unsubscribe function
+   */
+  subscribeToTrades(symbol: string, callback: TradeCallback): () => void;
+
+  /**
+   * Subscribe to order book updates
+   * @param symbol Trading symbol
+   * @param callback Function to call when order book updates
+   * @returns Unsubscribe function
+   */
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback): () => void;
+
+  /**
+   * Subscribe to ticker updates
+   * @param symbol Trading symbol
+   * @param callback Function to call when ticker updates
+   * @returns Unsubscribe function
+   */
+  subscribeToTicker(symbol: string, callback: TickerCallback): () => void;
+
+  /**
+   * Subscribe to multiple symbols at once
+   * @param symbols Array of trading symbols
+   * @param onQuote Callback for quote updates
+   * @returns Unsubscribe function
+   */
+  subscribeToMultiQuotes(
+    symbols: string[],
+    onQuote: QuoteCallback
+  ): () => void;
+
+  /**
+   * Unsubscribe from all subscriptions for a symbol
+   * @param symbol Trading symbol
+   */
+  unsubscribeAll(symbol: string): void;
+
+  /**
+   * Unsubscribe from all subscriptions
+   */
+  unsubscribeFromAll(): void;
+}
+
+/**
+ * Base class for data providers
+ * Provides common utilities and default implementations
+ */
+export abstract class BaseStockDataProvider implements IStockDataProvider {
+  abstract readonly name: string;
+  abstract readonly providerId: string;
+
+  protected _status: DataSourceStatus = DataSourceStatus.DISCONNECTED;
+  protected _config: DataSourceConfig | null = null;
+  protected _subscriptions: Map<string, Set<() => void>> = new Map();
+
+  get status(): DataSourceStatus {
+    return this._status;
+  }
+
+  abstract getCapabilities(): DataSourceCapabilities;
+  abstract connect(config: DataSourceConfig): Promise<void>;
+  abstract disconnect(): Promise<void>;
+  abstract getQuote(symbol: string): Promise<Quote>;
+  abstract getQuotes(symbols: string[]): Promise<Quote[]>;
+  abstract getBars(symbol: string, interval: BarInterval, limit?: number): Promise<Bar[]>;
+  abstract getBarsByRange(symbol: string, interval: BarInterval, startTime: number, endTime: number): Promise<Bar[]>;
+  abstract getOrderBook(symbol: string, depth?: number): Promise<OrderBook>;
+  abstract getRecentTrades(symbol: string, limit?: number): Promise<Trade[]>;
+  abstract getMarketInfo(symbol: string): Promise<MarketInfo>;
+  abstract getAvailableMarkets(): Promise<MarketInfo[]>;
+  abstract subscribeToQuotes(symbol: string, callback: QuoteCallback): () => void;
+  abstract subscribeToBars(symbol: string, interval: BarInterval, callback: BarCallback): () => void;
+  abstract subscribeToTrades(symbol: string, callback: TradeCallback): () => void;
+  abstract subscribeToOrderBook(symbol: string, callback: OrderBookCallback): () => void;
+  abstract subscribeToTicker(symbol: string, callback: TickerCallback): () => void;
+
+  /**
+   * Default implementation for multi-symbol subscription
+   * Providers can override for more efficient batch subscriptions
+   */
+  subscribeToMultiQuotes(symbols: string[], onQuote: QuoteCallback): () => void {
+    const unsubscribers = symbols.map(symbol => 
+      this.subscribeToQuotes(symbol, onQuote)
+    );
+    return () => {
+      unsubscribers.forEach(unsub => unsub());
+    };
+  }
+
+  unsubscribeAll(symbol: string): void {
+    const subs = this._subscriptions.get(symbol);
+    if (subs) {
+      subs.forEach(unsub => unsub());
+      this._subscriptions.delete(symbol);
+    }
+  }
+
+  unsubscribeFromAll(): void {
+    this._subscriptions.forEach(subs => {
+      subs.forEach(unsub => unsub());
+    });
+    this._subscriptions.clear();
+  }
+
+  protected setStatus(status: DataSourceStatus): void {
+    const previousStatus = this._status;
+    this._status = status;
+    if (previousStatus !== status) {
+      this.emit('statusChange', { previousStatus, status, timestamp: Date.now() });
+    }
+  }
+
+  protected trackSubscription(symbol: string, unsubscribe: () => void): void {
+    if (!this._subscriptions.has(symbol)) {
+      this._subscriptions.set(symbol, new Set());
+    }
+    this._subscriptions.get(symbol)!.add(unsubscribe);
+  }
+
+  protected removeSubscription(symbol: string, unsubscribe: () => void): void {
+    const subs = this._subscriptions.get(symbol);
+    if (subs) {
+      subs.delete(unsubscribe);
+      if (subs.size === 0) {
+        this._subscriptions.delete(symbol);
+      }
+    }
+  }
+
+  /**
+   * Emit an event (to be overridden by EventEmitter-based implementations)
+   */
+  protected emit(event: string, data: unknown): void {
+    // Default: no-op. Override in subclasses that need event emission.
+  }
+
+  /**
+   * Validate that the provider is connected
+   */
+  protected ensureConnected(): void {
+    if (this._status !== DataSourceStatus.CONNECTED) {
+      throw new DataSourceError(
+        DataSourceErrorType.CONNECTION_ERROR,
+        `Not connected to ${this.name}`,
+        this.providerId
+      );
+    }
+  }
+
+  /**
+   * Validate configuration
+   */
+  protected validateConfig(config: DataSourceConfig): void {
+    if (!config.providerId) {
+      throw new DataSourceError(
+        DataSourceErrorType.AUTHENTICATION_ERROR,
+        'Provider ID is required',
+        this.providerId
+      );
+    }
+  }
+
+  /**
+   * Normalize symbol format
+   */
+  protected normalizeSymbol(symbol: string): string {
+    return symbol.toUpperCase().replace(/[-_]/g, '/');
+  }
+
+  /**
+   * Sleep utility
+   */
+  protected sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Generate unique ID
+   */
+  protected generateId(prefix: string = ''): string {
+    return `${prefix}${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+}

--- a/src/datasource/providers/MockDataProvider.ts
+++ b/src/datasource/providers/MockDataProvider.ts
@@ -1,0 +1,678 @@
+/**
+ * Mock Data Provider
+ *
+ * Adapter that wraps the existing MockExchangeAdapter and implements
+ * the IStockDataProvider interface. Provides simulated market data
+ * for testing and development.
+ */
+
+import { EventEmitter } from 'events';
+import {
+  Quote,
+  Bar,
+  Trade,
+  OrderBook,
+  Ticker,
+  BarInterval,
+  DataSourceStatus,
+  DataSourceConfig,
+  DataSourceCapabilities,
+  DataSourceError,
+  DataSourceErrorType,
+  QuoteCallback,
+  BarCallback,
+  TradeCallback,
+  OrderBookCallback,
+  TickerCallback,
+  MarketInfo,
+  OrderBookLevel,
+} from '../types';
+import { IStockDataProvider, BaseStockDataProvider } from '../interface';
+
+/**
+ * Mock market configuration
+ */
+interface MockMarket {
+  symbol: string;
+  basePrice: number;
+  volatility: number;
+  tickSize: number;
+  baseCurrency: string;
+  quoteCurrency: string;
+}
+
+/**
+ * Mock Data Provider
+ *
+ * Provides simulated market data for testing purposes.
+ * Generates realistic-looking price movements and order books.
+ */
+export class MockDataProvider extends EventEmitter implements IStockDataProvider {
+  readonly name = 'Mock Data Provider';
+  readonly providerId = 'mock';
+
+  private _status: DataSourceStatus = DataSourceStatus.DISCONNECTED;
+  private _config: DataSourceConfig | null = null;
+  private _markets: Map<string, MockMarket> = new Map();
+  private _prices: Map<string, number> = new Map();
+
+  // Subscription management
+  private _quoteSubscriptions: Map<string, Set<QuoteCallback>> = new Map();
+  private _barSubscriptions: Map<string, Map<string, Set<BarCallback>>> = new Map();
+  private _tradeSubscriptions: Map<string, Set<TradeCallback>> = new Map();
+  private _orderBookSubscriptions: Map<string, Set<OrderBookCallback>> = new Map();
+  private _tickerSubscriptions: Map<string, Set<TickerCallback>> = new Map();
+
+  // Timers for generating updates
+  private _quoteTimers: Map<string, NodeJS.Timeout> = new Map();
+  private _barTimers: Map<string, NodeJS.Timeout> = new Map();
+  private _orderBookTimers: Map<string, NodeJS.Timeout> = new Map();
+
+  // Bar data storage
+  private _bars: Map<string, Map<string, Bar[]>> = new Map();
+
+  // Trade ID counter
+  private _tradeIdCounter = 0;
+
+  constructor() {
+    super();
+    this.initializeDefaultMarkets();
+  }
+
+  get status(): DataSourceStatus {
+    return this._status;
+  }
+
+  getCapabilities(): DataSourceCapabilities {
+    return {
+      realtimeQuotes: true,
+      historicalBars: true,
+      realtimeTrades: true,
+      realtimeOrderBook: true,
+      supportedIntervals: ['1m', '5m', '15m', '1h', '4h', '1d'],
+      maxBarHistory: 1000,
+      maxOrderBookDepth: 100,
+      multiSymbolSubscription: true,
+      maxSymbolsPerBatch: 50,
+    };
+  }
+
+  // ========== Connection Management ==========
+
+  async connect(config: DataSourceConfig): Promise<void> {
+    this._config = config;
+    this.setStatus(DataSourceStatus.CONNECTING);
+
+    // Simulate connection delay
+    await this.sleep(100);
+
+    this.setStatus(DataSourceStatus.CONNECTED);
+    this.emit('connected', { timestamp: Date.now() });
+  }
+
+  async disconnect(): Promise<void> {
+    // Clear all timers
+    Array.from(this._quoteTimers.values()).forEach(timer => clearInterval(timer));
+    Array.from(this._barTimers.values()).forEach(timer => clearInterval(timer));
+    Array.from(this._orderBookTimers.values()).forEach(timer => clearInterval(timer));
+
+    // Clear subscriptions
+    this._quoteSubscriptions.clear();
+    this._barSubscriptions.clear();
+    this._tradeSubscriptions.clear();
+    this._orderBookSubscriptions.clear();
+    this._tickerSubscriptions.clear();
+
+    this._quoteTimers.clear();
+    this._barTimers.clear();
+    this._orderBookTimers.clear();
+
+    this._config = null;
+    this.setStatus(DataSourceStatus.DISCONNECTED);
+    this.emit('disconnected', { timestamp: Date.now() });
+  }
+
+  // ========== Quote Data ==========
+
+  async getQuote(symbol: string): Promise<Quote> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this.getMarket(normalized);
+    const price = this.simulatePrice(normalized);
+
+    return {
+      symbol: normalized,
+      lastPrice: price,
+      bid: price * 0.9999,
+      ask: price * 1.0001,
+      high24h: price * 1.05,
+      low24h: price * 0.95,
+      priceChange24h: (Math.random() - 0.5) * price * 0.1,
+      priceChangePercent24h: (Math.random() - 0.5) * 10,
+      volume24h: Math.random() * 1000000,
+      quoteVolume24h: Math.random() * 1000000000,
+      timestamp: Date.now(),
+      source: this.providerId,
+    };
+  }
+
+  async getQuotes(symbols: string[]): Promise<Quote[]> {
+    return Promise.all(symbols.map(s => this.getQuote(s)));
+  }
+
+  // ========== Bar Data ==========
+
+  async getBars(symbol: string, interval: BarInterval, limit: number = 100): Promise<Bar[]> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this.getMarket(normalized);
+
+    // Generate mock bars
+    const bars: Bar[] = [];
+    const intervalMs = this.intervalToMs(interval);
+    const now = Date.now();
+    let currentPrice = this._prices.get(normalized) ?? market.basePrice;
+
+    for (let i = limit - 1; i >= 0; i--) {
+      const closeTime = now - i * intervalMs;
+      const openTime = closeTime - intervalMs;
+
+      // Simulate price movement
+      const open = currentPrice;
+      const change = (Math.random() - 0.5) * market.volatility * currentPrice;
+      const close = currentPrice + change;
+      const high = Math.max(open, close) * (1 + Math.random() * market.volatility * 0.5);
+      const low = Math.min(open, close) * (1 - Math.random() * market.volatility * 0.5);
+      const volume = Math.random() * 10000;
+
+      bars.push({
+        symbol: normalized,
+        interval,
+        openTime,
+        closeTime,
+        open,
+        high,
+        low,
+        close,
+        volume,
+        quoteVolume: volume * (open + close) / 2,
+        trades: Math.floor(Math.random() * 1000),
+        source: this.providerId,
+      });
+
+      currentPrice = close;
+    }
+
+    // Store for real-time updates
+    if (!this._bars.has(normalized)) {
+      this._bars.set(normalized, new Map());
+    }
+    this._bars.get(normalized)!.set(interval, bars);
+
+    return bars;
+  }
+
+  async getBarsByRange(
+    symbol: string,
+    interval: BarInterval,
+    startTime: number,
+    endTime: number
+  ): Promise<Bar[]> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const intervalMs = this.intervalToMs(interval);
+    const limit = Math.ceil((endTime - startTime) / intervalMs);
+    return this.getBars(symbol, interval, Math.min(limit, 1000));
+  }
+
+  // ========== Order Book ==========
+
+  async getOrderBook(symbol: string, depth: number = 20): Promise<OrderBook> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this.getMarket(normalized);
+    const price = this._prices.get(normalized) ?? market.basePrice;
+
+    const bids: OrderBookLevel[] = [];
+    const asks: OrderBookLevel[] = [];
+
+    for (let i = 0; i < depth; i++) {
+      const spread = (i + 1) * market.tickSize;
+      bids.push({
+        price: price - spread,
+        quantity: Math.random() * 10,
+      });
+      asks.push({
+        price: price + spread,
+        quantity: Math.random() * 10,
+      });
+    }
+
+    return {
+      symbol: normalized,
+      bids,
+      asks,
+      timestamp: Date.now(),
+      sequence: Date.now(),
+    };
+  }
+
+  // ========== Trade Data ==========
+
+  async getRecentTrades(symbol: string, limit: number = 100): Promise<Trade[]> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this.getMarket(normalized);
+
+    const trades: Trade[] = [];
+    const now = Date.now();
+
+    for (let i = 0; i < limit; i++) {
+      const price = this.simulatePrice(normalized);
+      trades.push({
+        id: `mock-trade-${++this._tradeIdCounter}`,
+        symbol: normalized,
+        price,
+        quantity: Math.random() * 10,
+        side: Math.random() > 0.5 ? 'buy' : 'sell',
+        timestamp: now - i * (1000 + Math.random() * 5000),
+        isMaker: Math.random() > 0.5,
+        source: this.providerId,
+      });
+    }
+
+    return trades.reverse();
+  }
+
+  // ========== Market Info ==========
+
+  async getMarketInfo(symbol: string): Promise<MarketInfo> {
+    this.ensureConnected();
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this.getMarket(normalized);
+
+    return {
+      symbol: normalized,
+      baseCurrency: market.baseCurrency,
+      quoteCurrency: market.quoteCurrency,
+      minQuantity: 0.001,
+      maxQuantity: 10000,
+      quantityStep: 0.001,
+      minPrice: 0.01,
+      maxPrice: 1000000,
+      priceStep: market.tickSize,
+      isActive: true,
+    };
+  }
+
+  async getAvailableMarkets(): Promise<MarketInfo[]> {
+    const markets: MarketInfo[] = [];
+    this._markets.forEach((market, symbol) => {
+      markets.push({
+        symbol,
+        baseCurrency: market.baseCurrency,
+        quoteCurrency: market.quoteCurrency,
+        minQuantity: 0.001,
+        maxQuantity: 10000,
+        quantityStep: 0.001,
+        minPrice: 0.01,
+        maxPrice: 1000000,
+        priceStep: market.tickSize,
+        isActive: true,
+      });
+    });
+    return markets;
+  }
+
+  // ========== Real-time Subscriptions ==========
+
+  subscribeToQuotes(symbol: string, callback: QuoteCallback): () => void {
+    const normalized = this.normalizeSymbol(symbol);
+
+    if (!this._quoteSubscriptions.has(normalized)) {
+      this._quoteSubscriptions.set(normalized, new Set());
+      this.startQuoteUpdates(normalized);
+    }
+
+    this._quoteSubscriptions.get(normalized)!.add(callback);
+
+    return () => {
+      const subs = this._quoteSubscriptions.get(normalized);
+      if (subs) {
+        subs.delete(callback);
+        if (subs.size === 0) {
+          this._quoteSubscriptions.delete(normalized);
+          const timer = this._quoteTimers.get(normalized);
+          if (timer) {
+            clearInterval(timer);
+            this._quoteTimers.delete(normalized);
+          }
+        }
+      }
+    };
+  }
+
+  subscribeToBars(symbol: string, interval: BarInterval, callback: BarCallback): () => void {
+    const normalized = this.normalizeSymbol(symbol);
+    const key = `${normalized}:${interval}`;
+
+    if (!this._barSubscriptions.has(normalized)) {
+      this._barSubscriptions.set(normalized, new Map());
+    }
+
+    const symbolBars = this._barSubscriptions.get(normalized)!;
+    if (!symbolBars.has(interval)) {
+      symbolBars.set(interval, new Set());
+      this.startBarUpdates(normalized, interval);
+    }
+
+    symbolBars.get(interval)!.add(callback);
+
+    return () => {
+      const symbolBars = this._barSubscriptions.get(normalized);
+      if (symbolBars) {
+        const intervalSubs = symbolBars.get(interval);
+        if (intervalSubs) {
+          intervalSubs.delete(callback);
+          if (intervalSubs.size === 0) {
+            symbolBars.delete(interval);
+            const timer = this._barTimers.get(key);
+            if (timer) {
+              clearInterval(timer);
+              this._barTimers.delete(key);
+            }
+          }
+        }
+      }
+    };
+  }
+
+  subscribeToTrades(symbol: string, callback: TradeCallback): () => void {
+    const normalized = this.normalizeSymbol(symbol);
+
+    if (!this._tradeSubscriptions.has(normalized)) {
+      this._tradeSubscriptions.set(normalized, new Set());
+    }
+
+    this._tradeSubscriptions.get(normalized)!.add(callback);
+
+    return () => {
+      const subs = this._tradeSubscriptions.get(normalized);
+      if (subs) {
+        subs.delete(callback);
+        if (subs.size === 0) {
+          this._tradeSubscriptions.delete(normalized);
+        }
+      }
+    };
+  }
+
+  subscribeToOrderBook(symbol: string, callback: OrderBookCallback): () => void {
+    const normalized = this.normalizeSymbol(symbol);
+
+    if (!this._orderBookSubscriptions.has(normalized)) {
+      this._orderBookSubscriptions.set(normalized, new Set());
+      this.startOrderBookUpdates(normalized);
+    }
+
+    this._orderBookSubscriptions.get(normalized)!.add(callback);
+
+    return () => {
+      const subs = this._orderBookSubscriptions.get(normalized);
+      if (subs) {
+        subs.delete(callback);
+        if (subs.size === 0) {
+          this._orderBookSubscriptions.delete(normalized);
+          const timer = this._orderBookTimers.get(normalized);
+          if (timer) {
+            clearInterval(timer);
+            this._orderBookTimers.delete(normalized);
+          }
+        }
+      }
+    };
+  }
+
+  subscribeToTicker(symbol: string, callback: TickerCallback): () => void {
+    const normalized = this.normalizeSymbol(symbol);
+
+    if (!this._tickerSubscriptions.has(normalized)) {
+      this._tickerSubscriptions.set(normalized, new Set());
+    }
+
+    this._tickerSubscriptions.get(normalized)!.add(callback);
+
+    return () => {
+      const subs = this._tickerSubscriptions.get(normalized);
+      if (subs) {
+        subs.delete(callback);
+        if (subs.size === 0) {
+          this._tickerSubscriptions.delete(normalized);
+        }
+      }
+    };
+  }
+
+  subscribeToMultiQuotes(symbols: string[], onQuote: QuoteCallback): () => void {
+    const unsubscribers = symbols.map(s => this.subscribeToQuotes(s, onQuote));
+    return () => unsubscribers.forEach(unsub => unsub());
+  }
+
+  unsubscribeAll(symbol: string): void {
+    const normalized = this.normalizeSymbol(symbol);
+
+    // Clear all subscriptions for this symbol
+    this._quoteSubscriptions.delete(normalized);
+    this._tradeSubscriptions.delete(normalized);
+    this._orderBookSubscriptions.delete(normalized);
+    this._tickerSubscriptions.delete(normalized);
+    this._barSubscriptions.delete(normalized);
+
+    // Clear timers
+    const quoteTimer = this._quoteTimers.get(normalized);
+    if (quoteTimer) {
+      clearInterval(quoteTimer);
+      this._quoteTimers.delete(normalized);
+    }
+
+    const obTimer = this._orderBookTimers.get(normalized);
+    if (obTimer) {
+      clearInterval(obTimer);
+      this._orderBookTimers.delete(normalized);
+    }
+  }
+
+  unsubscribeFromAll(): void {
+    // Clear all timers
+    Array.from(this._quoteTimers.values()).forEach(timer => clearInterval(timer));
+    Array.from(this._barTimers.values()).forEach(timer => clearInterval(timer));
+    Array.from(this._orderBookTimers.values()).forEach(timer => clearInterval(timer));
+
+    // Clear all subscriptions
+    this._quoteSubscriptions.clear();
+    this._barSubscriptions.clear();
+    this._tradeSubscriptions.clear();
+    this._orderBookSubscriptions.clear();
+    this._tickerSubscriptions.clear();
+
+    // Clear timer maps
+    this._quoteTimers.clear();
+    this._barTimers.clear();
+    this._orderBookTimers.clear();
+  }
+
+  // ========== Helper Methods ==========
+
+  /**
+   * Add a new market to the mock provider
+   */
+  addMarket(market: MockMarket): void {
+    this._markets.set(market.symbol, market);
+    this._prices.set(market.symbol, market.basePrice);
+  }
+
+  /**
+   * Set the current price for a market (for testing)
+   */
+  setPrice(symbol: string, price: number): void {
+    this._prices.set(this.normalizeSymbol(symbol), price);
+  }
+
+  private initializeDefaultMarkets(): void {
+    const markets: MockMarket[] = [
+      { symbol: 'BTC/USDT', basePrice: 50000, volatility: 0.02, tickSize: 1, baseCurrency: 'BTC', quoteCurrency: 'USDT' },
+      { symbol: 'ETH/USDT', basePrice: 3000, volatility: 0.03, tickSize: 0.01, baseCurrency: 'ETH', quoteCurrency: 'USDT' },
+      { symbol: 'BNB/USDT', basePrice: 400, volatility: 0.025, tickSize: 0.01, baseCurrency: 'BNB', quoteCurrency: 'USDT' },
+      { symbol: 'SOL/USDT', basePrice: 100, volatility: 0.04, tickSize: 0.01, baseCurrency: 'SOL', quoteCurrency: 'USDT' },
+      { symbol: 'AAPL/USD', basePrice: 175, volatility: 0.015, tickSize: 0.01, baseCurrency: 'AAPL', quoteCurrency: 'USD' },
+      { symbol: 'GOOGL/USD', basePrice: 140, volatility: 0.015, tickSize: 0.01, baseCurrency: 'GOOGL', quoteCurrency: 'USD' },
+      { symbol: 'MSFT/USD', basePrice: 380, volatility: 0.012, tickSize: 0.01, baseCurrency: 'MSFT', quoteCurrency: 'USD' },
+    ];
+
+    markets.forEach(m => {
+      this._markets.set(m.symbol, m);
+      this._prices.set(m.symbol, m.basePrice);
+    });
+  }
+
+  private ensureConnected(): void {
+    if (this._status !== DataSourceStatus.CONNECTED) {
+      throw new DataSourceError(
+        DataSourceErrorType.CONNECTION_ERROR,
+        'Not connected to Mock Data Provider',
+        this.providerId
+      );
+    }
+  }
+
+  private getMarket(symbol: string): MockMarket {
+    const normalized = this.normalizeSymbol(symbol);
+    const market = this._markets.get(normalized);
+    if (!market) {
+      throw new DataSourceError(
+        DataSourceErrorType.INVALID_SYMBOL,
+        `Market not found: ${symbol}`,
+        this.providerId
+      );
+    }
+    return market;
+  }
+
+  private simulatePrice(symbol: string): number {
+    const market = this.getMarket(symbol);
+    const currentPrice = this._prices.get(symbol) ?? market.basePrice;
+    const change = (Math.random() - 0.5) * 2 * market.volatility * currentPrice;
+    const newPrice = currentPrice + change;
+    this._prices.set(symbol, newPrice);
+    return newPrice;
+  }
+
+  private normalizeSymbol(symbol: string): string {
+    return symbol.toUpperCase().replace(/[-_/]/g, match => match === '-' || match === '_' ? '/' : match);
+  }
+
+  private intervalToMs(interval: BarInterval): number {
+    const map: Record<BarInterval, number> = {
+      '1m': 60000,
+      '3m': 180000,
+      '5m': 300000,
+      '15m': 900000,
+      '30m': 1800000,
+      '1h': 3600000,
+      '2h': 7200000,
+      '4h': 14400000,
+      '6h': 21600000,
+      '12h': 43200000,
+      '1d': 86400000,
+      '3d': 259200000,
+      '1w': 604800000,
+      '1M': 2592000000,
+    };
+    return map[interval] ?? 60000;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private setStatus(status: DataSourceStatus): void {
+    const previousStatus = this._status;
+    this._status = status;
+    if (previousStatus !== status) {
+      this.emit('statusChange', { previousStatus, status, timestamp: Date.now() });
+    }
+  }
+
+  private startQuoteUpdates(symbol: string): void {
+    const timer = setInterval(async () => {
+      try {
+        const quote = await this.getQuote(symbol);
+        const subs = this._quoteSubscriptions.get(symbol);
+        if (subs) {
+          subs.forEach(cb => cb(quote));
+        }
+      } catch (err) {
+        this.emit('error', err);
+      }
+    }, 1000);
+
+    this._quoteTimers.set(symbol, timer);
+  }
+
+  private startBarUpdates(symbol: string, interval: BarInterval): void {
+    const key = `${symbol}:${interval}`;
+    const intervalMs = this.intervalToMs(interval);
+
+    const timer = setInterval(async () => {
+      try {
+        const bars = this._bars.get(symbol)?.get(interval) ?? [];
+        const lastBar = bars[bars.length - 1];
+        const now = Date.now();
+
+        // Create a new bar
+        const market = this.getMarket(symbol);
+        const price = this._prices.get(symbol) ?? market.basePrice;
+
+        const newBar: Bar = {
+          symbol,
+          interval,
+          openTime: now - intervalMs,
+          closeTime: now,
+          open: lastBar?.close ?? price,
+          high: price * 1.001,
+          low: price * 0.999,
+          close: price,
+          volume: Math.random() * 100,
+          quoteVolume: Math.random() * 100 * price,
+          trades: Math.floor(Math.random() * 50),
+          source: this.providerId,
+        };
+
+        const subs = this._barSubscriptions.get(symbol)?.get(interval);
+        if (subs) {
+          subs.forEach(cb => cb(newBar));
+        }
+      } catch (err) {
+        this.emit('error', err);
+      }
+    }, this.intervalToMs(interval) / 10); // Update at 10x the interval frequency for demo
+
+    this._barTimers.set(key, timer);
+  }
+
+  private startOrderBookUpdates(symbol: string): void {
+    const timer = setInterval(async () => {
+      try {
+        const orderBook = await this.getOrderBook(symbol);
+        const subs = this._orderBookSubscriptions.get(symbol);
+        if (subs) {
+          subs.forEach(cb => cb(orderBook));
+        }
+      } catch (err) {
+        this.emit('error', err);
+      }
+    }, 500);
+
+    this._orderBookTimers.set(symbol, timer);
+  }
+}

--- a/src/datasource/providers/index.ts
+++ b/src/datasource/providers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Data Providers
+ *
+ * Export all available data providers.
+ */
+
+export { MockDataProvider } from './MockDataProvider';

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -1,0 +1,275 @@
+/**
+ * Data Source Types - Unified types for stock/crypto market data
+ *
+ * This module defines the core types used by all data providers,
+ * enabling seamless switching between different data sources.
+ */
+
+/**
+ * Quote - Current market price snapshot
+ */
+export interface Quote {
+  /** Trading symbol (e.g., 'BTC/USDT', 'AAPL') */
+  symbol: string;
+  /** Last trade price */
+  lastPrice: number;
+  /** Best bid price */
+  bid: number;
+  /** Best ask price */
+  ask: number;
+  /** 24h high price */
+  high24h: number;
+  /** 24h low price */
+  low24h: number;
+  /** 24h price change (absolute) */
+  priceChange24h: number;
+  /** 24h price change percentage */
+  priceChangePercent24h: number;
+  /** 24h volume in base currency */
+  volume24h: number;
+  /** 24h volume in quote currency */
+  quoteVolume24h: number;
+  /** Timestamp of the quote */
+  timestamp: number;
+  /** Data source identifier */
+  source?: string;
+}
+
+/**
+ * Bar - OHLCV candlestick data
+ */
+export interface Bar {
+  /** Trading symbol */
+  symbol: string;
+  /** Bar interval (e.g., '1m', '5m', '1h', '1d') */
+  interval: string;
+  /** Bar open time (timestamp) */
+  openTime: number;
+  /** Bar close time (timestamp) */
+  closeTime: number;
+  /** Open price */
+  open: number;
+  /** High price */
+  high: number;
+  /** Low price */
+  low: number;
+  /** Close price */
+  close: number;
+  /** Volume in base currency */
+  volume: number;
+  /** Volume in quote currency */
+  quoteVolume: number;
+  /** Number of trades */
+  trades?: number;
+  /** Taker buy volume (base currency) */
+  takerBuyVolume?: number;
+  /** Taker buy volume (quote currency) */
+  takerBuyQuoteVolume?: number;
+  /** Data source identifier */
+  source?: string;
+}
+
+/**
+ * Trade - Individual trade execution
+ */
+export interface Trade {
+  /** Trade ID */
+  id: string;
+  /** Trading symbol */
+  symbol: string;
+  /** Trade price */
+  price: number;
+  /** Trade quantity */
+  quantity: number;
+  /** Trade side (buy/sell) */
+  side: 'buy' | 'sell';
+  /** Trade timestamp */
+  timestamp: number;
+  /** Whether this was a maker order */
+  isMaker?: boolean;
+  /** Data source identifier */
+  source?: string;
+}
+
+/**
+ * Order book level - Single price level
+ */
+export interface OrderBookLevel {
+  /** Price */
+  price: number;
+  /** Quantity at this price level */
+  quantity: number;
+}
+
+/**
+ * Order book snapshot
+ */
+export interface OrderBook {
+  /** Trading symbol */
+  symbol: string;
+  /** Bid levels (sorted by price descending) */
+  bids: OrderBookLevel[];
+  /** Ask levels (sorted by price ascending) */
+  asks: OrderBookLevel[];
+  /** Timestamp of the snapshot */
+  timestamp: number;
+  /** Sequence number (for detecting gaps) */
+  sequence?: number;
+}
+
+/**
+ * Ticker - Real-time price update
+ */
+export interface Ticker {
+  /** Trading symbol */
+  symbol: string;
+  /** Last trade price */
+  lastPrice: number;
+  /** Price change in 24h */
+  priceChange: number;
+  /** Price change percentage in 24h */
+  priceChangePercent: number;
+  /** Best bid price */
+  bid: number;
+  /** Best ask price */
+  ask: number;
+  /** 24h volume */
+  volume: number;
+  /** 24h quote volume */
+  quoteVolume: number;
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * Supported bar intervals
+ */
+export type BarInterval = 
+  | '1m' | '3m' | '5m' | '15m' | '30m'  // Minutes
+  | '1h' | '2h' | '4h' | '6h' | '12h'   // Hours
+  | '1d' | '3d' | '1w' | '1M';          // Days/Weeks/Months
+
+/**
+ * Data source connection status
+ */
+export enum DataSourceStatus {
+  DISCONNECTED = 'disconnected',
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  RECONNECTING = 'reconnecting',
+  ERROR = 'error',
+}
+
+/**
+ * Data source configuration
+ */
+export interface DataSourceConfig {
+  /** Provider identifier (e.g., 'mock', 'binance', 'alpaca') */
+  providerId: string;
+  /** API key (if required) */
+  apiKey?: string;
+  /** API secret (if required) */
+  apiSecret?: string;
+  /** API passphrase (for exchanges that require it) */
+  passphrase?: string;
+  /** Whether to use testnet/sandbox mode */
+  testnet?: boolean;
+  /** Custom API endpoint */
+  endpoint?: string;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** Enable rate limiting */
+  rateLimit?: boolean;
+  /** WebSocket endpoint (if different from REST) */
+  wsEndpoint?: string;
+  /** Additional provider-specific options */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Data source capabilities
+ */
+export interface DataSourceCapabilities {
+  /** Supports real-time quotes via WebSocket */
+  realtimeQuotes: boolean;
+  /** Supports historical bar data */
+  historicalBars: boolean;
+  /** Supports real-time trade stream */
+  realtimeTrades: boolean;
+  /** Supports order book streaming */
+  realtimeOrderBook: boolean;
+  /** Supported bar intervals */
+  supportedIntervals: BarInterval[];
+  /** Maximum bar history length */
+  maxBarHistory: number;
+  /** Maximum order book depth */
+  maxOrderBookDepth: number;
+  /** Supports multiple symbols subscription */
+  multiSymbolSubscription: boolean;
+  /** Maximum symbols per subscription batch */
+  maxSymbolsPerBatch: number;
+}
+
+/**
+ * Subscription callback types
+ */
+export type QuoteCallback = (quote: Quote) => void;
+export type BarCallback = (bar: Bar) => void;
+export type TradeCallback = (trade: Trade) => void;
+export type OrderBookCallback = (orderBook: OrderBook) => void;
+export type TickerCallback = (ticker: Ticker) => void;
+
+/**
+ * Data source error types
+ */
+export enum DataSourceErrorType {
+  CONNECTION_ERROR = 'connection_error',
+  AUTHENTICATION_ERROR = 'authentication_error',
+  RATE_LIMIT_ERROR = 'rate_limit_error',
+  INVALID_SYMBOL = 'invalid_symbol',
+  INVALID_INTERVAL = 'invalid_interval',
+  TIMEOUT = 'timeout',
+  SUBSCRIPTION_ERROR = 'subscription_error',
+  UNKNOWN = 'unknown',
+}
+
+/**
+ * Data source error class
+ */
+export class DataSourceError extends Error {
+  constructor(
+    public readonly type: DataSourceErrorType,
+    message: string,
+    public readonly providerId?: string,
+    public readonly originalError?: Error
+  ) {
+    super(message);
+    this.name = 'DataSourceError';
+  }
+}
+
+/**
+ * Market metadata
+ */
+export interface MarketInfo {
+  /** Trading symbol */
+  symbol: string;
+  /** Base currency (e.g., 'BTC') */
+  baseCurrency: string;
+  /** Quote currency (e.g., 'USDT') */
+  quoteCurrency: string;
+  /** Minimum order quantity */
+  minQuantity: number;
+  /** Maximum order quantity */
+  maxQuantity: number;
+  /** Quantity step size */
+  quantityStep: number;
+  /** Minimum price */
+  minPrice: number;
+  /** Maximum price */
+  maxPrice: number;
+  /** Price step size (tick size) */
+  priceStep: number;
+  /** Is this market active/tradable */
+  isActive: boolean;
+}


### PR DESCRIPTION
## 概述

实现 Issue #358: 创建统一的数据源接口，支持多数据源切换

## 功能范围

### 1. 数据源接口定义 (`src/datasource/interface.ts`)
- 统一的 `IStockDataProvider` 接口
- 标准方法：`getQuote`, `getBars`, `subscribeQuotes` 等
- 数据类型：`Quote`, `Bar`, `Trade`, `OrderBook`, `Ticker`
- 基类 `BaseStockDataProvider` 提供公共功能

### 2. 数据源管理器 (`src/datasource/DataSourceManager.ts`)
- `DataSourceManager` 单例模式
- 支持注册/注销数据源
- 支持动态切换数据源
- 配置化管理（API Key、endpoints 等）
- 支持 Provider Factory 延迟初始化

### 3. 模拟数据源 (`src/datasource/providers/MockDataProvider.ts`)
- 模拟真实市场数据
- 支持加密货币：BTC/USDT, ETH/USDT, BNB/USDT, SOL/USDT
- 支持股票：AAPL, GOOGL, MSFT
- 实时数据订阅（quotes, bars, orderbook, trades）

### 4. 类型定义 (`src/datasource/types.ts`)
- `Quote` - 当前市场报价快照
- `Bar` - OHLCV K线数据
- `Trade` - 逐笔成交
- `OrderBook` - 订单簿
- `Ticker` - 行情更新
- `DataSourceConfig` - 数据源配置
- `DataSourceCapabilities` - 数据源能力
- `DataSourceError` - 错误类型

## 使用示例

```typescript
import { getDataSourceManager, MockDataProvider } from './datasource';

// 初始化
const manager = getDataSourceManager();
manager.registerProvider(new MockDataProvider(), { providerId: 'mock' });
await manager.connect();

// 获取数据
const quote = await manager.getQuote('BTC/USDT');
const bars = await manager.getBars('BTC/USDT', '1h', 100);
const orderBook = await manager.getOrderBook('BTC/USDT', 20);

// 订阅实时数据
const unsubscribe = manager.subscribeToQuotes('BTC/USDT', (quote) => {
  console.log('New quote:', quote);
});

// 切换数据源（将来支持 Binance、Alpaca 等）
// await manager.setActiveProvider('binance');
```

## 验收标准

- [x] 统一的数据源接口定义完成
- [x] 数据源管理器可切换数据源
- [x] 模拟数据源已适配
- [x] 类型定义完整
- [x] 测试覆盖（63 tests passing）

## 测试结果

```
PASS src/datasource/__tests__/MockDataProvider.test.ts
PASS src/datasource/__tests__/DataSourceManager.test.ts
PASS src/datasource/__tests__/types.test.ts

Test Suites: 3 passed, 3 total
Tests:       63 passed, 63 total
```

## 后续工作

- 实现 BinanceDataProvider（加密货币实时数据）
- 实现 AlpacaDataProvider（美股实时数据）
- 实现 PolygonDataProvider（美股历史数据）
- 添加缓存层
- 添加数据验证和清洗

Closes #358