### PR TITLE
feat: 深度回测分析报告

### DIFF
--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev|prs:0|ready:5|planning",
-    "timestamp": 1773918886044,
+    "digestHash": "spawn_dev|prs:0|ready:4|planning",
+    "timestamp": 1773920085997,
     "consecutiveCount": 1
   },
   "highWaterMark": 32,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2211,6 +2211,333 @@
         }
       }
     },
+    "/recommendations": {
+      "get": {
+        "summary": "Get personalized strategy recommendations",
+        "description": "Returns AI-powered strategy recommendations based on user history, preferences, and collaborative filtering",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of recommended strategies with match scores and reasons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "$ref": "#/components/schemas/MarketplaceStrategy"
+                          },
+                          "score": {
+                            "type": "number",
+                            "description": "Match score (0-100)"
+                          },
+                          "reasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "collaborative",
+                              "content_based",
+                              "hybrid",
+                              "trending"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recommendations/{recommendationId}/dismiss": {
+      "post": {
+        "summary": "Dismiss a recommendation",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "recommendationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation dismissed"
+          }
+        }
+      }
+    },
+    "/recommendations/{recommendationId}/click": {
+      "post": {
+        "summary": "Mark recommendation as clicked",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "recommendationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation marked as clicked"
+          }
+        }
+      }
+    },
+    "/recommendations/explain/{strategyId}": {
+      "get": {
+        "summary": "Get explanation for why a strategy is recommended",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation explanation with score breakdown"
+          }
+        }
+      }
+    },
+    "/recommendations/feedback": {
+      "post": {
+        "summary": "Record user feedback on a strategy",
+        "description": "Submit like/dislike feedback to improve future recommendations",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategyId",
+                  "feedbackType"
+                ],
+                "properties": {
+                  "strategyId": {
+                    "type": "string"
+                  },
+                  "feedbackType": {
+                    "type": "string",
+                    "enum": [
+                      "like",
+                      "dislike",
+                      "not_interested"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string",
+                    "description": "Optional reason for feedback"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded successfully"
+          }
+        }
+      }
+    },
+    "/recommendations/interactions": {
+      "post": {
+        "summary": "Record user interaction with a strategy",
+        "description": "Automatically track user interactions to improve recommendations",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategyId",
+                  "interactionType"
+                ],
+                "properties": {
+                  "strategyId": {
+                    "type": "string"
+                  },
+                  "interactionType": {
+                    "type": "string",
+                    "enum": [
+                      "view",
+                      "subscribe",
+                      "review",
+                      "signal_follow"
+                    ]
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional additional data"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Interaction recorded"
+          }
+        }
+      }
+    },
+    "/recommendations/profile": {
+      "get": {
+        "summary": "Get user's recommendation profile",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile with preferences"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update user's recommendation profile",
+        "description": "Set preferences to improve recommendation quality",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "riskTolerance": {
+                    "type": "string",
+                    "enum": [
+                      "conservative",
+                      "moderate",
+                      "aggressive",
+                      "very_aggressive"
+                    ]
+                  },
+                  "capitalScale": {
+                    "type": "string",
+                    "enum": [
+                      "small",
+                      "medium",
+                      "large",
+                      "institutional"
+                    ]
+                  },
+                  "preferredCategories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "preferredStrategyTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "preferredSymbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Profile updated"
+          }
+        }
+      }
+    },
+    "/recommendations/stats": {
+      "get": {
+        "summary": "Get recommendation system statistics",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "System statistics"
+          }
+        }
+      }
+    },
+    "/recommendations/cleanup": {
+      "post": {
+        "summary": "Clear expired recommendations (admin)",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of expired recommendations cleared"
+          }
+        }
+      }
+    },
     "/marketplace/strategies": {
       "get": {
         "summary": "List strategies in the marketplace",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1270,6 +1270,184 @@ paths:
                   timestamp: {type: integer}
         '404':
           description: 'Order book not found for symbol'
+  /recommendations:
+    get:
+      summary: 'Get personalized strategy recommendations'
+      description: 'Returns AI-powered strategy recommendations based on user history, preferences, and collaborative filtering'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 20
+      responses:
+        '200':
+          description: 'List of recommended strategies with match scores and reasons'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: {type: boolean}
+                  data: {type: array, items: {type: object, properties: {strategy: {$ref: '#/components/schemas/MarketplaceStrategy'}, score: {type: number, description: 'Match score (0-100)'}, reasons: {type: array, items: {type: string}}, algorithm: {type: string, enum: [collaborative, content_based, hybrid, trending]}}}}
+  '/recommendations/{recommendationId}/dismiss':
+    post:
+      summary: 'Dismiss a recommendation'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: recommendationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation dismissed'
+  '/recommendations/{recommendationId}/click':
+    post:
+      summary: 'Mark recommendation as clicked'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: recommendationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation marked as clicked'
+  '/recommendations/explain/{strategyId}':
+    get:
+      summary: 'Get explanation for why a strategy is recommended'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: strategyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation explanation with score breakdown'
+  /recommendations/feedback:
+    post:
+      summary: 'Record user feedback on a strategy'
+      description: 'Submit like/dislike feedback to improve future recommendations'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - strategyId
+                - feedbackType
+              properties:
+                strategyId:
+                  type: string
+                feedbackType:
+                  type: string
+                  enum: [like, dislike, not_interested]
+                reason:
+                  type: string
+                  description: 'Optional reason for feedback'
+      responses:
+        '200':
+          description: 'Feedback recorded successfully'
+  /recommendations/interactions:
+    post:
+      summary: 'Record user interaction with a strategy'
+      description: 'Automatically track user interactions to improve recommendations'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - strategyId
+                - interactionType
+              properties:
+                strategyId:
+                  type: string
+                interactionType:
+                  type: string
+                  enum: [view, subscribe, review, signal_follow]
+                metadata:
+                  type: object
+                  description: 'Optional additional data'
+      responses:
+        '200':
+          description: 'Interaction recorded'
+  /recommendations/profile:
+    get:
+      summary: 'Get user''s recommendation profile'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'User profile with preferences'
+    put:
+      summary: 'Update user''s recommendation profile'
+      description: 'Set preferences to improve recommendation quality'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                riskTolerance:
+                  type: string
+                  enum: [conservative, moderate, aggressive, very_aggressive]
+                capitalScale:
+                  type: string
+                  enum: [small, medium, large, institutional]
+                preferredCategories:
+                  type: array
+                  items: {type: string}
+                preferredStrategyTypes:
+                  type: array
+                  items: {type: string}
+                preferredSymbols:
+                  type: array
+                  items: {type: string}
+      responses:
+        '200':
+          description: 'Profile updated'
+  /recommendations/stats:
+    get:
+      summary: 'Get recommendation system statistics'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'System statistics'
+  /recommendations/cleanup:
+    post:
+      summary: 'Clear expired recommendations (admin)'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'Number of expired recommendations cleared'
   /marketplace/strategies:
     get:
       summary: 'List strategies in the marketplace'

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1270,6 +1270,184 @@ paths:
                   timestamp: {type: integer}
         '404':
           description: 'Order book not found for symbol'
+  /recommendations:
+    get:
+      summary: 'Get personalized strategy recommendations'
+      description: 'Returns AI-powered strategy recommendations based on user history, preferences, and collaborative filtering'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 20
+      responses:
+        '200':
+          description: 'List of recommended strategies with match scores and reasons'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: {type: boolean}
+                  data: {type: array, items: {type: object, properties: {strategy: {$ref: '#/components/schemas/MarketplaceStrategy'}, score: {type: number, description: 'Match score (0-100)'}, reasons: {type: array, items: {type: string}}, algorithm: {type: string, enum: [collaborative, content_based, hybrid, trending]}}}}
+  '/recommendations/{recommendationId}/dismiss':
+    post:
+      summary: 'Dismiss a recommendation'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: recommendationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation dismissed'
+  '/recommendations/{recommendationId}/click':
+    post:
+      summary: 'Mark recommendation as clicked'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: recommendationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation marked as clicked'
+  '/recommendations/explain/{strategyId}':
+    get:
+      summary: 'Get explanation for why a strategy is recommended'
+      tags:
+        - Recommendations
+      parameters:
+        -
+          name: strategyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Recommendation explanation with score breakdown'
+  /recommendations/feedback:
+    post:
+      summary: 'Record user feedback on a strategy'
+      description: 'Submit like/dislike feedback to improve future recommendations'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - strategyId
+                - feedbackType
+              properties:
+                strategyId:
+                  type: string
+                feedbackType:
+                  type: string
+                  enum: [like, dislike, not_interested]
+                reason:
+                  type: string
+                  description: 'Optional reason for feedback'
+      responses:
+        '200':
+          description: 'Feedback recorded successfully'
+  /recommendations/interactions:
+    post:
+      summary: 'Record user interaction with a strategy'
+      description: 'Automatically track user interactions to improve recommendations'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - strategyId
+                - interactionType
+              properties:
+                strategyId:
+                  type: string
+                interactionType:
+                  type: string
+                  enum: [view, subscribe, review, signal_follow]
+                metadata:
+                  type: object
+                  description: 'Optional additional data'
+      responses:
+        '200':
+          description: 'Interaction recorded'
+  /recommendations/profile:
+    get:
+      summary: 'Get user''s recommendation profile'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'User profile with preferences'
+    put:
+      summary: 'Update user''s recommendation profile'
+      description: 'Set preferences to improve recommendation quality'
+      tags:
+        - Recommendations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                riskTolerance:
+                  type: string
+                  enum: [conservative, moderate, aggressive, very_aggressive]
+                capitalScale:
+                  type: string
+                  enum: [small, medium, large, institutional]
+                preferredCategories:
+                  type: array
+                  items: {type: string}
+                preferredStrategyTypes:
+                  type: array
+                  items: {type: string}
+                preferredSymbols:
+                  type: array
+                  items: {type: string}
+      responses:
+        '200':
+          description: 'Profile updated'
+  /recommendations/stats:
+    get:
+      summary: 'Get recommendation system statistics'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'System statistics'
+  /recommendations/cleanup:
+    post:
+      summary: 'Clear expired recommendations (admin)'
+      tags:
+        - Recommendations
+      responses:
+        '200':
+          description: 'Number of expired recommendations cleared'
   /marketplace/strategies:
     get:
       summary: 'List strategies in the marketplace'

--- a/src/api/backtestAnalysisRoutes.ts
+++ b/src/api/backtestAnalysisRoutes.ts
@@ -1,0 +1,276 @@
+/**
+ * Backtest Analysis Routes
+ *
+ * @module api/backtestAnalysisRoutes
+ * @description API endpoints for deep backtest analysis and reporting
+ */
+
+import { Router, Request, Response } from 'express';
+import { BacktestEngine } from '../backtest/BacktestEngine';
+import { BacktestConfig } from '../backtest/types';
+import {
+  BacktestAnalyzer,
+  StrategyComparator,
+  ReportGenerator,
+  StrategyComparisonOptions,
+  ReportExportOptions,
+} from '../backtest-analysis';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('BacktestAnalysisRoutes');
+
+const router = Router();
+
+/**
+ * POST /api/backtest-analysis/analyze
+ * Run deep analysis on backtest results
+ */
+router.post('/analyze', async (req: Request, res: Response) => {
+  try {
+    const config: BacktestConfig = req.body.config;
+
+    log.info('Running deep backtest analysis with config:', config);
+
+    // Validate config
+    if (!config) {
+      return res.status(400).json({ error: 'Backtest configuration is required' });
+    }
+
+    if (!config.capital || config.capital < 100) {
+      return res.status(400).json({ error: 'Initial capital must be at least 100' });
+    }
+
+    if (!config.symbol) {
+      return res.status(400).json({ error: 'Symbol is required' });
+    }
+
+    if (!config.strategy) {
+      return res.status(400).json({ error: 'Strategy is required' });
+    }
+
+    // Run backtest
+    const engine = new BacktestEngine(config);
+    const backtestResult = engine.run();
+
+    // Generate deep analysis
+    const analyzer = new BacktestAnalyzer(backtestResult);
+    const report = analyzer.generateReport();
+
+    log.info('Deep analysis completed for strategy:', config.strategy);
+
+    res.json({
+      success: true,
+      report,
+    });
+  } catch (error: any) {
+    log.error('Deep analysis failed:', error);
+    res.status(500).json({
+      error: error.message || 'Deep analysis failed',
+    });
+  }
+});
+
+/**
+ * POST /api/backtest-analysis/compare
+ * Compare multiple strategies
+ */
+router.post('/compare', async (req: Request, res: Response) => {
+  try {
+    const options: StrategyComparisonOptions = req.body;
+
+    log.info('Running strategy comparison:', {
+      strategies: options.strategies?.length,
+      symbol: options.backtestConfig?.symbol,
+    });
+
+    // Validate
+    if (!options.strategies || !Array.isArray(options.strategies) || options.strategies.length < 2) {
+      return res.status(400).json({ error: 'At least 2 strategies are required for comparison' });
+    }
+
+    if (!options.backtestConfig) {
+      return res.status(400).json({ error: 'Backtest configuration is required' });
+    }
+
+    // Run comparison
+    const comparator = new StrategyComparator();
+    const comparison = await comparator.compare(options);
+
+    log.info('Strategy comparison completed');
+
+    res.json({
+      success: true,
+      comparison,
+    });
+  } catch (error: any) {
+    log.error('Strategy comparison failed:', error);
+    res.status(500).json({
+      error: error.message || 'Strategy comparison failed',
+    });
+  }
+});
+
+/**
+ * POST /api/backtest-analysis/export
+ * Export analysis report in specified format
+ */
+router.post('/export', async (req: Request, res: Response) => {
+  try {
+    const { config, exportOptions } = req.body as {
+      config: BacktestConfig;
+      exportOptions: ReportExportOptions;
+    };
+
+    log.info('Exporting backtest report:', { format: exportOptions?.format });
+
+    if (!config) {
+      return res.status(400).json({ error: 'Backtest configuration is required' });
+    }
+
+    if (!exportOptions || !exportOptions.format) {
+      return res.status(400).json({ error: 'Export format is required' });
+    }
+
+    // Run backtest
+    const engine = new BacktestEngine(config);
+    const backtestResult = engine.run();
+
+    // Generate analysis
+    const analyzer = new BacktestAnalyzer(backtestResult);
+    const report = analyzer.generateReport();
+
+    // Generate export
+    const generator = new ReportGenerator();
+    const exportResult = await generator.generate(report, exportOptions);
+
+    log.info('Report exported:', { filename: exportResult.filename });
+
+    // Set response headers
+    res.setHeader('Content-Type', exportResult.contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="${exportResult.filename}"`);
+
+    if (Buffer.isBuffer(exportResult.content)) {
+      res.send(exportResult.content);
+    } else {
+      res.send(exportResult.content);
+    }
+  } catch (error: any) {
+    log.error('Report export failed:', error);
+    res.status(500).json({
+      error: error.message || 'Report export failed',
+    });
+  }
+});
+
+/**
+ * POST /api/backtest-analysis/export-comparison
+ * Export strategy comparison report
+ */
+router.post('/export-comparison', async (req: Request, res: Response) => {
+  try {
+    const { comparisonOptions, exportOptions } = req.body as {
+      comparisonOptions: StrategyComparisonOptions;
+      exportOptions: ReportExportOptions;
+    };
+
+    log.info('Exporting comparison report:', { format: exportOptions?.format });
+
+    if (!comparisonOptions) {
+      return res.status(400).json({ error: 'Comparison options are required' });
+    }
+
+    if (!exportOptions || !exportOptions.format) {
+      return res.status(400).json({ error: 'Export format is required' });
+    }
+
+    // Run comparison
+    const comparator = new StrategyComparator();
+    const comparison = await comparator.compare(comparisonOptions);
+
+    // Generate export
+    const generator = new ReportGenerator();
+    const exportResult = await generator.generateComparisonReport(comparison, exportOptions);
+
+    log.info('Comparison report exported:', { filename: exportResult.filename });
+
+    // Set response headers
+    res.setHeader('Content-Type', exportResult.contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="${exportResult.filename}"`);
+
+    if (Buffer.isBuffer(exportResult.content)) {
+      res.send(exportResult.content);
+    } else {
+      res.send(exportResult.content);
+    }
+  } catch (error: any) {
+    log.error('Comparison export failed:', error);
+    res.status(500).json({
+      error: error.message || 'Comparison export failed',
+    });
+  }
+});
+
+/**
+ * GET /api/backtest-analysis/metrics
+ * Get list of available analysis metrics
+ */
+router.get('/metrics', (req: Request, res: Response) => {
+  res.json({
+    metrics: [
+      {
+        category: 'basic',
+        metrics: [
+          { id: 'totalReturn', name: '总回报率', description: '策略的总收益率百分比' },
+          { id: 'annualizedReturn', name: '年化回报率', description: '年化收益率' },
+          { id: 'maxDrawdown', name: '最大回撤', description: '最大资金回撤百分比' },
+          { id: 'sharpeRatio', name: '夏普比率', description: '风险调整后收益' },
+          { id: 'winRate', name: '胜率', description: '盈利交易占比' },
+          { id: 'profitFactor', name: '盈亏比', description: '总盈利与总亏损比' },
+        ],
+      },
+      {
+        category: 'risk',
+        metrics: [
+          { id: 'sortinoRatio', name: '索提诺比率', description: '下行风险调整后收益' },
+          { id: 'calmarRatio', name: '卡尔马比率', description: '年化收益与最大回撤比' },
+          { id: 'volatility', name: '波动率', description: '年化收益率标准差' },
+          { id: 'var95', name: 'VaR 95%', description: '95%置信度下的最大损失' },
+          { id: 'cvar95', name: 'CVaR 95%', description: '极端损失的平均值' },
+        ],
+      },
+      {
+        category: 'drawdown',
+        metrics: [
+          { id: 'maxDrawdownDuration', name: '最大回撤持续时间', description: '从高点恢复所需的最长时间' },
+          { id: 'recoveryFactor', name: '恢复因子', description: '总收益与最大回撤比' },
+          { id: 'timeUnderwater', name: '水下时间占比', description: '资金低于历史高点的比例' },
+        ],
+      },
+      {
+        category: 'trade',
+        metrics: [
+          { id: 'avgWin', name: '平均盈利', description: '单笔盈利交易的平均利润' },
+          { id: 'avgLoss', name: '平均亏损', description: '单笔亏损交易的平均损失' },
+          { id: 'expectancy', name: '期望值', description: '每笔交易的预期收益' },
+          { id: 'maxConsecutiveLosses', name: '最大连续亏损', description: '连续亏损交易的最大次数' },
+        ],
+      },
+    ],
+  });
+});
+
+/**
+ * GET /api/backtest-analysis/export-formats
+ * Get list of available export formats
+ */
+router.get('/export-formats', (req: Request, res: Response) => {
+  res.json({
+    formats: [
+      { id: 'pdf', name: 'PDF', description: '便携式文档格式，适合打印和分享' },
+      { id: 'excel', name: 'Excel/CSV', description: '电子表格格式，适合数据分析' },
+      { id: 'json', name: 'JSON', description: 'JSON 格式，适合程序化处理' },
+    ],
+  });
+});
+
+export default router;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -32,6 +32,7 @@ import { createWebhookRouter } from './webhookRoutes';
 import { createCopyTradingRouter } from './copyTradingRoutes';
 import { createLeaderboardRouter } from './leaderboardRoutes';
 import backtestRoutes from './backtestRoutes';
+import backtestAnalysisRoutes from './backtestAnalysisRoutes';
 import aiRoutes from './aiRoutes.js';
 import { BotManager } from '../bot';
 import { createBotRouter } from './botRoutes';
@@ -923,6 +924,7 @@ export class APIServer extends EventEmitter {
     this.app.use('/api/copy-trading', createCopyTradingRouter());
     this.app.use('/api/leaderboard', createLeaderboardRouter());
     this.app.use('/api/backtest', backtestRoutes);
+    this.app.use('/api/backtest-analysis', backtestAnalysisRoutes);
 
     // Bot API routes
     this.app.use('/api/bot', createBotRouter(this.botManager));

--- a/src/backtest-analysis/BacktestAnalyzer.ts
+++ b/src/backtest-analysis/BacktestAnalyzer.ts
@@ -1,0 +1,957 @@
+/**
+ * Backtest Analyzer
+ *
+ * @module backtest-analysis/BacktestAnalyzer
+ * @description Core analyzer for deep backtest analysis
+ */
+
+import {
+  BacktestResult,
+  TradeAnalysis,
+  EquityCurvePoint,
+  DrawdownAnalysis,
+  DrawdownPeriod,
+  PositionAnalysis,
+  MonthlyPerformance,
+  RiskMetrics,
+  TradeDistribution,
+  SizeBucket,
+  DurationBucket,
+  PnLBucket,
+  DeepAnalysisReport,
+  PerformanceScorecard,
+} from './types';
+import { BacktestStats } from '../backtest/types';
+import { PortfolioSnapshot } from '../portfolio/types';
+
+/**
+ * BacktestAnalyzer
+ * Performs comprehensive analysis on backtest results
+ */
+export class BacktestAnalyzer {
+  private result: BacktestResult;
+
+  constructor(result: BacktestResult) {
+    this.result = result;
+  }
+
+  /**
+   * Generate complete deep analysis report
+   */
+  generateReport(): DeepAnalysisReport {
+    const tradeAnalysis = this.analyzeTrades();
+    const equityCurve = this.generateEquityCurve();
+    const drawdownAnalysis = this.analyzeDrawdowns(equityCurve);
+    const positionAnalysis = this.analyzePositions();
+    const monthlyPerformance = this.analyzeMonthlyPerformance();
+    const tradeDistribution = this.analyzeTradeDistribution();
+    const riskMetrics = this.calculateRiskMetrics(equityCurve);
+    const performanceScorecard = this.calculatePerformanceScorecard(
+      this.result.stats,
+      riskMetrics,
+      tradeAnalysis
+    );
+    const recommendations = this.generateRecommendations(
+      this.result.stats,
+      riskMetrics,
+      tradeAnalysis,
+      drawdownAnalysis
+    );
+
+    return {
+      generatedAt: Date.now(),
+      config: {
+        symbol: this.result.config.symbol,
+        strategy: this.result.config.strategy,
+        strategyParams: this.result.config.strategyParams,
+        initialCapital: this.result.config.capital,
+        startTime: this.result.config.startTime,
+        endTime: this.result.config.endTime,
+        duration: this.result.duration,
+      },
+      basicStats: this.result.stats,
+      riskMetrics,
+      tradeAnalysis,
+      equityCurve,
+      drawdownAnalysis,
+      positionAnalysis,
+      monthlyPerformance,
+      tradeDistribution,
+      performanceScorecard,
+      recommendations,
+    };
+  }
+
+  /**
+   * Analyze individual trades
+   */
+  private analyzeTrades(): TradeAnalysis[] {
+    const trades = this.result.trades;
+    if (!trades || trades.length === 0) {
+      return [];
+    }
+
+    const analysis: TradeAnalysis[] = [];
+    const positions = new Map<string, { entryPrice: number; quantity: number; entryTime: number }>();
+
+    // Sort trades by timestamp
+    const sortedTrades = [...trades].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+
+    for (const trade of sortedTrades) {
+      const symbol = trade.symbol || this.result.config.symbol;
+      const side = trade.side?.toLowerCase() || 'buy';
+      const price = trade.price;
+      const quantity = trade.quantity;
+      const timestamp = trade.timestamp;
+
+      if (side === 'buy') {
+        // Opening or adding to position
+        const existing = positions.get(symbol);
+        if (existing) {
+          // Average in
+          const totalQuantity = existing.quantity + quantity;
+          const avgPrice = (existing.entryPrice * existing.quantity + price * quantity) / totalQuantity;
+          positions.set(symbol, { entryPrice: avgPrice, quantity: totalQuantity, entryTime: existing.entryTime });
+        } else {
+          positions.set(symbol, { entryPrice: price, quantity, entryTime: timestamp });
+        }
+      } else if (side === 'sell') {
+        // Closing position
+        const existing = positions.get(symbol);
+        if (existing) {
+          const pnl = (price - existing.entryPrice) * Math.min(quantity, existing.quantity);
+          const pnlPercent = ((price - existing.entryPrice) / existing.entryPrice) * 100;
+          const duration = timestamp - existing.entryTime;
+
+          analysis.push({
+            id: trade.id || `trade-${timestamp}`,
+            entryTime: existing.entryTime,
+            exitTime: timestamp,
+            side: 'long',
+            entryPrice: existing.entryPrice,
+            exitPrice: price,
+            quantity: Math.min(quantity, existing.quantity),
+            pnl,
+            pnlPercent,
+            duration,
+            mfe: this.calculateMFE(existing.entryPrice, price, this.result.snapshots, existing.entryTime, timestamp),
+            mae: this.calculateMAE(existing.entryPrice, price, this.result.snapshots, existing.entryTime, timestamp),
+            riskRewardRatio: pnlPercent > 0 ? pnlPercent / Math.abs(this.calculateMAE(existing.entryPrice, price, this.result.snapshots, existing.entryTime, timestamp) || 1) : 0,
+            holdingReturn: pnlPercent,
+            isWinner: pnl > 0,
+            exitReason: 'signal',
+          });
+
+          // Update or remove position
+          if (quantity >= existing.quantity) {
+            positions.delete(symbol);
+          } else {
+            positions.set(symbol, { ...existing, quantity: existing.quantity - quantity });
+          }
+        }
+      }
+    }
+
+    return analysis;
+  }
+
+  /**
+   * Calculate Maximum Favorable Excursion
+   */
+  private calculateMFE(
+    entryPrice: number,
+    exitPrice: number,
+    snapshots: PortfolioSnapshot[],
+    entryTime: number,
+    exitTime: number
+  ): number {
+    // Simplified - would need price data to calculate accurately
+    const favorable = exitPrice > entryPrice;
+    if (favorable) {
+      return ((exitPrice - entryPrice) / entryPrice) * 100;
+    }
+    return 0;
+  }
+
+  /**
+   * Calculate Maximum Adverse Excursion
+   */
+  private calculateMAE(
+    entryPrice: number,
+    exitPrice: number,
+    snapshots: PortfolioSnapshot[],
+    entryTime: number,
+    exitTime: number
+  ): number {
+    // Simplified - would need price data to calculate accurately
+    const adverse = exitPrice < entryPrice;
+    if (adverse) {
+      return ((entryPrice - exitPrice) / entryPrice) * 100;
+    }
+    return 0;
+  }
+
+  /**
+   * Generate equity curve with detailed metrics
+   */
+  private generateEquityCurve(): EquityCurvePoint[] {
+    const snapshots = this.result.snapshots;
+    if (!snapshots || snapshots.length === 0) {
+      return [];
+    }
+
+    const equityCurve: EquityCurvePoint[] = [];
+    const initialCapital = this.result.config.capital;
+    let peak = initialCapital;
+
+    for (let i = 0; i < snapshots.length; i++) {
+      const snapshot = snapshots[i];
+      const value = snapshot.totalValue;
+      const cash = snapshot.cash;
+      const positionValue = value - cash;
+
+      // Track peak for drawdown calculation
+      if (value > peak) {
+        peak = value;
+      }
+
+      const drawdown = peak - value;
+      const drawdownPercent = peak > 0 ? (drawdown / peak) * 100 : 0;
+      const cumulativeReturn = initialCapital > 0 ? ((value - initialCapital) / initialCapital) * 100 : 0;
+
+      // Calculate daily return
+      let dailyReturn = 0;
+      if (i > 0) {
+        const prevValue = snapshots[i - 1].totalValue;
+        dailyReturn = prevValue > 0 ? ((value - prevValue) / prevValue) * 100 : 0;
+      }
+
+      equityCurve.push({
+        timestamp: snapshot.timestamp,
+        value,
+        cash,
+        positionValue,
+        drawdown,
+        drawdownPercent,
+        dailyReturn,
+        cumulativeReturn,
+      });
+    }
+
+    return equityCurve;
+  }
+
+  /**
+   * Analyze drawdowns in detail
+   */
+  private analyzeDrawdowns(equityCurve: EquityCurvePoint[]): DrawdownAnalysis {
+    if (equityCurve.length === 0) {
+      return {
+        maxDrawdown: 0,
+        maxDrawdownDuration: 0,
+        avgDrawdown: 0,
+        drawdownPeriods: [],
+        recoveryFactor: 0,
+        timeUnderwater: 0,
+      };
+    }
+
+    const drawdownPeriods: DrawdownPeriod[] = [];
+    let maxDrawdown = 0;
+    let maxDrawdownDuration = 0;
+    let totalDrawdown = 0;
+    let underwaterCount = 0;
+    let peak = equityCurve[0].value;
+    let peakTime = equityCurve[0].timestamp;
+    let inDrawdown = false;
+    let drawdownStart = 0;
+    let troughValue = peak;
+    let troughTime = peakTime;
+
+    for (const point of equityCurve) {
+      if (point.value > peak) {
+        // New peak - end drawdown if in one
+        if (inDrawdown) {
+          const drawdownPercent = ((peak - troughValue) / peak) * 100;
+          const duration = troughTime - drawdownStart;
+          const recoveryDuration = point.timestamp - troughTime;
+
+          drawdownPeriods.push({
+            startTimestamp: drawdownStart,
+            troughTimestamp: troughTime,
+            endTimestamp: point.timestamp,
+            peakValue: peak,
+            troughValue,
+            drawdownPercent,
+            duration,
+            recoveryDuration,
+          });
+
+          if (drawdownPercent > maxDrawdown) {
+            maxDrawdown = drawdownPercent;
+            maxDrawdownDuration = duration + (recoveryDuration || 0);
+          }
+
+          if (duration > maxDrawdownDuration) {
+            maxDrawdownDuration = duration;
+          }
+        }
+
+        peak = point.value;
+        peakTime = point.timestamp;
+        troughValue = peak;
+        troughTime = peakTime;
+        inDrawdown = false;
+      } else {
+        // In drawdown
+        if (!inDrawdown) {
+          inDrawdown = true;
+          drawdownStart = peakTime;
+        }
+
+        if (point.value < troughValue) {
+          troughValue = point.value;
+          troughTime = point.timestamp;
+        }
+
+        totalDrawdown += point.drawdownPercent;
+        underwaterCount++;
+      }
+    }
+
+    // Handle ongoing drawdown
+    if (inDrawdown) {
+      const drawdownPercent = ((peak - troughValue) / peak) * 100;
+      drawdownPeriods.push({
+        startTimestamp: drawdownStart,
+        troughTimestamp: troughTime,
+        endTimestamp: null,
+        peakValue: peak,
+        troughValue,
+        drawdownPercent,
+        duration: troughTime - drawdownStart,
+        recoveryDuration: null,
+      });
+
+      if (drawdownPercent > maxDrawdown) {
+        maxDrawdown = drawdownPercent;
+      }
+    }
+
+    const avgDrawdown = underwaterCount > 0 ? totalDrawdown / underwaterCount : 0;
+    const timeUnderwater = equityCurve.length > 0 ? (underwaterCount / equityCurve.length) * 100 : 0;
+    const totalReturn = this.result.stats.totalReturn;
+    const recoveryFactor = maxDrawdown > 0 ? Math.abs(totalReturn / maxDrawdown) : 0;
+
+    return {
+      maxDrawdown,
+      maxDrawdownDuration,
+      avgDrawdown,
+      drawdownPeriods,
+      recoveryFactor,
+      timeUnderwater,
+    };
+  }
+
+  /**
+   * Analyze positions by symbol
+   */
+  private analyzePositions(): PositionAnalysis[] {
+    const trades = this.result.trades;
+    if (!trades || trades.length === 0) {
+      return [];
+    }
+
+    const symbolStats = new Map<string, {
+      totalTrades: number;
+      winners: number;
+      losers: number;
+      totalPnL: number;
+      maxPositionSize: number;
+      totalPositionSize: number;
+      longTrades: number;
+      shortTrades: number;
+      longWinners: number;
+      shortWinners: number;
+    }>();
+
+    for (const trade of trades) {
+      const symbol = trade.symbol || this.result.config.symbol;
+      const stats = symbolStats.get(symbol) || {
+        totalTrades: 0,
+        winners: 0,
+        losers: 0,
+        totalPnL: 0,
+        maxPositionSize: 0,
+        totalPositionSize: 0,
+        longTrades: 0,
+        shortTrades: 0,
+        longWinners: 0,
+        shortWinners: 0,
+      };
+
+      stats.totalTrades++;
+      stats.totalPnL += trade.realizedPnL || 0;
+
+      if ((trade.realizedPnL || 0) > 0) {
+        stats.winners++;
+      } else if ((trade.realizedPnL || 0) < 0) {
+        stats.losers++;
+      }
+
+      const side = trade.side?.toLowerCase() || 'buy';
+      if (side === 'buy') {
+        stats.longTrades++;
+        if ((trade.realizedPnL || 0) > 0) {
+          stats.longWinners++;
+        }
+      } else {
+        stats.shortTrades++;
+        if ((trade.realizedPnL || 0) > 0) {
+          stats.shortWinners++;
+        }
+      }
+
+      stats.totalPositionSize += trade.quantity || 0;
+      stats.maxPositionSize = Math.max(stats.maxPositionSize, trade.quantity || 0);
+
+      symbolStats.set(symbol, stats);
+    }
+
+    const analysis: PositionAnalysis[] = [];
+
+    for (const [symbol, stats] of symbolStats) {
+      analysis.push({
+        symbol,
+        totalTrades: stats.totalTrades,
+        winningTrades: stats.winners,
+        losingTrades: stats.losers,
+        winRate: stats.totalTrades > 0 ? (stats.winners / stats.totalTrades) * 100 : 0,
+        totalPnL: stats.totalPnL,
+        avgPnL: stats.totalTrades > 0 ? stats.totalPnL / stats.totalTrades : 0,
+        maxPositionSize: stats.maxPositionSize,
+        avgPositionSize: stats.totalTrades > 0 ? stats.totalPositionSize / stats.totalTrades : 0,
+        longTrades: stats.longTrades,
+        shortTrades: stats.shortTrades,
+        longWinRate: stats.longTrades > 0 ? (stats.longWinners / stats.longTrades) * 100 : 0,
+        shortWinRate: stats.shortTrades > 0 ? (stats.shortWinners / stats.shortTrades) * 100 : 0,
+      });
+    }
+
+    return analysis;
+  }
+
+  /**
+   * Analyze monthly performance
+   */
+  private analyzeMonthlyPerformance(): MonthlyPerformance[] {
+    const snapshots = this.result.snapshots;
+    if (!snapshots || snapshots.length === 0) {
+      return [];
+    }
+
+    const monthlyData = new Map<string, {
+      year: number;
+      month: number;
+      startCapital: number;
+      endCapital: number;
+      startTimestamp: number;
+      trades: number;
+      totalPnL: number;
+      winners: number;
+      losers: number;
+      maxDrawdown: number;
+      snapshots: PortfolioSnapshot[];
+    }>();
+
+    // Group snapshots by month
+    for (const snapshot of snapshots) {
+      const date = new Date(snapshot.timestamp);
+      const key = `${date.getFullYear()}-${date.getMonth() + 1}`;
+
+      const data = monthlyData.get(key) || {
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        startCapital: snapshot.totalValue,
+        endCapital: snapshot.totalValue,
+        startTimestamp: snapshot.timestamp,
+        trades: 0,
+        totalPnL: 0,
+        winners: 0,
+        losers: 0,
+        maxDrawdown: 0,
+        snapshots: [],
+      };
+
+      data.endCapital = snapshot.totalValue;
+      data.snapshots.push(snapshot);
+      monthlyData.set(key, data);
+    }
+
+    // Add trade data to months
+    for (const trade of this.result.trades) {
+      if (!trade.timestamp) continue;
+      const date = new Date(trade.timestamp);
+      const key = `${date.getFullYear()}-${date.getMonth() + 1}`;
+      const data = monthlyData.get(key);
+      if (data) {
+        data.trades++;
+        data.totalPnL += trade.realizedPnL || 0;
+        if ((trade.realizedPnL || 0) > 0) {
+          data.winners++;
+        } else if ((trade.realizedPnL || 0) < 0) {
+          data.losers++;
+        }
+      }
+    }
+
+    // Calculate monthly metrics
+    const performance: MonthlyPerformance[] = [];
+    let peak = 0;
+
+    for (const [, data] of monthlyData) {
+      const returnPercent = data.startCapital > 0 
+        ? ((data.endCapital - data.startCapital) / data.startCapital) * 100 
+        : 0;
+      
+      // Calculate max drawdown for the month
+      let monthMaxDD = 0;
+      peak = data.snapshots[0]?.totalValue || 0;
+      for (const snap of data.snapshots) {
+        if (snap.totalValue > peak) {
+          peak = snap.totalValue;
+        }
+        const dd = peak > 0 ? ((peak - snap.totalValue) / peak) * 100 : 0;
+        monthMaxDD = Math.max(monthMaxDD, dd);
+      }
+
+      performance.push({
+        year: data.year,
+        month: data.month,
+        returnPercent,
+        trades: data.trades,
+        winRate: data.trades > 0 ? (data.winners / data.trades) * 100 : 0,
+        maxDrawdown: monthMaxDD,
+        totalPnL: data.totalPnL,
+        startCapital: data.startCapital,
+        endCapital: data.endCapital,
+      });
+    }
+
+    // Sort by year and month
+    return performance.sort((a, b) => {
+      if (a.year !== b.year) return a.year - b.year;
+      return a.month - b.month;
+    });
+  }
+
+  /**
+   * Analyze trade distribution
+   */
+  private analyzeTradeDistribution(): TradeDistribution {
+    const trades = this.result.trades;
+    const byHour = new Array(24).fill(0);
+    const byDayOfWeek = new Array(7).fill(0);
+    const byMonth = new Array(12).fill(0);
+
+    // Size buckets
+    const sizeBuckets: SizeBucket[] = [
+      { label: '0-10', min: 0, max: 10, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '10-50', min: 10, max: 50, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '50-100', min: 50, max: 100, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '100-500', min: 100, max: 500, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '500+', min: 500, max: Infinity, count: 0, winRate: 0, avgPnL: 0 },
+    ];
+
+    // Duration buckets (in milliseconds)
+    const durationBuckets: DurationBucket[] = [
+      { label: '<1min', minMs: 0, maxMs: 60000, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '1-5min', minMs: 60000, maxMs: 300000, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '5-15min', minMs: 300000, maxMs: 900000, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '15-60min', minMs: 900000, maxMs: 3600000, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '1-4h', minMs: 3600000, maxMs: 14400000, count: 0, winRate: 0, avgPnL: 0 },
+      { label: '>4h', minMs: 14400000, maxMs: Infinity, count: 0, winRate: 0, avgPnL: 0 },
+    ];
+
+    // P&L buckets
+    const pnlBuckets: PnLBucket[] = [
+      { label: 'Large Loss (<-10%)', min: -Infinity, max: -10, count: 0 },
+      { label: 'Moderate Loss (-10% to -5%)', min: -10, max: -5, count: 0 },
+      { label: 'Small Loss (-5% to 0%)', min: -5, max: 0, count: 0 },
+      { label: 'Small Win (0% to 5%)', min: 0, max: 5, count: 0 },
+      { label: 'Moderate Win (5% to 10%)', min: 5, max: 10, count: 0 },
+      { label: 'Large Win (>10%)', min: 10, max: Infinity, count: 0 },
+    ];
+
+    if (!trades || trades.length === 0) {
+      return { byHour, byDayOfWeek, byMonth, bySize: sizeBuckets, byDuration: durationBuckets, byPnL: pnlBuckets };
+    }
+
+    // Process trades
+    for (const trade of trades) {
+      if (trade.timestamp) {
+        const date = new Date(trade.timestamp);
+        byHour[date.getHours()]++;
+        byDayOfWeek[date.getDay()]++;
+        byMonth[date.getMonth()]++;
+      }
+
+      const quantity = trade.quantity || 0;
+      const pnl = trade.realizedPnL || 0;
+      const pnlPercent = trade.price ? (pnl / trade.price) * 100 : 0;
+
+      // Size bucket
+      for (const bucket of sizeBuckets) {
+        if (quantity >= bucket.min && quantity < bucket.max) {
+          bucket.count++;
+          break;
+        }
+      }
+
+      // Duration bucket (using trade duration if available)
+      const duration = trade.duration || 0;
+      for (const bucket of durationBuckets) {
+        if (duration >= bucket.minMs && duration < bucket.maxMs) {
+          bucket.count++;
+          break;
+        }
+      }
+
+      // P&L bucket (using percentage)
+      for (const bucket of pnlBuckets) {
+        if (pnlPercent >= bucket.min && pnlPercent < bucket.max) {
+          bucket.count++;
+          break;
+        }
+      }
+    }
+
+    return { byHour, byDayOfWeek, byMonth, bySize: sizeBuckets, byDuration: durationBuckets, byPnL: pnlBuckets };
+  }
+
+  /**
+   * Calculate advanced risk metrics
+   */
+  private calculateRiskMetrics(equityCurve: EquityCurvePoint[]): RiskMetrics {
+    if (equityCurve.length < 2) {
+      return {
+        sharpeRatio: 0,
+        sortinoRatio: 0,
+        calmarRatio: 0,
+        volatility: 0,
+        downsideDeviation: 0,
+        var95: 0,
+        cvar95: 0,
+        maxConsecutiveLosses: 0,
+        maxConsecutiveWins: 0,
+        avgLeverage: 1,
+        maxLeverage: 1,
+      };
+    }
+
+    // Calculate returns
+    const returns: number[] = [];
+    for (let i = 1; i < equityCurve.length; i++) {
+      const prevValue = equityCurve[i - 1].value;
+      const currValue = equityCurve[i].value;
+      if (prevValue > 0) {
+        returns.push((currValue - prevValue) / prevValue);
+      }
+    }
+
+    if (returns.length === 0) {
+      return {
+        sharpeRatio: 0,
+        sortinoRatio: 0,
+        calmarRatio: 0,
+        volatility: 0,
+        downsideDeviation: 0,
+        var95: 0,
+        cvar95: 0,
+        maxConsecutiveLosses: 0,
+        maxConsecutiveWins: 0,
+        avgLeverage: 1,
+        maxLeverage: 1,
+      };
+    }
+
+    // Mean return
+    const meanReturn = returns.reduce((a, b) => a + b, 0) / returns.length;
+
+    // Standard deviation
+    const variance = returns.reduce((sum, r) => sum + Math.pow(r - meanReturn, 2), 0) / returns.length;
+    const stdDev = Math.sqrt(variance);
+
+    // Downside deviation (negative returns only)
+    const negativeReturns = returns.filter(r => r < 0);
+    const downsideVariance = negativeReturns.length > 0
+      ? negativeReturns.reduce((sum, r) => sum + Math.pow(r, 2), 0) / negativeReturns.length
+      : 0;
+    const downsideDeviation = Math.sqrt(downsideVariance);
+
+    // Annualized metrics (assuming daily returns)
+    const annualizedReturn = meanReturn * 252;
+    const annualizedStdDev = stdDev * Math.sqrt(252);
+    const riskFreeRate = 0.02; // 2% annual risk-free rate
+
+    // Sharpe ratio
+    const sharpeRatio = annualizedStdDev > 0 
+      ? (annualizedReturn - riskFreeRate) / annualizedStdDev 
+      : 0;
+
+    // Sortino ratio
+    const annualizedDownsideDev = downsideDeviation * Math.sqrt(252);
+    const sortinoRatio = annualizedDownsideDev > 0 
+      ? (annualizedReturn - riskFreeRate) / annualizedDownsideDev 
+      : 0;
+
+    // Calmar ratio
+    const maxDrawdown = this.result.stats.maxDrawdown;
+    const calmarRatio = maxDrawdown > 0 
+      ? this.result.stats.annualizedReturn / maxDrawdown 
+      : 0;
+
+    // VaR (95%) - using historical simulation
+    const sortedReturns = [...returns].sort((a, b) => a - b);
+    const var95Index = Math.floor(returns.length * 0.05);
+    const var95 = sortedReturns[var95Index] || 0;
+
+    // CVaR (Expected Shortfall)
+    const tailReturns = sortedReturns.slice(0, var95Index + 1);
+    const cvar95 = tailReturns.length > 0 
+      ? tailReturns.reduce((a, b) => a + b, 0) / tailReturns.length 
+      : 0;
+
+    // Consecutive wins/losses
+    let consecutiveWins = 0;
+    let consecutiveLosses = 0;
+    let maxConsecutiveWins = 0;
+    let maxConsecutiveLosses = 0;
+
+    for (const r of returns) {
+      if (r > 0) {
+        consecutiveWins++;
+        consecutiveLosses = 0;
+        maxConsecutiveWins = Math.max(maxConsecutiveWins, consecutiveWins);
+      } else if (r < 0) {
+        consecutiveLosses++;
+        consecutiveWins = 0;
+        maxConsecutiveLosses = Math.max(maxConsecutiveLosses, consecutiveLosses);
+      }
+    }
+
+    return {
+      sharpeRatio,
+      sortinoRatio,
+      calmarRatio,
+      volatility: annualizedStdDev,
+      downsideDeviation: annualizedDownsideDev,
+      var95,
+      cvar95,
+      maxConsecutiveLosses,
+      maxConsecutiveWins,
+      avgLeverage: 1, // Would need position tracking to calculate
+      maxLeverage: 1,
+    };
+  }
+
+  /**
+   * Calculate performance scorecard
+   */
+  private calculatePerformanceScorecard(
+    stats: BacktestStats,
+    riskMetrics: RiskMetrics,
+    tradeAnalysis: TradeAnalysis[]
+  ): PerformanceScorecard {
+    // Score each category (0-100)
+    const profitabilityScore = this.scoreProfitability(stats);
+    const riskScore = this.scoreRisk(stats, riskMetrics);
+    const consistencyScore = this.scoreConsistency(tradeAnalysis, stats, riskMetrics);
+    const efficiencyScore = this.scoreEfficiency(stats, riskMetrics);
+
+    // Weighted overall score
+    const weights = {
+      profitability: 0.35,
+      risk: 0.30,
+      consistency: 0.20,
+      efficiency: 0.15,
+    };
+
+    const overallScore = 
+      profitabilityScore * weights.profitability +
+      riskScore * weights.risk +
+      consistencyScore * weights.consistency +
+      efficiencyScore * weights.efficiency;
+
+    return {
+      overallScore: Math.round(overallScore * 10) / 10,
+      profitabilityScore: Math.round(profitabilityScore * 10) / 10,
+      riskScore: Math.round(riskScore * 10) / 10,
+      consistencyScore: Math.round(consistencyScore * 10) / 10,
+      efficiencyScore: Math.round(efficiencyScore * 10) / 10,
+      breakdown: [
+        { category: '盈利能力', score: profitabilityScore, weight: weights.profitability, description: '回报率和利润因子表现' },
+        { category: '风险管理', score: riskScore, weight: weights.risk, description: '最大回撤和波动性控制' },
+        { category: '一致性', score: consistencyScore, weight: weights.consistency, description: '胜率和交易稳定性' },
+        { category: '效率', score: efficiencyScore, weight: weights.efficiency, description: '夏普比率和资金利用' },
+      ],
+    };
+  }
+
+  /**
+   * Score profitability (0-100)
+   */
+  private scoreProfitability(stats: BacktestStats): number {
+    let score = 50;
+
+    // Total return contribution
+    if (stats.totalReturn > 50) score += 25;
+    else if (stats.totalReturn > 30) score += 20;
+    else if (stats.totalReturn > 15) score += 15;
+    else if (stats.totalReturn > 5) score += 10;
+    else if (stats.totalReturn < -10) score -= 20;
+
+    // Profit factor contribution
+    if (stats.profitFactor > 3) score += 25;
+    else if (stats.profitFactor > 2) score += 20;
+    else if (stats.profitFactor > 1.5) score += 10;
+    else if (stats.profitFactor < 1) score -= 25;
+
+    return Math.max(0, Math.min(100, score));
+  }
+
+  /**
+   * Score risk management (0-100)
+   */
+  private scoreRisk(stats: BacktestStats, riskMetrics: RiskMetrics): number {
+    let score = 50;
+
+    // Max drawdown contribution
+    if (stats.maxDrawdown < 5) score += 25;
+    else if (stats.maxDrawdown < 10) score += 20;
+    else if (stats.maxDrawdown < 20) score += 10;
+    else if (stats.maxDrawdown < 30) score -= 10;
+    else if (stats.maxDrawdown > 50) score -= 25;
+
+    // Sharpe ratio contribution
+    if (riskMetrics.sharpeRatio > 2) score += 25;
+    else if (riskMetrics.sharpeRatio > 1.5) score += 20;
+    else if (riskMetrics.sharpeRatio > 1) score += 10;
+    else if (riskMetrics.sharpeRatio < 0.5) score -= 15;
+
+    return Math.max(0, Math.min(100, score));
+  }
+
+  /**
+   * Score consistency (0-100)
+   */
+  private scoreConsistency(tradeAnalysis: TradeAnalysis[], stats: BacktestStats, riskMetrics: RiskMetrics): number {
+    let score = 50;
+
+    // Win rate contribution
+    if (stats.winRate > 60) score += 20;
+    else if (stats.winRate > 50) score += 15;
+    else if (stats.winRate > 45) score += 10;
+    else if (stats.winRate < 35) score -= 15;
+
+    // Trade count contribution (need enough trades for statistical significance)
+    if (stats.totalTrades >= 100) score += 15;
+    else if (stats.totalTrades >= 50) score += 10;
+    else if (stats.totalTrades >= 30) score += 5;
+    else score -= 10;
+
+    // Consecutive loss control
+    if (stats.totalTrades > 0) {
+      const maxConsecLossRatio = riskMetrics.maxConsecutiveLosses / stats.totalTrades;
+      if (maxConsecLossRatio < 0.05) score += 15;
+      else if (maxConsecLossRatio < 0.1) score += 10;
+      else if (maxConsecLossRatio > 0.2) score -= 10;
+    }
+
+    return Math.max(0, Math.min(100, score));
+  }
+
+  /**
+   * Score efficiency (0-100)
+   */
+  private scoreEfficiency(stats: BacktestStats, riskMetrics: RiskMetrics): number {
+    let score = 50;
+
+    // Sharpe ratio
+    if (riskMetrics.sharpeRatio > 2) score += 25;
+    else if (riskMetrics.sharpeRatio > 1.5) score += 20;
+    else if (riskMetrics.sharpeRatio > 1) score += 15;
+    else if (riskMetrics.sharpeRatio < 0.5) score -= 20;
+
+    // Return per trade
+    const returnPerTrade = stats.totalTrades > 0 ? stats.totalReturn / stats.totalTrades : 0;
+    if (returnPerTrade > 0.5) score += 15;
+    else if (returnPerTrade > 0.2) score += 10;
+    else if (returnPerTrade < 0.05) score -= 10;
+
+    return Math.max(0, Math.min(100, score));
+  }
+
+  /**
+   * Generate recommendations based on analysis
+   */
+  private generateRecommendations(
+    stats: BacktestStats,
+    riskMetrics: RiskMetrics,
+    tradeAnalysis: TradeAnalysis[],
+    drawdownAnalysis: DrawdownAnalysis
+  ): string[] {
+    const recommendations: string[] = [];
+
+    // Profitability recommendations
+    if (stats.profitFactor < 1.5) {
+      recommendations.push('考虑优化止损策略，提高盈亏比。当前盈亏比较低，建议设置更严格的止损或更宽的止盈。');
+    }
+
+    if (stats.winRate < 45 && stats.profitFactor > 1.5) {
+      recommendations.push('当前胜率较低但盈亏比尚可，可考虑增加过滤条件减少虚假信号。');
+    }
+
+    if (stats.winRate > 55 && stats.profitFactor < 1.5) {
+      recommendations.push('胜率较高但单笔盈利较小，建议适当放宽止盈目标或使用追踪止损。');
+    }
+
+    // Risk management recommendations
+    if (stats.maxDrawdown > 25) {
+      recommendations.push(`最大回撤 ${stats.maxDrawdown.toFixed(1)}% 偏高，建议降低仓位或增加风险控制措施。`);
+    }
+
+    if (riskMetrics.maxConsecutiveLosses > 5) {
+      recommendations.push(`最大连续亏损次数为 ${riskMetrics.maxConsecutiveLosses} 次，建议在连续亏损后降低仓位或暂停交易。`);
+    }
+
+    if (riskMetrics.sharpeRatio < 1) {
+      recommendations.push('夏普比率偏低，考虑增加市场趋势过滤或减少震荡行情中的交易。');
+    }
+
+    // Consistency recommendations
+    if (stats.totalTrades < 30) {
+      recommendations.push('交易样本数量较少，建议延长回测周期以获得更可靠的统计结果。');
+    }
+
+    // Drawdown recommendations
+    if (drawdownAnalysis.timeUnderwater > 50) {
+      recommendations.push(`资金在水下的时间占比 ${drawdownAnalysis.timeUnderwater.toFixed(1)}% 较高，建议优化入场时机。`);
+    }
+
+    if (drawdownAnalysis.recoveryFactor < 2) {
+      recommendations.push('恢复因子较低，策略从回撤中恢复的能力不足，建议增加仓位管理策略。');
+    }
+
+    // Positive feedback
+    if (stats.profitFactor > 2 && stats.sharpeRatio > 1.5 && stats.maxDrawdown < 15) {
+      recommendations.push('策略表现优秀，盈利能力、风险控制和稳定性均达到较高水平。');
+    }
+
+    if (recommendations.length === 0) {
+      recommendations.push('策略整体表现良好，继续监控实盘表现以确保回测结果可复现。');
+    }
+
+    return recommendations;
+  }
+}

--- a/src/backtest-analysis/ReportGenerator.ts
+++ b/src/backtest-analysis/ReportGenerator.ts
@@ -1,0 +1,793 @@
+/**
+ * Report Generator
+ *
+ * @module backtest-analysis/ReportGenerator
+ * @description Generate detailed reports from backtest analysis
+ */
+
+import {
+  DeepAnalysisReport,
+  ComparisonReport,
+  ReportExportOptions,
+  EquityCurvePoint,
+  TradeAnalysis,
+  MonthlyPerformance,
+} from './types';
+import { PerformanceScorecard } from './types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * ReportGenerator
+ * Generates formatted reports in various formats
+ */
+export class ReportGenerator {
+  /**
+   * Generate report in specified format
+   */
+  async generate(report: DeepAnalysisReport, options: ReportExportOptions): Promise<{
+    content: string | Buffer;
+    contentType: string;
+    filename: string;
+  }> {
+    switch (options.format) {
+      case 'pdf':
+        return this.generatePDF(report, options);
+      case 'excel':
+        return this.generateExcel(report, options);
+      case 'json':
+      default:
+        return this.generateJSON(report, options);
+    }
+  }
+
+  /**
+   * Generate comparison report
+   */
+  async generateComparisonReport(
+    comparison: ComparisonReport,
+    options: ReportExportOptions
+  ): Promise<{
+    content: string | Buffer;
+    contentType: string;
+    filename: string;
+  }> {
+    switch (options.format) {
+      case 'pdf':
+        return this.generateComparisonPDF(comparison, options);
+      case 'excel':
+        return this.generateComparisonExcel(comparison, options);
+      case 'json':
+      default:
+        return this.generateComparisonJSON(comparison, options);
+    }
+  }
+
+  /**
+   * Generate JSON report
+   */
+  private generateJSON(
+    report: DeepAnalysisReport,
+    options: ReportExportOptions
+  ): { content: string; contentType: string; filename: string } {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = options.title 
+      ? `${options.title.replace(/\s+/g, '_')}_${timestamp}.json`
+      : `backtest_report_${timestamp}.json`;
+
+    return {
+      content: JSON.stringify(report, null, 2),
+      contentType: 'application/json',
+      filename,
+    };
+  }
+
+  /**
+   * Generate PDF report
+   */
+  private async generatePDF(
+    report: DeepAnalysisReport,
+    options: ReportExportOptions
+  ): Promise<{ content: Buffer; contentType: string; filename: string }> {
+    // Use pdfmake 0.3.x API
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createPdf } = require('pdfmake');
+
+    const content: any[] = [
+      // Title
+      {
+        text: options.title || '深度回测分析报告',
+        style: 'header',
+        alignment: 'center',
+        margin: [0, 0, 0, 20] as [number, number, number, number],
+      },
+      // Generation info
+      {
+        text: `生成时间: ${new Date(report.generatedAt).toLocaleString('zh-CN')}`,
+        style: 'subheader',
+        alignment: 'right',
+        margin: [0, 0, 0, 20] as [number, number, number, number],
+      },
+    ];
+
+    // Configuration section
+    content.push(
+      this.generateConfigSection(report),
+      this.generateBasicStatsSection(report),
+      this.generateRiskMetricsSection(report),
+      this.generateScorecardSection(report.performanceScorecard)
+    );
+
+    // Optional sections
+    if (options.includeEquityCurve !== false && report.equityCurve.length > 0) {
+      content.push(this.generateEquityCurveSection(report.equityCurve));
+    }
+
+    if (options.includeMonthlyBreakdown !== false && report.monthlyPerformance.length > 0) {
+      content.push(this.generateMonthlySection(report.monthlyPerformance));
+    }
+
+    if (options.includeDistribution !== false) {
+      content.push(this.generateDistributionSection(report));
+    }
+
+    if (options.includeRecommendations !== false && report.recommendations.length > 0) {
+      content.push(this.generateRecommendationsSection(report.recommendations));
+    }
+
+    const docDefinition = {
+      pageSize: 'A4' as const,
+      pageMargins: [40, 60, 40, 60],
+      content,
+      styles: {
+        header: { fontSize: 20, bold: true },
+        subheader: { fontSize: 10, color: '#666666' },
+        sectionHeader: { fontSize: 14, bold: true, margin: [0, 15, 0, 5] as [number, number, number, number] },
+        tableHeader: { bold: true, fontSize: 9, fillColor: '#EEEEEE' },
+      },
+      defaultStyle: { font: 'Helvetica' as const },
+    };
+
+    return new Promise((resolve, reject) => {
+      try {
+        const pdfDoc = createPdf(docDefinition);
+        pdfDoc.getBuffer((buffer: Buffer) => {
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+          const filename = options.title 
+            ? `${options.title.replace(/\s+/g, '_')}_${timestamp}.pdf`
+            : `backtest_report_${timestamp}.pdf`;
+
+          resolve({ content: buffer, contentType: 'application/pdf', filename });
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Generate Excel report
+   */
+  private async generateExcel(
+    report: DeepAnalysisReport,
+    options: ReportExportOptions
+  ): Promise<{ content: Buffer; contentType: string; filename: string }> {
+    // Simplified Excel generation using CSV format for now
+    // A full implementation would use a library like exceljs
+    const sheets: string[] = [];
+
+    // Summary sheet
+    sheets.push(this.generateSummaryCSV(report));
+
+    // Equity curve sheet
+    if (options.includeEquityCurve !== false) {
+      sheets.push(this.generateEquityCurveCSV(report.equityCurve));
+    }
+
+    // Monthly performance sheet
+    if (options.includeMonthlyBreakdown !== false) {
+      sheets.push(this.generateMonthlyCSV(report.monthlyPerformance));
+    }
+
+    // Trade list sheet
+    if (options.includeTradeList !== false && report.tradeAnalysis.length > 0) {
+      sheets.push(this.generateTradeListCSV(report.tradeAnalysis));
+    }
+
+    const content = sheets.join('\n\n--- Sheet ---\n\n');
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = options.title 
+      ? `${options.title.replace(/\s+/g, '_')}_${timestamp}.csv`
+      : `backtest_report_${timestamp}.csv`;
+
+    return {
+      content: Buffer.from(content, 'utf-8'),
+      contentType: 'text/csv',
+      filename,
+    };
+  }
+
+  /**
+   * Generate configuration section for PDF
+   */
+  private generateConfigSection(report: DeepAnalysisReport): any {
+    return {
+      stack: [
+        { text: '回测配置', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 0,
+            widths: ['40%', '60%'],
+            body: [
+              ['交易对', report.config.symbol],
+              ['策略', report.config.strategy],
+              ['初始资金', `$${report.config.initialCapital.toFixed(2)}`],
+              ['开始时间', new Date(report.config.startTime).toLocaleDateString('zh-CN')],
+              ['结束时间', new Date(report.config.endTime).toLocaleDateString('zh-CN')],
+              ['回测时长', `${(report.config.duration / 1000).toFixed(2)}秒`],
+            ],
+          },
+          layout: 'noBorders',
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate basic stats section for PDF
+   */
+  private generateBasicStatsSection(report: DeepAnalysisReport): any {
+    const stats = report.basicStats;
+    return {
+      stack: [
+        { text: '基础统计', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 0,
+            widths: ['50%', '50%'],
+            body: [
+              ['总回报率', `${stats.totalReturn.toFixed(2)}%`],
+              ['年化回报率', `${stats.annualizedReturn.toFixed(2)}%`],
+              ['最大回撤', `${stats.maxDrawdown.toFixed(2)}%`],
+              ['夏普比率', stats.sharpeRatio.toFixed(4)],
+              ['总交易数', stats.totalTrades.toString()],
+              ['盈利交易', stats.winningTrades.toString()],
+              ['亏损交易', stats.losingTrades.toString()],
+              ['胜率', `${stats.winRate.toFixed(2)}%`],
+              ['平均盈利', `$${stats.avgWin.toFixed(2)}`],
+              ['平均亏损', `$${stats.avgLoss.toFixed(2)}`],
+              ['盈亏比', stats.profitFactor.toFixed(4)],
+            ],
+          },
+          layout: 'noBorders',
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate risk metrics section for PDF
+   */
+  private generateRiskMetricsSection(report: DeepAnalysisReport): any {
+    const risk = report.riskMetrics;
+    return {
+      stack: [
+        { text: '风险指标', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 0,
+            widths: ['50%', '50%'],
+            body: [
+              ['夏普比率', risk.sharpeRatio.toFixed(4)],
+              ['索提诺比率', risk.sortinoRatio.toFixed(4)],
+              ['卡尔马比率', risk.calmarRatio.toFixed(4)],
+              ['年化波动率', `${(risk.volatility * 100).toFixed(2)}%`],
+              ['下行偏差', `${(risk.downsideDeviation * 100).toFixed(2)}%`],
+              ['VaR (95%)', `${(risk.var95 * 100).toFixed(2)}%`],
+              ['CVaR (95%)', `${(risk.cvar95 * 100).toFixed(2)}%`],
+              ['最大连续亏损', risk.maxConsecutiveLosses.toString()],
+              ['最大连续盈利', risk.maxConsecutiveWins.toString()],
+            ],
+          },
+          layout: 'noBorders',
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate scorecard section for PDF
+   */
+  private generateScorecardSection(scorecard: PerformanceScorecard): any {
+    return {
+      stack: [
+        { text: '综合评分', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 0,
+            widths: ['40%', '30%', '30%'],
+            body: [
+              ['评分维度', '分数', '权重'],
+              ['综合评分', { text: scorecard.overallScore.toFixed(1), bold: true }, '-'],
+              ...scorecard.breakdown.map(b => [
+                b.category,
+                b.score.toFixed(1),
+                `${(b.weight * 100).toFixed(0)}%`,
+              ]),
+            ],
+          },
+          layout: {
+            hLineWidth: () => 1,
+            vLineWidth: () => 1,
+            hLineColor: () => '#CCCCCC',
+            vLineColor: () => '#CCCCCC',
+          },
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate equity curve section for PDF
+   */
+  private generateEquityCurveSection(equityCurve: EquityCurvePoint[]): any {
+    // Sample data for display (show first 20 and last 20)
+    const samplePoints = equityCurve.length <= 40 
+      ? equityCurve 
+      : [
+          ...equityCurve.slice(0, 20),
+          ...equityCurve.slice(-20),
+        ];
+
+    const tableBody: any[][] = [
+      [
+        { text: '时间', style: 'tableHeader' },
+        { text: '资产价值', style: 'tableHeader' },
+        { text: '回撤%', style: 'tableHeader' },
+        { text: '累计回报%', style: 'tableHeader' },
+      ],
+    ];
+
+    for (const point of samplePoints) {
+      tableBody.push([
+        new Date(point.timestamp).toLocaleDateString('zh-CN'),
+        `$${point.value.toFixed(2)}`,
+        `${point.drawdownPercent.toFixed(2)}%`,
+        `${point.cumulativeReturn.toFixed(2)}%`,
+      ]);
+    }
+
+    return {
+      stack: [
+        { text: '资金曲线', style: 'sectionHeader' },
+        {
+          text: `数据点总数: ${equityCurve.length}`,
+          style: 'subheader',
+          margin: [0, 0, 0, 5] as [number, number, number, number],
+        },
+        {
+          table: {
+            headerRows: 1,
+            widths: ['*', 'auto', 'auto', 'auto'],
+            body: tableBody,
+          },
+          layout: {
+            hLineWidth: () => 1,
+            vLineWidth: () => 1,
+            hLineColor: () => '#CCCCCC',
+            vLineColor: () => '#CCCCCC',
+          },
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate monthly section for PDF
+   */
+  private generateMonthlySection(monthly: MonthlyPerformance[]): any {
+    const tableBody: any[][] = [
+      [
+        { text: '月份', style: 'tableHeader' },
+        { text: '回报率%', style: 'tableHeader' },
+        { text: '交易数', style: 'tableHeader' },
+        { text: '胜率%', style: 'tableHeader' },
+        { text: '最大回撤%', style: 'tableHeader' },
+      ],
+    ];
+
+    for (const m of monthly) {
+      tableBody.push([
+        `${m.year}/${m.month.toString().padStart(2, '0')}`,
+        {
+          text: m.returnPercent.toFixed(2),
+          color: m.returnPercent >= 0 ? 'green' : 'red',
+        },
+        m.trades.toString(),
+        `${m.winRate.toFixed(1)}%`,
+        `${m.maxDrawdown.toFixed(2)}%`,
+      ]);
+    }
+
+    return {
+      stack: [
+        { text: '月度表现', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 1,
+            widths: ['auto', 'auto', 'auto', 'auto', 'auto'],
+            body: tableBody,
+          },
+          layout: {
+            hLineWidth: () => 1,
+            vLineWidth: () => 1,
+            hLineColor: () => '#CCCCCC',
+            vLineColor: () => '#CCCCCC',
+          },
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate distribution section for PDF
+   */
+  private generateDistributionSection(report: DeepAnalysisReport): any {
+    const dist = report.tradeDistribution;
+    
+    return {
+      stack: [
+        { text: '交易分布', style: 'sectionHeader' },
+        {
+          columns: [
+            {
+              width: '*',
+              stack: [
+                { text: '按交易量分布', bold: true },
+                ...dist.bySize.map(s => ({
+                  text: `${s.label}: ${s.count}笔`,
+                  fontSize: 9,
+                })),
+              ],
+            },
+            {
+              width: '*',
+              stack: [
+                { text: '按持续时间分布', bold: true },
+                ...dist.byDuration.map(d => ({
+                  text: `${d.label}: ${d.count}笔`,
+                  fontSize: 9,
+                })),
+              ],
+            },
+          ],
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate recommendations section for PDF
+   */
+  private generateRecommendationsSection(recommendations: string[]): any {
+    return {
+      stack: [
+        { text: '策略建议', style: 'sectionHeader' },
+        {
+          ul: recommendations.map(r => ({
+            text: r,
+            fontSize: 10,
+          })),
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate summary CSV
+   */
+  private generateSummaryCSV(report: DeepAnalysisReport): string {
+    const lines: string[] = [
+      '指标,数值',
+      `总回报率,${report.basicStats.totalReturn.toFixed(2)}%`,
+      `年化回报率,${report.basicStats.annualizedReturn.toFixed(2)}%`,
+      `最大回撤,${report.basicStats.maxDrawdown.toFixed(2)}%`,
+      `夏普比率,${report.basicStats.sharpeRatio.toFixed(4)}`,
+      `总交易数,${report.basicStats.totalTrades}`,
+      `胜率,${report.basicStats.winRate.toFixed(2)}%`,
+      `盈亏比,${report.basicStats.profitFactor.toFixed(4)}`,
+      `综合评分,${report.performanceScorecard.overallScore.toFixed(1)}`,
+    ];
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate equity curve CSV
+   */
+  private generateEquityCurveCSV(equityCurve: EquityCurvePoint[]): string {
+    const lines: string[] = [
+      '时间,资产价值,现金,持仓价值,回撤,回撤%,累计回报%',
+      ...equityCurve.map(p => 
+        `${new Date(p.timestamp).toISOString()},${p.value.toFixed(2)},${p.cash.toFixed(2)},${p.positionValue.toFixed(2)},${p.drawdown.toFixed(2)},${p.drawdownPercent.toFixed(4)},${p.cumulativeReturn.toFixed(4)}`
+      ),
+    ];
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate monthly performance CSV
+   */
+  private generateMonthlyCSV(monthly: MonthlyPerformance[]): string {
+    const lines: string[] = [
+      '年,月,回报率%,交易数,胜率%,最大回撤%,总盈亏',
+      ...monthly.map(m => 
+        `${m.year},${m.month},${m.returnPercent.toFixed(4)},${m.trades},${m.winRate.toFixed(2)},${m.maxDrawdown.toFixed(2)},${m.totalPnL.toFixed(2)}`
+      ),
+    ];
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate trade list CSV
+   */
+  private generateTradeListCSV(trades: TradeAnalysis[]): string {
+    const lines: string[] = [
+      'ID,入场时间,出场时间,方向,入场价,出场价,数量,盈亏,盈亏%,持续时间(ms),是否盈利',
+      ...trades.map(t => 
+        `${t.id},${new Date(t.entryTime).toISOString()},${new Date(t.exitTime).toISOString()},${t.side},${t.entryPrice.toFixed(4)},${t.exitPrice.toFixed(4)},${t.quantity.toFixed(4)},${t.pnl.toFixed(4)},${t.pnlPercent.toFixed(4)},${t.duration},${t.isWinner}`
+      ),
+    ];
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate comparison PDF
+   */
+  private async generateComparisonPDF(
+    comparison: ComparisonReport,
+    options: ReportExportOptions
+  ): Promise<{ content: Buffer; contentType: string; filename: string }> {
+    // Use pdfmake 0.3.x API
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createPdf } = require('pdfmake');
+
+    const content: any[] = [
+      {
+        text: options.title || '策略对比报告',
+        style: 'header',
+        alignment: 'center',
+        margin: [0, 0, 0, 20] as [number, number, number, number],
+      },
+      {
+        text: `生成时间: ${new Date(comparison.generatedAt).toLocaleString('zh-CN')}`,
+        style: 'subheader',
+        alignment: 'right',
+        margin: [0, 0, 0, 20] as [number, number, number, number],
+      },
+      // Summary
+      {
+        text: '对比摘要',
+        style: 'sectionHeader',
+      },
+      {
+        table: {
+          headerRows: 0,
+          widths: ['50%', '50%'],
+          body: [
+            ['最佳综合表现', comparison.summary.bestOverall],
+            ['最高回报', comparison.summary.bestReturn],
+            ['最低风险', comparison.summary.lowestRisk],
+            ['最高夏普比率', comparison.summary.highestSharpe],
+            ['最稳定', comparison.summary.mostConsistent],
+          ],
+        },
+        layout: 'noBorders',
+        margin: [0, 0, 0, 20] as [number, number, number, number],
+      },
+      // Rankings table
+      this.generateRankingsTable(comparison.rankings),
+      // Detailed comparison
+      this.generateDetailedComparisonTable(comparison.results),
+    ];
+
+    const docDefinition = {
+      pageSize: 'A4' as const,
+      pageOrientation: 'landscape' as const,
+      pageMargins: [40, 60, 40, 60],
+      content,
+      styles: {
+        header: { fontSize: 20, bold: true },
+        subheader: { fontSize: 10, color: '#666666' },
+        sectionHeader: { fontSize: 14, bold: true, margin: [0, 15, 0, 5] as [number, number, number, number] },
+        tableHeader: { bold: true, fontSize: 9, fillColor: '#EEEEEE' },
+      },
+      defaultStyle: { font: 'Helvetica' as const },
+    };
+
+    return new Promise((resolve, reject) => {
+      try {
+        const pdfDoc = createPdf(docDefinition);
+        pdfDoc.getBuffer((buffer: Buffer) => {
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+          resolve({
+            content: buffer,
+            contentType: 'application/pdf',
+            filename: `strategy_comparison_${timestamp}.pdf`,
+          });
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Generate rankings table
+   */
+  private generateRankingsTable(rankings: any[]): any {
+    // Find overall ranking
+    const overall = rankings.find(r => r.metric === '综合评分');
+    
+    if (!overall) return {};
+
+    return {
+      stack: [
+        { text: '综合排名', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 1,
+            widths: ['auto', '*', 'auto'],
+            body: [
+              [
+                { text: '排名', style: 'tableHeader' },
+                { text: '策略', style: 'tableHeader' },
+                { text: '分数', style: 'tableHeader' },
+              ],
+              ...overall.rankings.map((r: any) => [
+                r.rank.toString(),
+                r.strategyName,
+                r.value.toFixed(2),
+              ]),
+            ],
+          },
+          layout: {
+            hLineWidth: () => 1,
+            vLineWidth: () => 1,
+            hLineColor: () => '#CCCCCC',
+            vLineColor: () => '#CCCCCC',
+          },
+        },
+      ],
+      margin: [0, 0, 0, 20] as [number, number, number, number],
+    };
+  }
+
+  /**
+   * Generate detailed comparison table
+   */
+  private generateDetailedComparisonTable(results: any[]): any {
+    const headerRow = [
+      { text: '指标', style: 'tableHeader' },
+      ...results.map(r => ({ text: r.strategyName, style: 'tableHeader' })),
+    ];
+
+    const metrics = [
+      { label: '总回报率%', key: 'stats.totalReturn', format: (v: number) => v.toFixed(2) },
+      { label: '年化回报%', key: 'stats.annualizedReturn', format: (v: number) => v.toFixed(2) },
+      { label: '夏普比率', key: 'riskMetrics.sharpeRatio', format: (v: number) => v.toFixed(4) },
+      { label: '最大回撤%', key: 'stats.maxDrawdown', format: (v: number) => v.toFixed(2) },
+      { label: '总交易数', key: 'stats.totalTrades', format: (v: number) => v.toString() },
+      { label: '胜率%', key: 'stats.winRate', format: (v: number) => v.toFixed(1) },
+      { label: '盈亏比', key: 'stats.profitFactor', format: (v: number) => v.toFixed(2) },
+      { label: '恢复因子', key: 'drawdownAnalysis.recoveryFactor', format: (v: number) => v.toFixed(2) },
+    ];
+
+    const body = [
+      headerRow,
+      ...metrics.map(m => [
+        m.label,
+        ...results.map(r => {
+          const value = this.getNestedValue(r, m.key);
+          return m.format(value);
+        }),
+      ]),
+    ];
+
+    return {
+      stack: [
+        { text: '详细对比', style: 'sectionHeader' },
+        {
+          table: {
+            headerRows: 1,
+            widths: ['auto', ...results.map(() => '*')],
+            body,
+          },
+          layout: {
+            hLineWidth: () => 1,
+            vLineWidth: () => 1,
+            hLineColor: () => '#CCCCCC',
+            vLineColor: () => '#CCCCCC',
+          },
+        },
+      ],
+    };
+  }
+
+  /**
+   * Get nested value from object
+   */
+  private getNestedValue(obj: any, path: string): any {
+    return path.split('.').reduce((o, k) => (o && o[k] !== undefined) ? o[k] : 0, obj);
+  }
+
+  /**
+   * Generate comparison Excel
+   */
+  private async generateComparisonExcel(
+    comparison: ComparisonReport,
+    options: ReportExportOptions
+  ): Promise<{ content: Buffer; contentType: string; filename: string }> {
+    // Generate CSV format
+    const lines: string[] = ['策略对比报告'];
+    lines.push('');
+    lines.push('摘要');
+    lines.push(`最佳综合表现,${comparison.summary.bestOverall}`);
+    lines.push(`最高回报,${comparison.summary.bestReturn}`);
+    lines.push(`最低风险,${comparison.summary.lowestRisk}`);
+    lines.push('');
+    lines.push('详细对比');
+    
+    // Header
+    const headers = ['指标', ...comparison.results.map(r => r.strategyName)];
+    lines.push(headers.join(','));
+    
+    // Metrics
+    const metrics = [
+      { label: '总回报率%', key: 'stats.totalReturn' },
+      { label: '年化回报%', key: 'stats.annualizedReturn' },
+      { label: '夏普比率', key: 'riskMetrics.sharpeRatio' },
+      { label: '最大回撤%', key: 'stats.maxDrawdown' },
+      { label: '总交易数', key: 'stats.totalTrades' },
+      { label: '胜率%', key: 'stats.winRate' },
+      { label: '盈亏比', key: 'stats.profitFactor' },
+    ];
+
+    for (const m of metrics) {
+      const values = comparison.results.map(r => {
+        const v = this.getNestedValue(r, m.key);
+        return typeof v === 'number' ? v.toFixed(2) : v;
+      });
+      lines.push(`${m.label},${values.join(',')}`);
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    return {
+      content: Buffer.from(lines.join('\n'), 'utf-8'),
+      contentType: 'text/csv',
+      filename: `strategy_comparison_${timestamp}.csv`,
+    };
+  }
+
+  /**
+   * Generate comparison JSON
+   */
+  private generateComparisonJSON(
+    comparison: ComparisonReport,
+    options: ReportExportOptions
+  ): { content: string; contentType: string; filename: string } {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    return {
+      content: JSON.stringify(comparison, null, 2),
+      contentType: 'application/json',
+      filename: `strategy_comparison_${timestamp}.json`,
+    };
+  }
+}

--- a/src/backtest-analysis/StrategyComparator.ts
+++ b/src/backtest-analysis/StrategyComparator.ts
@@ -1,0 +1,343 @@
+/**
+ * Strategy Comparator
+ *
+ * @module backtest-analysis/StrategyComparator
+ * @description Compare multiple strategy backtest results
+ */
+
+import { BacktestEngine } from '../backtest/BacktestEngine';
+import { BacktestConfig } from '../backtest/types';
+import {
+  StrategyComparisonOptions,
+  StrategyComparisonResult,
+  ComparisonReport,
+  ComparisonRanking,
+  EquityCurvePoint,
+  MonthlyPerformance,
+  RiskMetrics,
+} from './types';
+import { BacktestAnalyzer } from './BacktestAnalyzer';
+
+/**
+ * StrategyComparator
+ * Compares multiple strategy backtest results
+ */
+export class StrategyComparator {
+  /**
+   * Compare multiple strategies
+   */
+  async compare(options: StrategyComparisonOptions): Promise<ComparisonReport> {
+    const results: StrategyComparisonResult[] = [];
+    const equityCurves: { strategyName: string; data: EquityCurvePoint[] }[] = [];
+
+    // Run backtest for each strategy
+    for (const strategy of options.strategies) {
+      const config: BacktestConfig = {
+        capital: options.backtestConfig.capital,
+        symbol: options.backtestConfig.symbol,
+        startTime: options.backtestConfig.startTime,
+        endTime: options.backtestConfig.endTime,
+        strategy: strategy.type,
+        strategyParams: strategy.params,
+        tickInterval: options.backtestConfig.tickInterval,
+      };
+
+      const engine = new BacktestEngine(config);
+      const backtestResult = engine.run();
+
+      // Generate deep analysis
+      const analyzer = new BacktestAnalyzer(backtestResult);
+      const report = analyzer.generateReport();
+
+      // Store equity curve for comparison charts
+      equityCurves.push({
+        strategyName: strategy.name,
+        data: report.equityCurve,
+      });
+
+      // Build result
+      results.push({
+        strategyName: strategy.name,
+        parameters: strategy.params || {},
+        stats: backtestResult.stats,
+        riskMetrics: report.riskMetrics,
+        tradeSummary: {
+          totalTrades: backtestResult.stats.totalTrades,
+          winners: backtestResult.stats.winningTrades,
+          losers: backtestResult.stats.losingTrades,
+          avgWin: backtestResult.stats.avgWin,
+          avgLoss: backtestResult.stats.avgLoss,
+          profitFactor: backtestResult.stats.profitFactor,
+          expectancy: this.calculateExpectancy(backtestResult.stats),
+        },
+        drawdownAnalysis: {
+          maxDrawdown: report.drawdownAnalysis.maxDrawdown,
+          maxDrawdownDuration: report.drawdownAnalysis.maxDrawdownDuration,
+          recoveryFactor: report.drawdownAnalysis.recoveryFactor,
+        },
+        returnAnalysis: {
+          totalReturn: backtestResult.stats.totalReturn,
+          annualizedReturn: backtestResult.stats.annualizedReturn,
+          monthlyReturns: report.monthlyPerformance,
+        },
+        executionMetrics: {
+          duration: backtestResult.duration,
+          tradesPerSecond: backtestResult.duration > 0 
+            ? backtestResult.stats.totalTrades / (backtestResult.duration / 1000) 
+            : 0,
+        },
+      });
+    }
+
+    // Generate rankings
+    const rankings = this.generateRankings(results);
+
+    // Generate summary
+    const summary = this.generateSummary(results);
+
+    // Generate comparison charts data
+    const comparisonCharts = {
+      equityCurves,
+      drawdownComparison: results.map(r => ({
+        strategyName: r.strategyName,
+        maxDrawdown: r.drawdownAnalysis.maxDrawdown,
+      })),
+      returnDistribution: results.map(r => ({
+        strategyName: r.strategyName,
+        returns: r.returnAnalysis.monthlyReturns.map(m => m.returnPercent),
+      })),
+    };
+
+    return {
+      generatedAt: Date.now(),
+      config: options,
+      results,
+      rankings,
+      summary,
+      comparisonCharts,
+    };
+  }
+
+  /**
+   * Calculate expectancy
+   */
+  private calculateExpectancy(stats: { winRate: number; avgWin: number; avgLoss: number }): number {
+    const winProbability = stats.winRate / 100;
+    const lossProbability = 1 - winProbability;
+    return winProbability * stats.avgWin - lossProbability * stats.avgLoss;
+  }
+
+  /**
+   * Generate rankings for each metric
+   */
+  private generateRankings(results: StrategyComparisonResult[]): ComparisonRanking[] {
+    const metrics = [
+      { key: 'totalReturn', label: '总回报率', higherIsBetter: true },
+      { key: 'sharpeRatio', label: '夏普比率', higherIsBetter: true },
+      { key: 'maxDrawdown', label: '最大回撤', higherIsBetter: false },
+      { key: 'profitFactor', label: '盈亏比', higherIsBetter: true },
+      { key: 'winRate', label: '胜率', higherIsBetter: true },
+      { key: 'recoveryFactor', label: '恢复因子', higherIsBetter: true },
+    ];
+
+    const rankings: ComparisonRanking[] = [];
+
+    for (const metric of metrics) {
+      const values = results.map(r => ({
+        strategyName: r.strategyName,
+        value: this.getMetricValue(r, metric.key),
+      }));
+
+      // Sort based on whether higher is better
+      values.sort((a, b) => 
+        metric.higherIsBetter ? b.value - a.value : a.value - b.value
+      );
+
+      // Assign ranks
+      const rankingsWithRank = values.map((v, index) => ({
+        ...v,
+        rank: index + 1,
+      }));
+
+      rankings.push({
+        metric: metric.label,
+        rankings: rankingsWithRank,
+      });
+    }
+
+    // Overall ranking (composite score)
+    const overallScores = results.map(r => ({
+      strategyName: r.strategyName,
+      value: this.calculateOverallScore(r),
+    }));
+
+    overallScores.sort((a, b) => b.value - a.value);
+
+    rankings.push({
+      metric: '综合评分',
+      rankings: overallScores.map((v, index) => ({
+        ...v,
+        rank: index + 1,
+      })),
+    });
+
+    return rankings;
+  }
+
+  /**
+   * Get metric value from result
+   */
+  private getMetricValue(result: StrategyComparisonResult, key: string): number {
+    switch (key) {
+      case 'totalReturn':
+        return result.stats.totalReturn;
+      case 'sharpeRatio':
+        return result.riskMetrics.sharpeRatio;
+      case 'maxDrawdown':
+        return result.stats.maxDrawdown;
+      case 'profitFactor':
+        return result.stats.profitFactor;
+      case 'winRate':
+        return result.stats.winRate;
+      case 'recoveryFactor':
+        return result.drawdownAnalysis.recoveryFactor;
+      default:
+        return 0;
+    }
+  }
+
+  /**
+   * Calculate overall score for ranking
+   */
+  private calculateOverallScore(result: StrategyComparisonResult): number {
+    // Weighted score
+    const returnScore = Math.max(0, Math.min(100, result.stats.totalReturn + 50)) * 0.3;
+    const sharpeScore = Math.max(0, Math.min(100, result.riskMetrics.sharpeRatio * 30)) * 0.25;
+    const drawdownScore = Math.max(0, 100 - result.stats.maxDrawdown) * 0.2;
+    const profitFactorScore = Math.max(0, Math.min(100, result.stats.profitFactor * 25)) * 0.15;
+    const winRateScore = result.stats.winRate * 0.1;
+
+    return returnScore + sharpeScore + drawdownScore + profitFactorScore + winRateScore;
+  }
+
+  /**
+   * Generate summary with best strategies
+   */
+  private generateSummary(results: StrategyComparisonResult[]): ComparisonReport['summary'] {
+    if (results.length === 0) {
+      return {
+        bestOverall: '',
+        bestReturn: '',
+        lowestRisk: '',
+        highestSharpe: '',
+        mostConsistent: '',
+      };
+    }
+
+    // Best overall (highest composite score)
+    const sortedByOverall = [...results].sort(
+      (a, b) => this.calculateOverallScore(b) - this.calculateOverallScore(a)
+    );
+
+    // Best return
+    const sortedByReturn = [...results].sort(
+      (a, b) => b.stats.totalReturn - a.stats.totalReturn
+    );
+
+    // Lowest risk (lowest max drawdown)
+    const sortedByRisk = [...results].sort(
+      (a, b) => a.stats.maxDrawdown - b.stats.maxDrawdown
+    );
+
+    // Highest Sharpe
+    const sortedBySharpe = [...results].sort(
+      (a, b) => b.riskMetrics.sharpeRatio - a.riskMetrics.sharpeRatio
+    );
+
+    // Most consistent (highest win rate with decent trades)
+    const sortedByConsistency = [...results]
+      .filter(r => r.stats.totalTrades >= 10)
+      .sort((a, b) => b.stats.winRate - a.stats.winRate);
+
+    return {
+      bestOverall: sortedByOverall[0]?.strategyName || '',
+      bestReturn: sortedByReturn[0]?.strategyName || '',
+      lowestRisk: sortedByRisk[0]?.strategyName || '',
+      highestSharpe: sortedBySharpe[0]?.strategyName || '',
+      mostConsistent: sortedByConsistency[0]?.strategyName || '',
+    };
+  }
+
+  /**
+   * Generate comparison table data
+   */
+  generateComparisonTable(results: StrategyComparisonResult[]): {
+    headers: string[];
+    rows: string[][];
+  } {
+    const headers = [
+      '策略名称',
+      '总回报率',
+      '年化回报',
+      '夏普比率',
+      '最大回撤',
+      '总交易数',
+      '胜率',
+      '盈亏比',
+      '恢复因子',
+    ];
+
+    const rows = results.map(r => [
+      r.strategyName,
+      `${r.stats.totalReturn.toFixed(2)}%`,
+      `${r.stats.annualizedReturn.toFixed(2)}%`,
+      r.riskMetrics.sharpeRatio.toFixed(2),
+      `${r.stats.maxDrawdown.toFixed(2)}%`,
+      r.stats.totalTrades.toString(),
+      `${r.stats.winRate.toFixed(1)}%`,
+      r.stats.profitFactor.toFixed(2),
+      r.drawdownAnalysis.recoveryFactor.toFixed(2),
+    ]);
+
+    return { headers, rows };
+  }
+
+  /**
+   * Generate pairwise comparison
+   */
+  generatePairwiseComparison(
+    result1: StrategyComparisonResult,
+    result2: StrategyComparisonResult
+  ): {
+    metric: string;
+    strategy1: { name: string; value: number };
+    strategy2: { name: string; value: number };
+    winner: string;
+    difference: number;
+  }[] {
+    const metrics = [
+      { name: '总回报率', key1: 'totalReturn', key2: 'totalReturn', higherIsBetter: true },
+      { name: '夏普比率', key1: 'sharpeRatio', key2: 'sharpeRatio', higherIsBetter: true },
+      { name: '最大回撤', key1: 'maxDrawdown', key2: 'maxDrawdown', higherIsBetter: false },
+      { name: '胜率', key1: 'winRate', key2: 'winRate', higherIsBetter: true },
+      { name: '盈亏比', key1: 'profitFactor', key2: 'profitFactor', higherIsBetter: true },
+    ];
+
+    return metrics.map(m => {
+      const value1 = this.getMetricValue(result1, m.key1);
+      const value2 = this.getMetricValue(result2, m.key2);
+
+      const winner = m.higherIsBetter
+        ? value1 > value2 ? result1.strategyName : result2.strategyName
+        : value1 < value2 ? result1.strategyName : result2.strategyName;
+
+      return {
+        metric: m.name,
+        strategy1: { name: result1.strategyName, value: value1 },
+        strategy2: { name: result2.strategyName, value: value2 },
+        winner,
+        difference: Math.abs(value1 - value2),
+      };
+    });
+  }
+}

--- a/src/backtest-analysis/__tests__/backtest-analysis.test.ts
+++ b/src/backtest-analysis/__tests__/backtest-analysis.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for Backtest Analysis Module
+ *
+ * @module backtest-analysis/__tests__/backtest-analysis.test
+ */
+
+import { BacktestEngine } from '../../backtest/BacktestEngine';
+import { BacktestConfig } from '../../backtest/types';
+import {
+  BacktestAnalyzer,
+  StrategyComparator,
+  ReportGenerator,
+} from '../index';
+import {
+  DeepAnalysisReport,
+  StrategyComparisonOptions,
+  ReportExportOptions,
+} from '../types';
+
+// Mock pdfmake before any imports that use it
+jest.mock('pdfmake', () => {
+  return jest.fn().mockImplementation(() => ({
+    createPdfKitDocument: jest.fn().mockReturnValue({
+      on: jest.fn((event: string, callback: any) => {
+        if (event === 'end') {
+          setTimeout(() => callback(), 10);
+        }
+      }),
+      end: jest.fn(),
+    }),
+  }));
+});
+
+// Also mock createPdf export
+jest.mock('pdfmake', () => {
+  const mockCreatePdf = jest.fn().mockReturnValue({
+    getBuffer: jest.fn((callback: (buffer: Buffer) => void) => {
+      callback(Buffer.from('mock-pdf-content'));
+    }),
+  });
+  
+  return {
+    __esModule: true,
+    default: mockCreatePdf,
+    createPdf: mockCreatePdf,
+  };
+});
+
+describe('BacktestAnalyzer', () => {
+  let backtestResult: any;
+  let analyzer: BacktestAnalyzer;
+
+  beforeAll(() => {
+    // Create a simple backtest config
+    const config: BacktestConfig = {
+      capital: 10000,
+      symbol: 'BTC/USDT',
+      startTime: Date.now() - 30 * 24 * 60 * 60 * 1000, // 30 days ago
+      endTime: Date.now(),
+      strategy: 'sma',
+      strategyParams: {
+        shortPeriod: 5,
+        longPeriod: 20,
+        tradeQuantity: 1,
+      },
+      tickInterval: 60000, // 1 minute
+    };
+
+    // Run backtest
+    const engine = new BacktestEngine(config);
+    backtestResult = engine.run();
+    analyzer = new BacktestAnalyzer(backtestResult);
+  });
+
+  describe('generateReport', () => {
+    let report: DeepAnalysisReport;
+
+    beforeAll(() => {
+      report = analyzer.generateReport();
+    });
+
+    it('should generate a complete deep analysis report', () => {
+      expect(report).toBeDefined();
+      expect(report.generatedAt).toBeGreaterThan(0);
+      expect(report.config).toBeDefined();
+      expect(report.basicStats).toBeDefined();
+      expect(report.riskMetrics).toBeDefined();
+      expect(report.equityCurve).toBeDefined();
+      expect(report.drawdownAnalysis).toBeDefined();
+      expect(report.performanceScorecard).toBeDefined();
+    });
+
+    it('should have correct config information', () => {
+      expect(report.config.symbol).toBe('BTC/USDT');
+      expect(report.config.strategy).toBe('sma');
+      expect(report.config.initialCapital).toBe(10000);
+    });
+
+    it('should calculate basic stats correctly', () => {
+      expect(report.basicStats.initialCapital).toBe(10000);
+      expect(report.basicStats.finalCapital).toBeGreaterThanOrEqual(0);
+      expect(typeof report.basicStats.totalReturn).toBe('number');
+      expect(typeof report.basicStats.winRate).toBe('number');
+    });
+
+    it('should calculate risk metrics', () => {
+      expect(typeof report.riskMetrics.sharpeRatio).toBe('number');
+      expect(typeof report.riskMetrics.sortinoRatio).toBe('number');
+      expect(typeof report.riskMetrics.calmarRatio).toBe('number');
+      expect(typeof report.riskMetrics.volatility).toBe('number');
+      expect(typeof report.riskMetrics.maxConsecutiveLosses).toBe('number');
+    });
+
+    it('should generate equity curve with correct structure', () => {
+      expect(Array.isArray(report.equityCurve)).toBe(true);
+      if (report.equityCurve.length > 0) {
+        const point = report.equityCurve[0];
+        expect(point.timestamp).toBeDefined();
+        expect(point.value).toBeDefined();
+        expect(point.drawdown).toBeDefined();
+        expect(point.cumulativeReturn).toBeDefined();
+      }
+    });
+
+    it('should analyze drawdowns', () => {
+      expect(report.drawdownAnalysis.maxDrawdown).toBeGreaterThanOrEqual(0);
+      expect(report.drawdownAnalysis.recoveryFactor).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(report.drawdownAnalysis.drawdownPeriods)).toBe(true);
+    });
+
+    it('should calculate performance scorecard', () => {
+      expect(report.performanceScorecard.overallScore).toBeGreaterThanOrEqual(0);
+      expect(report.performanceScorecard.overallScore).toBeLessThanOrEqual(100);
+      expect(report.performanceScorecard.profitabilityScore).toBeGreaterThanOrEqual(0);
+      expect(report.performanceScorecard.riskScore).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(report.performanceScorecard.breakdown)).toBe(true);
+    });
+
+    it('should generate recommendations', () => {
+      expect(Array.isArray(report.recommendations)).toBe(true);
+      expect(report.recommendations.length).toBeGreaterThan(0);
+      report.recommendations.forEach(rec => {
+        expect(typeof rec).toBe('string');
+        expect(rec.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should analyze monthly performance', () => {
+      expect(Array.isArray(report.monthlyPerformance)).toBe(true);
+    });
+
+    it('should analyze trade distribution', () => {
+      expect(report.tradeDistribution).toBeDefined();
+      expect(Array.isArray(report.tradeDistribution.byHour)).toBe(true);
+      expect(report.tradeDistribution.byHour.length).toBe(24);
+      expect(Array.isArray(report.tradeDistribution.byDayOfWeek)).toBe(true);
+      expect(report.tradeDistribution.byDayOfWeek.length).toBe(7);
+    });
+  });
+
+  describe('trade analysis', () => {
+    it('should analyze individual trades', () => {
+      const report = analyzer.generateReport();
+      expect(Array.isArray(report.tradeAnalysis)).toBe(true);
+    });
+  });
+
+  describe('position analysis', () => {
+    it('should analyze positions by symbol', () => {
+      const report = analyzer.generateReport();
+      expect(Array.isArray(report.positionAnalysis)).toBe(true);
+    });
+  });
+});
+
+describe('StrategyComparator', () => {
+  let comparator: StrategyComparator;
+  let comparisonOptions: StrategyComparisonOptions;
+
+  beforeAll(() => {
+    comparator = new StrategyComparator();
+    comparisonOptions = {
+      strategies: [
+        { name: 'SMA-5-20', type: 'sma', params: { shortPeriod: 5, longPeriod: 20, tradeQuantity: 1 } },
+        { name: 'SMA-10-30', type: 'sma', params: { shortPeriod: 10, longPeriod: 30, tradeQuantity: 1 } },
+      ],
+      backtestConfig: {
+        capital: 10000,
+        symbol: 'BTC/USDT',
+        startTime: Date.now() - 7 * 24 * 60 * 60 * 1000, // 7 days ago
+        endTime: Date.now(),
+        tickInterval: 60000,
+      },
+    };
+  });
+
+  describe('compare', () => {
+    let comparison: any;
+
+    beforeAll(async () => {
+      comparison = await comparator.compare(comparisonOptions);
+    });
+
+    it('should compare multiple strategies', () => {
+      expect(comparison).toBeDefined();
+      expect(comparison.generatedAt).toBeGreaterThan(0);
+      expect(comparison.results).toBeDefined();
+      expect(comparison.results.length).toBe(2);
+    });
+
+    it('should have results for each strategy', () => {
+      comparison.results.forEach((result: any) => {
+        expect(result.strategyName).toBeDefined();
+        expect(result.stats).toBeDefined();
+        expect(result.riskMetrics).toBeDefined();
+        expect(result.tradeSummary).toBeDefined();
+        expect(result.drawdownAnalysis).toBeDefined();
+        expect(result.returnAnalysis).toBeDefined();
+      });
+    });
+
+    it('should generate rankings', () => {
+      expect(Array.isArray(comparison.rankings)).toBe(true);
+      expect(comparison.rankings.length).toBeGreaterThan(0);
+      
+      comparison.rankings.forEach((ranking: any) => {
+        expect(ranking.metric).toBeDefined();
+        expect(Array.isArray(ranking.rankings)).toBe(true);
+        ranking.rankings.forEach((r: any) => {
+          expect(r.strategyName).toBeDefined();
+          expect(typeof r.value).toBe('number');
+          expect(typeof r.rank).toBe('number');
+        });
+      });
+    });
+
+    it('should generate summary with best strategies', () => {
+      expect(comparison.summary).toBeDefined();
+      expect(comparison.summary.bestOverall).toBeDefined();
+      expect(comparison.summary.bestReturn).toBeDefined();
+      expect(comparison.summary.lowestRisk).toBeDefined();
+      expect(comparison.summary.highestSharpe).toBeDefined();
+    });
+
+    it('should generate comparison charts data', () => {
+      expect(comparison.comparisonCharts).toBeDefined();
+      expect(Array.isArray(comparison.comparisonCharts.equityCurves)).toBe(true);
+      expect(Array.isArray(comparison.comparisonCharts.drawdownComparison)).toBe(true);
+    });
+  });
+
+  describe('generateComparisonTable', () => {
+    it('should generate comparison table', async () => {
+      const comparison = await comparator.compare(comparisonOptions);
+      const table = comparator.generateComparisonTable(comparison.results);
+
+      expect(table.headers).toBeDefined();
+      expect(table.rows).toBeDefined();
+      expect(table.headers.length).toBeGreaterThan(0);
+      expect(table.rows.length).toBe(comparison.results.length);
+    });
+  });
+});
+
+describe('ReportGenerator', () => {
+  let report: DeepAnalysisReport;
+  let generator: ReportGenerator;
+
+  beforeAll(() => {
+    // Create a simple backtest and analysis
+    const config: BacktestConfig = {
+      capital: 10000,
+      symbol: 'BTC/USDT',
+      startTime: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      endTime: Date.now(),
+      strategy: 'sma',
+      tickInterval: 60000,
+    };
+
+    const engine = new BacktestEngine(config);
+    const backtestResult = engine.run();
+    const analyzer = new BacktestAnalyzer(backtestResult);
+    report = analyzer.generateReport();
+    generator = new ReportGenerator();
+  });
+
+  describe('generate JSON report', () => {
+    it('should generate JSON format report', async () => {
+      const options: ReportExportOptions = {
+        format: 'json',
+        includeEquityCurve: true,
+        includeTradeList: true,
+      };
+
+      const result = await generator.generate(report, options);
+
+      expect(result.content).toBeDefined();
+      expect(result.contentType).toBe('application/json');
+      expect(result.filename).toContain('.json');
+
+      // Verify JSON is valid
+      const parsed = JSON.parse(result.content as string);
+      expect(parsed.generatedAt).toBe(report.generatedAt);
+    });
+  });
+
+  describe('generate PDF report', () => {
+    it('should generate PDF format report', async () => {
+      const options: ReportExportOptions = {
+        format: 'pdf',
+        includeEquityCurve: true,
+        includeMonthlyBreakdown: true,
+        includeRecommendations: true,
+      };
+
+      const result = await generator.generate(report, options);
+
+      expect(result.content).toBeDefined();
+      expect(result.contentType).toBe('application/pdf');
+      expect(result.filename).toContain('.pdf');
+      expect(result.content).toBeInstanceOf(Buffer);
+    });
+  });
+
+  describe('generate Excel report', () => {
+    it('should generate CSV format report', async () => {
+      const options: ReportExportOptions = {
+        format: 'excel',
+        includeEquityCurve: true,
+        includeMonthlyBreakdown: true,
+      };
+
+      const result = await generator.generate(report, options);
+
+      expect(result.content).toBeDefined();
+      expect(result.contentType).toBe('text/csv');
+      expect(result.filename).toContain('.csv');
+    });
+  });
+
+  describe('report with custom title', () => {
+    it('should include custom title in filename', async () => {
+      const options: ReportExportOptions = {
+        format: 'json',
+        title: 'Custom Backtest Report',
+      };
+
+      const result = await generator.generate(report, options);
+      expect(result.filename).toContain('Custom_Backtest_Report');
+    });
+  });
+});
+
+describe('Integration Tests', () => {
+  it('should run complete analysis workflow', async () => {
+    // Setup
+    const config: BacktestConfig = {
+      capital: 10000,
+      symbol: 'BTC/USDT',
+      startTime: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      endTime: Date.now(),
+      strategy: 'sma',
+      tickInterval: 60000,
+    };
+
+    // Run backtest
+    const engine = new BacktestEngine(config);
+    const backtestResult = engine.run();
+    expect(backtestResult).toBeDefined();
+
+    // Analyze
+    const analyzer = new BacktestAnalyzer(backtestResult);
+    const report = analyzer.generateReport();
+    expect(report).toBeDefined();
+
+    // Export
+    const generator = new ReportGenerator();
+    const exportResult = await generator.generate(report, { format: 'json' });
+    expect(exportResult.content).toBeDefined();
+
+    // Verify
+    const parsed = JSON.parse(exportResult.content as string);
+    expect(parsed.config.symbol).toBe('BTC/USDT');
+  });
+
+  it('should run strategy comparison workflow', async () => {
+    const comparator = new StrategyComparator();
+    
+    const options: StrategyComparisonOptions = {
+      strategies: [
+        { name: 'SMA-Fast', type: 'sma', params: { shortPeriod: 5, longPeriod: 15 } },
+        { name: 'SMA-Slow', type: 'sma', params: { shortPeriod: 15, longPeriod: 30 } },
+      ],
+      backtestConfig: {
+        capital: 10000,
+        symbol: 'BTC/USDT',
+        startTime: Date.now() - 7 * 24 * 60 * 60 * 1000,
+        endTime: Date.now(),
+        tickInterval: 60000,
+      },
+    };
+
+    const comparison = await comparator.compare(options);
+    expect(comparison.results.length).toBe(2);
+    expect(comparison.summary.bestOverall).toBeDefined();
+
+    // Export comparison
+    const generator = new ReportGenerator();
+    const exportResult = await generator.generateComparisonReport(comparison, { format: 'json' });
+    expect(exportResult.content).toBeDefined();
+  });
+});

--- a/src/backtest-analysis/index.ts
+++ b/src/backtest-analysis/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Backtest Analysis Module
+ *
+ * @module backtest-analysis
+ * @description Deep analysis and reporting for backtest results
+ */
+
+export { BacktestAnalyzer } from './BacktestAnalyzer';
+export { StrategyComparator } from './StrategyComparator';
+export { ReportGenerator } from './ReportGenerator';
+export * from './types';

--- a/src/backtest-analysis/types.ts
+++ b/src/backtest-analysis/types.ts
@@ -1,0 +1,485 @@
+/**
+ * Deep Backtest Analysis Types
+ *
+ * @module backtest-analysis/types
+ * @description Type definitions for comprehensive backtest analysis and reporting
+ */
+
+import { BacktestResult, BacktestStats } from '../backtest/types';
+import { PortfolioSnapshot } from '../portfolio/types';
+
+/**
+ * Extended trade analysis
+ */
+export interface TradeAnalysis {
+  /** Trade ID */
+  id: string;
+  /** Entry timestamp */
+  entryTime: number;
+  /** Exit timestamp */
+  exitTime: number;
+  /** Trade direction */
+  side: 'long' | 'short';
+  /** Entry price */
+  entryPrice: number;
+  /** Exit price */
+  exitPrice: number;
+  /** Position size */
+  quantity: number;
+  /** Profit/Loss */
+  pnl: number;
+  /** P&L percentage */
+  pnlPercent: number;
+  /** Trade duration in milliseconds */
+  duration: number;
+  /** Maximum favorable excursion */
+  mfe: number;
+  /** Maximum adverse excursion */
+  mae: number;
+  /** Risk-reward ratio achieved */
+  riskRewardRatio: number;
+  /** Holding period return */
+  holdingReturn: number;
+  /** Whether trade was profitable */
+  isWinner: boolean;
+  /** Exit reason */
+  exitReason?: 'signal' | 'stop_loss' | 'take_profit' | 'end_of_period';
+}
+
+/**
+ * Equity curve point
+ */
+export interface EquityCurvePoint {
+  /** Timestamp */
+  timestamp: number;
+  /** Portfolio value */
+  value: number;
+  /** Cash value */
+  cash: number;
+  /** Position value */
+  positionValue: number;
+  /** Drawdown at this point */
+  drawdown: number;
+  /** Drawdown percentage */
+  drawdownPercent: number;
+  /** Daily return */
+  dailyReturn?: number;
+  /** Cumulative return */
+  cumulativeReturn: number;
+}
+
+/**
+ * Drawdown analysis
+ */
+export interface DrawdownAnalysis {
+  /** Maximum drawdown percentage */
+  maxDrawdown: number;
+  /** Maximum drawdown duration in milliseconds */
+  maxDrawdownDuration: number;
+  /** Average drawdown */
+  avgDrawdown: number;
+  /** Drawdown periods */
+  drawdownPeriods: DrawdownPeriod[];
+  /** Recovery factor (total return / max drawdown) */
+  recoveryFactor: number;
+  /** Time underwater percentage */
+  timeUnderwater: number;
+}
+
+/**
+ * Individual drawdown period
+ */
+export interface DrawdownPeriod {
+  /** Start timestamp */
+  startTimestamp: number;
+  /** Trough timestamp */
+  troughTimestamp: number;
+  /** End timestamp (null if not recovered) */
+  endTimestamp: number | null;
+  /** Peak value before drawdown */
+  peakValue: number;
+  /** Trough value */
+  troughValue: number;
+  /** Drawdown percentage */
+  drawdownPercent: number;
+  /** Duration in milliseconds */
+  duration: number;
+  /** Recovery duration in milliseconds (null if not recovered) */
+  recoveryDuration: number | null;
+}
+
+/**
+ * Position analysis
+ */
+export interface PositionAnalysis {
+  /** Symbol */
+  symbol: string;
+  /** Total trades for this symbol */
+  totalTrades: number;
+  /** Winning trades */
+  winningTrades: number;
+  /** Losing trades */
+  losingTrades: number;
+  /** Win rate */
+  winRate: number;
+  /** Total P&L */
+  totalPnL: number;
+  /** Average P&L per trade */
+  avgPnL: number;
+  /** Maximum position size held */
+  maxPositionSize: number;
+  /** Average position size */
+  avgPositionSize: number;
+  /** Long trades count */
+  longTrades: number;
+  /** Short trades count */
+  shortTrades: number;
+  /** Long win rate */
+  longWinRate: number;
+  /** Short win rate */
+  shortWinRate: number;
+}
+
+/**
+ * Monthly performance breakdown
+ */
+export interface MonthlyPerformance {
+  /** Year */
+  year: number;
+  /** Month (1-12) */
+  month: number;
+  /** Monthly return percentage */
+  returnPercent: number;
+  /** Number of trades */
+  trades: number;
+  /** Win rate */
+  winRate: number;
+  /** Maximum drawdown in month */
+  maxDrawdown: number;
+  /** Total P&L */
+  totalPnL: number;
+  /** Starting capital */
+  startCapital: number;
+  /** Ending capital */
+  endCapital: number;
+}
+
+/**
+ * Risk metrics
+ */
+export interface RiskMetrics {
+  /** Sharpe ratio */
+  sharpeRatio: number;
+  /** Sortino ratio (downside risk adjusted) */
+  sortinoRatio: number;
+  /** Calmar ratio (annual return / max drawdown) */
+  calmarRatio: number;
+  /** Volatility (annualized standard deviation) */
+  volatility: number;
+  /** Downside deviation */
+  downsideDeviation: number;
+  /** Value at Risk (95%) */
+  var95: number;
+  /** Conditional VaR (Expected Shortfall) */
+  cvar95: number;
+  /** Beta (if benchmark provided) */
+  beta?: number;
+  /** Alpha (if benchmark provided) */
+  alpha?: number;
+  /** Information ratio (if benchmark provided) */
+  informationRatio?: number;
+  /** Maximum consecutive losses */
+  maxConsecutiveLosses: number;
+  /** Maximum consecutive wins */
+  maxConsecutiveWins: number;
+  /** Average leverage used */
+  avgLeverage: number;
+  /** Maximum leverage used */
+  maxLeverage: number;
+}
+
+/**
+ * Trade distribution statistics
+ */
+export interface TradeDistribution {
+  /** Trade count by hour of day */
+  byHour: number[];
+  /** Trade count by day of week (0=Sunday) */
+  byDayOfWeek: number[];
+  /** Trade count by month */
+  byMonth: number[];
+  /** Trade count by size buckets */
+  bySize: SizeBucket[];
+  /** Trade count by duration buckets */
+  byDuration: DurationBucket[];
+  /** Trade count by P&L buckets */
+  byPnL: PnLBucket[];
+}
+
+/**
+ * Size bucket for distribution
+ */
+export interface SizeBucket {
+  /** Size range label */
+  label: string;
+  /** Minimum size */
+  min: number;
+  /** Maximum size */
+  max: number;
+  /** Count of trades */
+  count: number;
+  /** Win rate in this bucket */
+  winRate: number;
+  /** Average P&L */
+  avgPnL: number;
+}
+
+/**
+ * Duration bucket for distribution
+ */
+export interface DurationBucket {
+  /** Duration range label */
+  label: string;
+  /** Minimum duration in ms */
+  minMs: number;
+  /** Maximum duration in ms */
+  maxMs: number;
+  /** Count of trades */
+  count: number;
+  /** Win rate in this bucket */
+  winRate: number;
+  /** Average P&L */
+  avgPnL: number;
+}
+
+/**
+ * P&L bucket for distribution
+ */
+export interface PnLBucket {
+  /** P&L range label */
+  label: string;
+  /** Minimum P&L */
+  min: number;
+  /** Maximum P&L */
+  max: number;
+  /** Count of trades */
+  count: number;
+}
+
+/**
+ * Strategy comparison result
+ */
+export interface StrategyComparisonResult {
+  /** Strategy name */
+  strategyName: string;
+  /** Strategy parameters */
+  parameters: Record<string, any>;
+  /** Basic stats */
+  stats: BacktestStats;
+  /** Risk metrics */
+  riskMetrics: RiskMetrics;
+  /** Trade analysis summary */
+  tradeSummary: {
+    totalTrades: number;
+    winners: number;
+    losers: number;
+    avgWin: number;
+    avgLoss: number;
+    profitFactor: number;
+    expectancy: number;
+  };
+  /** Drawdown analysis */
+  drawdownAnalysis: {
+    maxDrawdown: number;
+    maxDrawdownDuration: number;
+    recoveryFactor: number;
+  };
+  /** Return analysis */
+  returnAnalysis: {
+    totalReturn: number;
+    annualizedReturn: number;
+    monthlyReturns: MonthlyPerformance[];
+  };
+  /** Execution metrics */
+  executionMetrics: {
+    duration: number;
+    tradesPerSecond: number;
+  };
+}
+
+/**
+ * Comparison ranking
+ */
+export interface ComparisonRanking {
+  /** Metric name */
+  metric: string;
+  /** Rankings by strategy */
+  rankings: {
+    strategyName: string;
+    value: number;
+    rank: number;
+  }[];
+}
+
+/**
+ * Complete deep analysis report
+ */
+export interface DeepAnalysisReport {
+  /** Report generation timestamp */
+  generatedAt: number;
+  /** Backtest configuration */
+  config: {
+    symbol: string;
+    strategy: string;
+    strategyParams?: Record<string, any>;
+    initialCapital: number;
+    startTime: number;
+    endTime: number;
+    duration: number;
+  };
+  /** Basic statistics */
+  basicStats: BacktestStats;
+  /** Risk metrics */
+  riskMetrics: RiskMetrics;
+  /** Extended trade analysis */
+  tradeAnalysis: TradeAnalysis[];
+  /** Equity curve */
+  equityCurve: EquityCurvePoint[];
+  /** Drawdown analysis */
+  drawdownAnalysis: DrawdownAnalysis;
+  /** Position analysis */
+  positionAnalysis: PositionAnalysis[];
+  /** Monthly performance */
+  monthlyPerformance: MonthlyPerformance[];
+  /** Trade distribution */
+  tradeDistribution: TradeDistribution;
+  /** Performance scorecard */
+  performanceScorecard: PerformanceScorecard;
+  /** Recommendations */
+  recommendations: string[];
+}
+
+/**
+ * Performance scorecard
+ */
+export interface PerformanceScorecard {
+  /** Overall score (0-100) */
+  overallScore: number;
+  /** Profitability score */
+  profitabilityScore: number;
+  /** Risk management score */
+  riskScore: number;
+  /** Consistency score */
+  consistencyScore: number;
+  /** Efficiency score */
+  efficiencyScore: number;
+  /** Score breakdown */
+  breakdown: {
+    category: string;
+    score: number;
+    weight: number;
+    description: string;
+  }[];
+}
+
+/**
+ * Report export options
+ */
+export interface ReportExportOptions {
+  /** Export format */
+  format: 'pdf' | 'excel' | 'json';
+  /** Include equity curve chart data */
+  includeEquityCurve?: boolean;
+  /** Include trade list */
+  includeTradeList?: boolean;
+  /** Include monthly breakdown */
+  includeMonthlyBreakdown?: boolean;
+  /** Include trade distribution */
+  includeDistribution?: boolean;
+  /** Include recommendations */
+  includeRecommendations?: boolean;
+  /** Custom report title */
+  title?: string;
+  /** Locale for formatting */
+  locale?: string;
+}
+
+/**
+ * Strategy comparison options
+ */
+export interface StrategyComparisonOptions {
+  /** Strategies to compare */
+  strategies: {
+    name: string;
+    type: string;
+    params?: Record<string, any>;
+  }[];
+  /** Common backtest configuration */
+  backtestConfig: {
+    capital: number;
+    symbol: string;
+    startTime: number;
+    endTime: number;
+    tickInterval?: number;
+  };
+  /** Comparison metrics to include */
+  metrics?: string[];
+}
+
+/**
+ * Comparison report
+ */
+export interface ComparisonReport {
+  /** Report generation timestamp */
+  generatedAt: number;
+  /** Comparison configuration */
+  config: StrategyComparisonOptions;
+  /** Results per strategy */
+  results: StrategyComparisonResult[];
+  /** Rankings */
+  rankings: ComparisonRanking[];
+  /** Summary */
+  summary: {
+    bestOverall: string;
+    bestReturn: string;
+    lowestRisk: string;
+    highestSharpe: string;
+    mostConsistent: string;
+  };
+  /** Visual comparison data */
+  comparisonCharts: {
+    equityCurves: { strategyName: string; data: EquityCurvePoint[] }[];
+    drawdownComparison: { strategyName: string; maxDrawdown: number }[];
+    returnDistribution: { strategyName: string; returns: number[] }[];
+  };
+}
+
+/**
+ * Signal analysis for backtest
+ */
+export interface SignalAnalysis {
+  /** Total signals generated */
+  totalSignals: number;
+  /** Signals by type */
+  signalsByType: {
+    type: string;
+    count: number;
+    winRate: number;
+    avgPnL: number;
+  }[];
+  /** Signal timing analysis */
+  timingAnalysis: {
+    optimalHours: number[];
+    optimalDays: number[];
+    worstHours: number[];
+    worstDays: number[];
+  };
+  /** Signal quality metrics */
+  qualityMetrics: {
+    precision: number;
+    recall: number;
+    f1Score: number;
+  };
+}
+
+export type { BacktestResult, BacktestStats, PortfolioSnapshot };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,28 @@ export * from './portfolio';
 export * from './strategy';
 export * from './backtest';
 
+// Backtest Analysis Module
+export {
+  BacktestAnalyzer,
+  StrategyComparator,
+  ReportGenerator,
+} from './backtest-analysis';
+export type {
+  DeepAnalysisReport,
+  StrategyComparisonOptions,
+  StrategyComparisonResult,
+  ComparisonReport,
+  EquityCurvePoint,
+  TradeAnalysis,
+  MonthlyPerformance,
+  RiskMetrics,
+  PerformanceScorecard,
+  DrawdownAnalysis,
+  PositionAnalysis,
+  TradeDistribution,
+  ReportExportOptions,
+} from './backtest-analysis';
+
 // Risk Alerting Module
 export {
   RiskCalculator,
@@ -24,7 +46,7 @@ export type {
   RiskAlertStatus,
   NotificationChannels,
   RiskAlertRule,
-  RiskMetrics,
+  RiskMetrics as RiskAlertMetrics,
   RiskAlert,
   PositionData,
   PortfolioData,


### PR DESCRIPTION
## 概述
实现 Issue #387 - 深度回测分析报告

## 功能特性

### 详细分析指标
- ✅ 胜率、盈亏比、最大回撤、夏普比率等核心指标
- ✅ 索提诺比率、卡尔马比率等风险调整指标
- ✅ VaR (95%) 和 CVaR 风险指标
- ✅ 最大连续盈亏次数统计

### 可视化数据
- ✅ 资金曲线（含回撤和累计回报）
- ✅ 月度表现分解
- ✅ 持仓分布分析
- ✅ 交易分布（按时间、数量、持续时间）

### 导出功能
- ✅ PDF 格式报告
- ✅ Excel/CSV 格式
- ✅ JSON 格式

### 策略对比功能
- ✅ 多策略同时对比
- ✅ 综合评分排名
- ✅ 各指标排名
- ✅ 对比报告导出

## API 端点

| 方法 | 端点 | 描述 |
|------|------|------|
| POST | /api/backtest-analysis/analyze | 运行深度分析 |
| POST | /api/backtest-analysis/compare | 策略对比 |
| POST | /api/backtest-analysis/export | 导出报告 |
| POST | /api/backtest-analysis/export-comparison | 导出对比报告 |
| GET | /api/backtest-analysis/metrics | 获取可用指标列表 |
| GET | /api/backtest-analysis/export-formats | 获取导出格式列表 |

## 测试覆盖
- ✅ 24 个测试用例全部通过
- ✅ 涵盖分析器、对比器、报告生成器
- ✅ 集成测试验证完整工作流

## 文件变更
- 新增 `src/backtest-analysis/` 模块
  - `BacktestAnalyzer.ts` - 核心分析引擎
  - `StrategyComparator.ts` - 策略对比
  - `ReportGenerator.ts` - 报告生成
  - `types.ts` - 类型定义
- 新增 `src/api/backtestAnalysisRoutes.ts` - API 路由
- 更新 `src/index.ts` - 模块导出

Closes #387