### PR TITLE
fix: API docs page blank due to missing YAML parser (Issue #408)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,5755 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "AlphaArena Trading Platform API",
+    "description": "\nComprehensive API for the AlphaArena algorithmic trading platform.\n\n## Authentication\nMost API endpoints require authentication. Use one of the following methods:\n- **API Key**: Include `X-API-Key` header with your API key\n- **JWT Token**: Include `Authorization: Bearer <token>` header\n\n## Rate Limits\nRate limits are based on API key permissions:\n- **read**: 60 requests/minute, 10,000 requests/day\n- **trade**: 120 requests/minute, 20,000 requests/day\n- **admin**: 300 requests/minute, 50,000 requests/day\n\nRate limit headers are included in every response:\n- `X-RateLimit-Limit-Minute`: Maximum requests per minute\n- `X-RateLimit-Remaining-Minute`: Remaining requests this minute\n- `X-RateLimit-Limit-Day`: Maximum requests per day\n- `X-RateLimit-Remaining-Day`: Remaining requests today\n\n## Error Handling\nAll errors follow a consistent format:\n```json\n{\n  \"success\": false,\n  \"error\": \"Error message\",\n  \"code\": \"ERROR_CODE\"\n}\n```\n      ",
+    "version": "1.0.0",
+    "contact": {
+      "name": "AlphaArena Support",
+      "email": "support@alphaarena.io"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "/api",
+      "description": "Current server (relative path)"
+    },
+    {
+      "url": "https://alphaarena-production.up.railway.app/api",
+      "description": "Production server"
+    },
+    {
+      "url": "http://localhost:3001/api",
+      "description": "Development server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Health",
+      "description": "System health and status endpoints"
+    },
+    {
+      "name": "Authentication",
+      "description": "User authentication and authorization"
+    },
+    {
+      "name": "Public API",
+      "description": "Public API for third-party developers (API Key authentication)"
+    },
+    {
+      "name": "Strategies",
+      "description": "Trading strategy management"
+    },
+    {
+      "name": "Trades",
+      "description": "Trade history and execution"
+    },
+    {
+      "name": "Orders",
+      "description": "Order management"
+    },
+    {
+      "name": "Conditional Orders",
+      "description": "Stop-loss, take-profit, and OCO orders"
+    },
+    {
+      "name": "Portfolios",
+      "description": "Portfolio management"
+    },
+    {
+      "name": "Market Data",
+      "description": "Market ticker and price data"
+    },
+    {
+      "name": "Orderbook",
+      "description": "Order book data"
+    },
+    {
+      "name": "Leaderboard",
+      "description": "Strategy performance rankings"
+    },
+    {
+      "name": "Backtest",
+      "description": "Strategy backtesting"
+    },
+    {
+      "name": "Bot Management",
+      "description": "Trading bot configuration"
+    },
+    {
+      "name": "Bot Control",
+      "description": "Trading bot execution control"
+    },
+    {
+      "name": "Webhooks",
+      "description": "Webhook configuration"
+    },
+    {
+      "name": "API Keys",
+      "description": "API key management"
+    },
+    {
+      "name": "Templates",
+      "description": "Strategy templates marketplace"
+    },
+    {
+      "name": "Copy Trading",
+      "description": "Copy trading features"
+    },
+    {
+      "name": "Notifications",
+      "description": "User notifications"
+    },
+    {
+      "name": "Export",
+      "description": "Data export functionality"
+    },
+    {
+      "name": "AI",
+      "description": "AI-powered features"
+    },
+    {
+      "name": "Subscriptions",
+      "description": "Subscription management"
+    },
+    {
+      "name": "User Dashboard",
+      "description": "User dashboard and profile"
+    },
+    {
+      "name": "Schedules",
+      "description": "Scheduled tasks management"
+    },
+    {
+      "name": "Alerts",
+      "description": "Alert management"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API Key for authentication (format: aa_live_xxx or aa_test_xxx)"
+      },
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT token obtained from login/register"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        }
+      },
+      "Success": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "data": {
+            "type": "object"
+          }
+        }
+      },
+      "Strategy": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SMA",
+              "RSI",
+              "MACD",
+              "Bollinger",
+              "custom"
+            ]
+          },
+          "params": {
+            "type": "object"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "stopped"
+            ]
+          },
+          "capital": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Trade": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "strategyId": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "price": {
+            "type": "number"
+          },
+          "total": {
+            "type": "number"
+          },
+          "fee": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Portfolio": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "strategyId": {
+            "type": "string"
+          },
+          "totalValue": {
+            "type": "number"
+          },
+          "cashBalance": {
+            "type": "number"
+          },
+          "positions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "averagePrice": {
+                  "type": "number"
+                },
+                "currentValue": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "realizedPnL": {
+            "type": "number"
+          },
+          "unrealizedPnL": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "strategyId": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit",
+              "stop_market",
+              "stop_limit"
+            ]
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "price": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "filled",
+              "partially_filled",
+              "cancelled"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Ticker": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "priceChange24h": {
+            "type": "number"
+          },
+          "priceChangePercent24h": {
+            "type": "number"
+          },
+          "high24h": {
+            "type": "number"
+          },
+          "low24h": {
+            "type": "number"
+          },
+          "volume24h": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "integer"
+          }
+        }
+      },
+      "OrderBook": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "bids": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "description": "[price, quantity] pairs"
+          },
+          "asks": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "description": "[price, quantity] pairs"
+          },
+          "timestamp": {
+            "type": "integer"
+          }
+        }
+      },
+      "LeaderboardEntry": {
+        "type": "object",
+        "properties": {
+          "rank": {
+            "type": "integer"
+          },
+          "strategyId": {
+            "type": "string"
+          },
+          "strategyName": {
+            "type": "string"
+          },
+          "totalReturn": {
+            "type": "number"
+          },
+          "winRate": {
+            "type": "number"
+          },
+          "profitFactor": {
+            "type": "number"
+          },
+          "sharpeRatio": {
+            "type": "number"
+          },
+          "maxDrawdown": {
+            "type": "number"
+          },
+          "tradeCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "BotConfig": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "strategy",
+          "tradingPair",
+          "interval",
+          "mode",
+          "initialCapital"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique bot identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "Bot name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Bot description"
+          },
+          "strategy": {
+            "type": "string",
+            "enum": [
+              "SMA",
+              "RSI",
+              "MACD",
+              "Bollinger",
+              "Stochastic",
+              "ATR"
+            ],
+            "description": "Trading strategy type"
+          },
+          "tradingPair": {
+            "type": "object",
+            "properties": {
+              "base": {
+                "type": "string",
+                "example": "BTC"
+              },
+              "quote": {
+                "type": "string",
+                "example": "USDT"
+              },
+              "symbol": {
+                "type": "string",
+                "example": "BTCUSDT"
+              }
+            }
+          },
+          "interval": {
+            "type": "string",
+            "enum": [
+              "1m",
+              "5m",
+              "15m",
+              "1h",
+              "4h",
+              "1d"
+            ],
+            "description": "Time interval for strategy execution"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "paper",
+              "live"
+            ],
+            "description": "Trading mode"
+          },
+          "initialCapital": {
+            "type": "number",
+            "description": "Initial capital allocation"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether bot is enabled"
+          }
+        }
+      },
+      "BotState": {
+        "type": "object",
+        "properties": {
+          "botId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "stopped",
+              "running",
+              "paused",
+              "error"
+            ]
+          },
+          "portfolioValue": {
+            "type": "number"
+          },
+          "initialCapital": {
+            "type": "number"
+          },
+          "realizedPnL": {
+            "type": "number"
+          },
+          "unrealizedPnL": {
+            "type": "number"
+          },
+          "totalPnL": {
+            "type": "number"
+          },
+          "tradeCount": {
+            "type": "integer"
+          },
+          "winCount": {
+            "type": "integer"
+          },
+          "lossCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "username": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Notification": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "trade",
+              "signal",
+              "alert",
+              "error",
+              "system"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          },
+          "read": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    },
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "description": "Check if the API server is running",
+        "operationId": "healthCheck",
+        "tags": [
+          "Health"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Server is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "timestamp": {
+                      "type": "integer",
+                      "example": 1710844800000
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/status": {
+      "get": {
+        "summary": "Detailed health status",
+        "description": "Get detailed system health status including database, realtime, and order book status",
+        "operationId": "healthStatus",
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "System status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "healthy",
+                        "degraded",
+                        "unhealthy"
+                      ]
+                    },
+                    "uptime": {
+                      "type": "number",
+                      "description": "Server uptime in seconds"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "checks": {
+                      "type": "object",
+                      "properties": {
+                        "database": {
+                          "type": "boolean"
+                        },
+                        "realtime": {
+                          "type": "boolean"
+                        },
+                        "orderbooks": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "System metrics",
+        "description": "Get system performance metrics including memory, CPU, and request statistics",
+        "operationId": "getMetrics",
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "memory": {
+                      "type": "object",
+                      "properties": {
+                        "used": {
+                          "type": "integer"
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "percentage": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "cpu": {
+                      "type": "object",
+                      "properties": {
+                        "usage": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "requests": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "perMinute": {
+                          "type": "number"
+                        },
+                        "avgResponseTime": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/errors": {
+      "get": {
+        "summary": "Recent errors",
+        "description": "Get recent system errors for debugging",
+        "operationId": "getErrors",
+        "tags": [
+          "Health"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            },
+            "description": "Maximum number of errors to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Error list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string"
+                          },
+                          "severity": {
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high",
+                              "critical"
+                            ]
+                          },
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "bySeverity": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api": {
+      "get": {
+        "summary": "API information",
+        "description": "Get API version and available endpoints",
+        "operationId": "getApiInfo",
+        "tags": [
+          "Health"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "API information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "example": "AlphaArena API"
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "1.0.0"
+                    },
+                    "endpoints": {
+                      "type": "object",
+                      "properties": {
+                        "strategies": {
+                          "type": "string"
+                        },
+                        "trades": {
+                          "type": "string"
+                        },
+                        "portfolios": {
+                          "type": "string"
+                        },
+                        "stats": {
+                          "type": "string"
+                        },
+                        "leaderboard": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "realtime": {
+                      "type": "string",
+                      "example": "Supabase Realtime"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/strategies": {
+      "get": {
+        "summary": "List all strategies",
+        "description": "Retrieve a list of all trading strategies",
+        "operationId": "listStrategies",
+        "tags": [
+          "Strategies"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Strategy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/strategies/{id}": {
+      "get": {
+        "summary": "Get strategy details",
+        "description": "Retrieve details for a specific strategy",
+        "operationId": "getStrategy",
+        "tags": [
+          "Strategies"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Strategy ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Strategy"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Strategy not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/trades": {
+      "get": {
+        "summary": "List all trades",
+        "description": "Retrieve a list of all trades with optional filtering",
+        "operationId": "listTrades",
+        "tags": [
+          "Trades"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by strategy ID"
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by trading symbol"
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "buy",
+                "sell"
+              ]
+            },
+            "description": "Filter by trade side"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Trade"
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/trades/export": {
+      "get": {
+        "summary": "Export trades",
+        "description": "Export trades to CSV format",
+        "operationId": "exportTrades",
+        "tags": [
+          "Trades"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "buy",
+                "sell"
+              ]
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exported trades file",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/portfolios": {
+      "get": {
+        "summary": "List portfolios",
+        "description": "Retrieve all portfolios",
+        "operationId": "listPortfolios",
+        "tags": [
+          "Portfolios"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Portfolio"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/portfolios/history": {
+      "get": {
+        "summary": "Get portfolio history",
+        "description": "Retrieve portfolio value history over time",
+        "operationId": "getPortfolioHistory",
+        "tags": [
+          "Portfolios"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeRange",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1d",
+                "1w",
+                "1m",
+                "all"
+              ],
+              "default": "1w"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "value": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing strategyId parameter"
+          }
+        }
+      }
+    },
+    "/api/stats": {
+      "get": {
+        "summary": "Get system statistics",
+        "description": "Retrieve aggregate statistics about strategies, trades, and volumes",
+        "operationId": "getStats",
+        "tags": [
+          "Strategies"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "totalStrategies": {
+                          "type": "integer"
+                        },
+                        "activeStrategies": {
+                          "type": "integer"
+                        },
+                        "totalTrades": {
+                          "type": "integer"
+                        },
+                        "totalVolume": {
+                          "type": "number"
+                        },
+                        "buyTrades": {
+                          "type": "integer"
+                        },
+                        "sellTrades": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leaderboard": {
+      "get": {
+        "summary": "Get leaderboard",
+        "description": "Retrieve the strategy leaderboard with rankings",
+        "operationId": "getLeaderboard",
+        "tags": [
+          "Leaderboard"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "roi",
+                "winRate",
+                "profitFactor",
+                "sharpeRatio"
+              ],
+              "default": "roi"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/LeaderboardEntry"
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leaderboard/{strategyId}": {
+      "get": {
+        "summary": "Get strategy rank",
+        "description": "Get ranking information for a specific strategy",
+        "operationId": "getStrategyRank",
+        "tags": [
+          "Leaderboard"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/LeaderboardEntry"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Strategy not found in leaderboard"
+          }
+        }
+      }
+    },
+    "/api/leaderboard/refresh": {
+      "post": {
+        "summary": "Refresh leaderboard",
+        "description": "Trigger a leaderboard recalculation",
+        "operationId": "refreshLeaderboard",
+        "tags": [
+          "Leaderboard"
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard refreshed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/LeaderboardEntry"
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/orders": {
+      "get": {
+        "summary": "List orders",
+        "description": "Retrieve all orders with optional filtering",
+        "operationId": "listOrders",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "filled",
+                "cancelled"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Order"
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new order",
+        "description": "Submit a new order",
+        "operationId": "createOrder",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "side",
+                  "type",
+                  "quantity"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string",
+                    "example": "BTCUSDT"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "buy",
+                      "sell"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "market",
+                      "limit"
+                    ]
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Required for limit orders"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Order created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Order"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/api/orders/{orderId}/cancel": {
+      "post": {
+        "summary": "Cancel an order",
+        "description": "Cancel an open order",
+        "operationId": "cancelOrder",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order cancelled successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Order"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Only pending orders can be cancelled"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/api/conditional-orders": {
+      "get": {
+        "summary": "List conditional orders",
+        "description": "Retrieve all conditional orders (stop-loss, take-profit)",
+        "operationId": "listConditionalOrders",
+        "tags": [
+          "Conditional Orders"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "triggered",
+                "cancelled"
+              ]
+            }
+          },
+          {
+            "name": "orderType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "stop_loss",
+                "take_profit"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "side": {
+                            "type": "string",
+                            "enum": [
+                              "buy",
+                              "sell"
+                            ]
+                          },
+                          "orderType": {
+                            "type": "string",
+                            "enum": [
+                              "stop_loss",
+                              "take_profit"
+                            ]
+                          },
+                          "triggerPrice": {
+                            "type": "number"
+                          },
+                          "quantity": {
+                            "type": "number"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "triggered",
+                              "cancelled"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create conditional order",
+        "description": "Create a new conditional order (stop-loss, take-profit)",
+        "operationId": "createConditionalOrder",
+        "tags": [
+          "Conditional Orders"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "side",
+                  "orderType",
+                  "triggerPrice",
+                  "quantity"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "buy",
+                      "sell"
+                    ]
+                  },
+                  "orderType": {
+                    "type": "string",
+                    "enum": [
+                      "stop_loss",
+                      "take_profit"
+                    ]
+                  },
+                  "triggerPrice": {
+                    "type": "number"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Conditional order created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "symbol": {
+                          "type": "string"
+                        },
+                        "orderType": {
+                          "type": "string"
+                        },
+                        "triggerPrice": {
+                          "type": "number"
+                        },
+                        "quantity": {
+                          "type": "number"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/api/conditional-orders/{orderId}/cancel": {
+      "post": {
+        "summary": "Cancel conditional order",
+        "description": "Cancel an active conditional order",
+        "operationId": "cancelConditionalOrder",
+        "tags": [
+          "Conditional Orders"
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conditional order cancelled successfully"
+          },
+          "400": {
+            "description": "Only active conditional orders can be cancelled"
+          },
+          "404": {
+            "description": "Conditional order not found"
+          }
+        }
+      }
+    },
+    "/api/conditional-orders/stats": {
+      "get": {
+        "summary": "Get conditional order statistics",
+        "description": "Retrieve statistics about conditional orders",
+        "operationId": "getConditionalOrderStats",
+        "tags": [
+          "Conditional Orders"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "active": {
+                          "type": "integer"
+                        },
+                        "triggered": {
+                          "type": "integer"
+                        },
+                        "cancelled": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/market/tickers": {
+      "get": {
+        "summary": "Get all market tickers",
+        "description": "Retrieve ticker data for all trading pairs",
+        "operationId": "getAllTickers",
+        "tags": [
+          "Market Data"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Ticker"
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/market/tickers/{symbol}": {
+      "get": {
+        "summary": "Get ticker for symbol",
+        "description": "Retrieve ticker data for a specific trading pair",
+        "operationId": "getTicker",
+        "tags": [
+          "Market Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTCUSDT"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Ticker"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticker not found for symbol"
+          }
+        }
+      }
+    },
+    "/api/market/kline/{symbol}": {
+      "get": {
+        "summary": "Get K-line (candlestick) data",
+        "description": "Retrieve candlestick/OHLCV data for a trading pair",
+        "operationId": "getKlineData",
+        "tags": [
+          "Market Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTCUSDT"
+          },
+          {
+            "name": "timeframe",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1m",
+                "5m",
+                "15m",
+                "1h",
+                "4h",
+                "1d"
+              ],
+              "default": "1h"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Candle"
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/orderbook/{symbol}": {
+      "get": {
+        "summary": "Get orderbook snapshot",
+        "description": "Retrieve current orderbook (bids and asks) for a trading pair",
+        "operationId": "getOrderbook",
+        "tags": [
+          "Orderbook"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTCUSDT"
+          },
+          {
+            "name": "levels",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of price levels to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/OrderBook"
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order book not found for symbol"
+          }
+        }
+      }
+    },
+    "/api/orderbook/{symbol}/best": {
+      "get": {
+        "summary": "Get best bid/ask prices",
+        "description": "Retrieve the best bid and ask prices for a trading pair",
+        "operationId": "getBestPrices",
+        "tags": [
+          "Orderbook"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTCUSDT"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "bestBid": {
+                          "type": "number"
+                        },
+                        "bestAsk": {
+                          "type": "number"
+                        },
+                        "spread": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "timestamp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order book not found for symbol"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts": {
+      "get": {
+        "summary": "Get all exchange accounts",
+        "description": "Returns all exchange accounts for the authenticated user",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of exchange accounts"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add exchange account",
+        "description": "Add a new exchange account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "exchange",
+                  "environment",
+                  "apiKey",
+                  "apiSecret"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "exchange": {
+                    "type": "string",
+                    "enum": [
+                      "alpaca",
+                      "binance",
+                      "okx",
+                      "bybit",
+                      "mock"
+                    ]
+                  },
+                  "environment": {
+                    "type": "string",
+                    "enum": [
+                      "live",
+                      "paper",
+                      "testnet"
+                    ]
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "apiSecret": {
+                    "type": "string"
+                  },
+                  "apiPassphrase": {
+                    "type": "string"
+                  },
+                  "isPrimary": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account created"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/primary": {
+      "get": {
+        "summary": "Get primary account",
+        "description": "Returns the user's primary exchange account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Primary account"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/unified": {
+      "get": {
+        "summary": "Get unified account summary",
+        "description": "Returns a unified view of all accounts with aggregated balances and positions",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unified account summary"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/{accountId}": {
+      "get": {
+        "summary": "Get account by ID",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account details"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "apiSecret": {
+                    "type": "string"
+                  },
+                  "isPrimary": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account updated"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account deleted"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/{accountId}/set-primary": {
+      "post": {
+        "summary": "Set as primary account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Primary account set"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/{accountId}/switch": {
+      "post": {
+        "summary": "Switch to account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account switched"
+          }
+        }
+      }
+    },
+    "/api/exchange-accounts/{accountId}/sync": {
+      "post": {
+        "summary": "Sync account",
+        "tags": [
+          "Exchange Accounts"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "accountId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account synced"
+          }
+        }
+      }
+    },
+    "/api/account-groups": {
+      "get": {
+        "summary": "Get all account groups",
+        "tags": [
+          "Account Groups"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of account groups"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create account group",
+        "tags": [
+          "Account Groups"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "accountIds"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "accountIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "strategyAllocation": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Account group created"
+          }
+        }
+      }
+    },
+    "/api/account-groups/{groupId}": {
+      "get": {
+        "summary": "Get account group by ID",
+        "tags": [
+          "Account Groups"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "groupId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account group details"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update account group",
+        "tags": [
+          "Account Groups"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "groupId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "accountIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "strategyAllocation": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account group updated"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete account group",
+        "tags": [
+          "Account Groups"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "groupId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account group deleted"
+          }
+        }
+      }
+    },
+    "/public/v1": {
+      "get": {
+        "summary": "Get public API information",
+        "description": "Returns information about the public API including version and available endpoints",
+        "operationId": "getPublicApiInfo",
+        "tags": [
+          "Public API"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string",
+                          "example": "1.0.0"
+                        },
+                        "endpoints": {
+                          "type": "object",
+                          "properties": {
+                            "strategies": {
+                              "type": "string",
+                              "example": "/public/v1/strategies"
+                            },
+                            "backtest": {
+                              "type": "string",
+                              "example": "/public/v1/backtest"
+                            },
+                            "account": {
+                              "type": "string",
+                              "example": "/public/v1/account"
+                            },
+                            "market": {
+                              "type": "string",
+                              "example": "/public/v1/market"
+                            }
+                          }
+                        },
+                        "rateLimits": {
+                          "type": "object",
+                          "properties": {
+                            "remaining": {
+                              "type": "integer"
+                            },
+                            "resetAt": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/strategies": {
+      "get": {
+        "summary": "List all strategies",
+        "description": "Retrieve a list of all trading strategies for the authenticated user",
+        "operationId": "publicListStrategies",
+        "tags": [
+          "Strategies"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "paused",
+                "stopped"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of strategies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Strategy"
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new strategy",
+        "description": "Create a new trading strategy",
+        "operationId": "publicCreateStrategy",
+        "tags": [
+          "Strategies"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "symbol"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Strategy name"
+                  },
+                  "symbol": {
+                    "type": "string",
+                    "description": "Trading symbol (e.g., BTC/USDT)"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Strategy description"
+                  },
+                  "config": {
+                    "type": "object",
+                    "description": "Strategy configuration parameters"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Strategy created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Strategy"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/strategies/{id}": {
+      "get": {
+        "summary": "Get strategy details",
+        "description": "Retrieve detailed information about a specific strategy",
+        "operationId": "publicGetStrategy",
+        "tags": [
+          "Strategies"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Strategy ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Strategy details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Strategy"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Strategy not found"
+          }
+        }
+      }
+    },
+    "/public/v1/strategies/{id}/status": {
+      "put": {
+        "summary": "Update strategy status",
+        "description": "Update the status of a trading strategy (start, pause, stop)",
+        "operationId": "publicUpdateStrategyStatus",
+        "tags": [
+          "Strategies"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused",
+                      "stopped"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status updated"
+          },
+          "404": {
+            "description": "Strategy not found"
+          }
+        }
+      }
+    },
+    "/public/v1/backtest/run": {
+      "post": {
+        "summary": "Run a backtest",
+        "description": "Execute a backtest with the specified configuration",
+        "operationId": "publicRunBacktest",
+        "tags": [
+          "Backtest"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "strategy",
+                  "capital",
+                  "startTime",
+                  "endTime"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string",
+                    "description": "Trading symbol (e.g., BTC/USDT)"
+                  },
+                  "strategy": {
+                    "type": "string",
+                    "enum": [
+                      "sma",
+                      "rsi",
+                      "macd",
+                      "bollinger",
+                      "atr"
+                    ],
+                    "description": "Strategy type"
+                  },
+                  "capital": {
+                    "type": "number",
+                    "description": "Initial capital"
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "params": {
+                    "type": "object",
+                    "description": "Strategy-specific parameters"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Backtest result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "stats": {
+                          "type": "object",
+                          "properties": {
+                            "totalReturn": {
+                              "type": "number"
+                            },
+                            "winRate": {
+                              "type": "number"
+                            },
+                            "profitFactor": {
+                              "type": "number"
+                            },
+                            "maxDrawdown": {
+                              "type": "number"
+                            },
+                            "sharpeRatio": {
+                              "type": "number"
+                            }
+                          }
+                        },
+                        "trades": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/backtest/strategies": {
+      "get": {
+        "summary": "List available backtest strategies",
+        "description": "Get a list of all available strategies for backtesting",
+        "operationId": "publicListBacktestStrategies",
+        "tags": [
+          "Backtest"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of strategies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/backtest/symbols": {
+      "get": {
+        "summary": "List available symbols",
+        "description": "Get a list of all available trading symbols for backtesting",
+        "operationId": "publicListBacktestSymbols",
+        "tags": [
+          "Backtest"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of symbols",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "category": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/account": {
+      "get": {
+        "summary": "Get account information",
+        "description": "Retrieve the virtual trading account information for the authenticated user",
+        "operationId": "publicGetAccount",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "balance": {
+                          "type": "number"
+                        },
+                        "initial_capital": {
+                          "type": "number"
+                        },
+                        "frozen_balance": {
+                          "type": "number"
+                        },
+                        "total_realized_pnl": {
+                          "type": "number"
+                        },
+                        "total_trades": {
+                          "type": "integer"
+                        },
+                        "winning_trades": {
+                          "type": "integer"
+                        },
+                        "losing_trades": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found"
+          }
+        }
+      }
+    },
+    "/public/v1/account/positions": {
+      "get": {
+        "summary": "List account positions",
+        "description": "Retrieve all positions for the authenticated user's account",
+        "operationId": "publicListPositions",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of positions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "number"
+                          },
+                          "average_cost": {
+                            "type": "number"
+                          },
+                          "current_price": {
+                            "type": "number"
+                          },
+                          "market_value": {
+                            "type": "number"
+                          },
+                          "unrealized_pnl": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/v1/account/orders": {
+      "get": {
+        "summary": "List account orders",
+        "description": "Retrieve all orders for the authenticated user's account",
+        "operationId": "publicListOrders",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "open",
+                "partial",
+                "filled",
+                "cancelled",
+                "rejected"
+              ]
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of orders"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an order",
+        "description": "Submit a new trading order",
+        "operationId": "publicCreateOrder",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "side",
+                  "order_type",
+                  "quantity"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string",
+                    "description": "Trading symbol"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "buy",
+                      "sell"
+                    ]
+                  },
+                  "order_type": {
+                    "type": "string",
+                    "enum": [
+                      "market",
+                      "limit",
+                      "stop_market",
+                      "stop_limit"
+                    ]
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Required for limit and stop_limit orders"
+                  },
+                  "stop_price": {
+                    "type": "number",
+                    "description": "Required for stop_market and stop_limit orders"
+                  },
+                  "time_in_force": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ],
+                    "default": "GTC"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Order created"
+          }
+        }
+      }
+    },
+    "/public/v1/account/orders/{orderId}/cancel": {
+      "post": {
+        "summary": "Cancel an order",
+        "description": "Cancel an open order",
+        "operationId": "publicCancelOrder",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order cancelled"
+          },
+          "400": {
+            "description": "Order cannot be cancelled"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/public/v1/account/trades": {
+      "get": {
+        "summary": "List account trades",
+        "description": "Retrieve trade history for the authenticated user's account",
+        "operationId": "publicListTrades",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "buy",
+                "sell"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of trades"
+          }
+        }
+      }
+    },
+    "/public/v1/leaderboard": {
+      "get": {
+        "summary": "Get leaderboard",
+        "description": "Retrieve the strategy performance leaderboard",
+        "operationId": "publicGetLeaderboard",
+        "tags": [
+          "Leaderboard"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "roi",
+                "winRate",
+                "profitFactor",
+                "sharpeRatio"
+              ],
+              "default": "roi"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard data"
+          }
+        }
+      }
+    },
+    "/recommendations": {
+      "get": {
+        "summary": "Get personalized strategy recommendations",
+        "description": "Returns AI-powered strategy recommendations based on user history, preferences, and collaborative filtering",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of recommended strategies with match scores and reasons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "strategy": {
+                            "$ref": "#/components/schemas/MarketplaceStrategy"
+                          },
+                          "score": {
+                            "type": "number",
+                            "description": "Match score (0-100)"
+                          },
+                          "reasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "algorithm": {
+                            "type": "string",
+                            "enum": [
+                              "collaborative",
+                              "content_based",
+                              "hybrid",
+                              "trending"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recommendations/{recommendationId}/dismiss": {
+      "post": {
+        "summary": "Dismiss a recommendation",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "recommendationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation dismissed"
+          }
+        }
+      }
+    },
+    "/recommendations/{recommendationId}/click": {
+      "post": {
+        "summary": "Mark recommendation as clicked",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "recommendationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation marked as clicked"
+          }
+        }
+      }
+    },
+    "/recommendations/explain/{strategyId}": {
+      "get": {
+        "summary": "Get explanation for why a strategy is recommended",
+        "tags": [
+          "Recommendations"
+        ],
+        "parameters": [
+          {
+            "name": "strategyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recommendation explanation with score breakdown"
+          }
+        }
+      }
+    },
+    "/recommendations/feedback": {
+      "post": {
+        "summary": "Record user feedback on a strategy",
+        "description": "Submit like/dislike feedback to improve future recommendations",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategyId",
+                  "feedbackType"
+                ],
+                "properties": {
+                  "strategyId": {
+                    "type": "string"
+                  },
+                  "feedbackType": {
+                    "type": "string",
+                    "enum": [
+                      "like",
+                      "dislike",
+                      "not_interested"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string",
+                    "description": "Optional reason for feedback"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded successfully"
+          }
+        }
+      }
+    },
+    "/recommendations/interactions": {
+      "post": {
+        "summary": "Record user interaction with a strategy",
+        "description": "Automatically track user interactions to improve recommendations",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategyId",
+                  "interactionType"
+                ],
+                "properties": {
+                  "strategyId": {
+                    "type": "string"
+                  },
+                  "interactionType": {
+                    "type": "string",
+                    "enum": [
+                      "view",
+                      "subscribe",
+                      "review",
+                      "signal_follow"
+                    ]
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional additional data"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Interaction recorded"
+          }
+        }
+      }
+    },
+    "/recommendations/profile": {
+      "get": {
+        "summary": "Get user's recommendation profile",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile with preferences"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update user's recommendation profile",
+        "description": "Set preferences to improve recommendation quality",
+        "tags": [
+          "Recommendations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "riskTolerance": {
+                    "type": "string",
+                    "enum": [
+                      "conservative",
+                      "moderate",
+                      "aggressive",
+                      "very_aggressive"
+                    ]
+                  },
+                  "capitalScale": {
+                    "type": "string",
+                    "enum": [
+                      "small",
+                      "medium",
+                      "large",
+                      "institutional"
+                    ]
+                  },
+                  "preferredCategories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "preferredStrategyTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "preferredSymbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Profile updated"
+          }
+        }
+      }
+    },
+    "/recommendations/stats": {
+      "get": {
+        "summary": "Get recommendation system statistics",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "System statistics"
+          }
+        }
+      }
+    },
+    "/recommendations/cleanup": {
+      "post": {
+        "summary": "Clear expired recommendations (admin)",
+        "tags": [
+          "Recommendations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of expired recommendations cleared"
+          }
+        }
+      }
+    },
+    "/marketplace/strategies": {
+      "get": {
+        "summary": "List strategies in the marketplace",
+        "tags": [
+          "Marketplace"
+        ],
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "strategyType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "minRating",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "isFeatured",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created_at",
+                "rating_avg",
+                "subscriber_count",
+                "view_count",
+                "name"
+              ]
+            }
+          },
+          {
+            "name": "orderDirection",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of strategies"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/featured": {
+      "get": {
+        "summary": "Get featured strategies",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/top-rated": {
+      "get": {
+        "summary": "Get top rated strategies",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/categories": {
+      "get": {
+        "summary": "Get available categories",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/tags": {
+      "get": {
+        "summary": "Get popular tags",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/{id}": {
+      "get": {
+        "summary": "Get strategy by ID",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "put": {
+        "summary": "Update a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/{id}/publish": {
+      "post": {
+        "summary": "Publish a strategy to the marketplace",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/subscriptions": {
+      "post": {
+        "summary": "Subscribe to a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "get": {
+        "summary": "Get user's subscriptions",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/subscriptions/{id}": {
+      "get": {
+        "summary": "Get subscription by ID",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "delete": {
+        "summary": "Cancel a subscription",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/subscriptions/{id}/pause": {
+      "post": {
+        "summary": "Pause a subscription",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/subscriptions/{id}/resume": {
+      "post": {
+        "summary": "Resume a subscription",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/{strategyId}/reviews": {
+      "get": {
+        "summary": "Get reviews for a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "post": {
+        "summary": "Create a review for a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/reviews/{reviewId}": {
+      "put": {
+        "summary": "Update a review",
+        "tags": [
+          "Marketplace"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a review",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/strategies/{strategyId}/signals": {
+      "get": {
+        "summary": "Get signals for a strategy",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/signals": {
+      "post": {
+        "summary": "Publish a new signal",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/signals/my": {
+      "get": {
+        "summary": "Get active signals for user's subscribed strategies",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/signals/{signalId}/execute": {
+      "post": {
+        "summary": "Mark a signal as executed for a subscription",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/publishers/{publisherId}/stats": {
+      "get": {
+        "summary": "Get publisher stats",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/publishers/top": {
+      "get": {
+        "summary": "Get top publishers",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/marketplace/publishers/me/strategies": {
+      "get": {
+        "summary": "Get current user's published strategies",
+        "tags": [
+          "Marketplace"
+        ]
+      }
+    },
+    "/api/strategy-portfolios": {
+      "post": {
+        "summary": "Create a new strategy portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "totalCapital",
+                  "strategies"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "totalCapital": {
+                    "type": "number"
+                  },
+                  "allocationMethod": {
+                    "type": "string",
+                    "enum": [
+                      "equal",
+                      "custom",
+                      "risk_parity"
+                    ]
+                  },
+                  "rebalanceConfig": {
+                    "type": "object"
+                  },
+                  "strategies": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "strategyId": {
+                          "type": "string"
+                        },
+                        "weight": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Portfolio created successfully"
+          }
+        }
+      },
+      "get": {
+        "summary": "Get all portfolios for the user",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "paused",
+                "stopped"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of portfolios"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}": {
+      "get": {
+        "summary": "Get portfolio by ID",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio details"
+          },
+          "404": {
+            "description": "Portfolio not found"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "totalCapital": {
+                    "type": "number"
+                  },
+                  "allocationMethod": {
+                    "type": "string"
+                  },
+                  "rebalanceConfig": {
+                    "type": "object"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Portfolio updated successfully"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Portfolio deleted successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/start": {
+      "post": {
+        "summary": "Start portfolio (activate all strategies)",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio started successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/stop": {
+      "post": {
+        "summary": "Stop portfolio (stop all strategies)",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio stopped successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/pause": {
+      "post": {
+        "summary": "Pause portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio paused successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/strategies": {
+      "post": {
+        "summary": "Add strategy to portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "strategyId"
+                ],
+                "properties": {
+                  "strategyId": {
+                    "type": "string"
+                  },
+                  "weight": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Strategy added successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/strategies/{strategyId}": {
+      "delete": {
+        "summary": "Remove strategy from portfolio",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "strategyId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Strategy removed successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/strategies/{strategyId}/weight": {
+      "put": {
+        "summary": "Update strategy weight",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "strategyId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "weight"
+                ],
+                "properties": {
+                  "weight": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Weight updated successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/rebalance/preview": {
+      "get": {
+        "summary": "Preview portfolio rebalance",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rebalance preview"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/rebalance": {
+      "post": {
+        "summary": "Execute portfolio rebalance",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "enum": [
+                      "threshold",
+                      "scheduled",
+                      "manual",
+                      "strategy_change"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rebalance executed successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/rebalance/history": {
+      "get": {
+        "summary": "Get rebalance history",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rebalance history"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/performance": {
+      "get": {
+        "summary": "Get portfolio performance",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio performance metrics"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/performance/history": {
+      "get": {
+        "summary": "Get performance history",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "snapshotType",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "minute",
+                "hourly",
+                "daily",
+                "weekly"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Performance history"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/performance/snapshot": {
+      "post": {
+        "summary": "Create performance snapshot",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "snapshotType": {
+                    "type": "string",
+                    "enum": [
+                      "minute",
+                      "hourly",
+                      "daily",
+                      "weekly"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Snapshot created successfully"
+          }
+        }
+      }
+    },
+    "/api/strategy-portfolios/{id}/risk": {
+      "get": {
+        "summary": "Get portfolio risk analysis",
+        "tags": [
+          "StrategyPortfolio"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Risk metrics"
+          }
+        }
+      }
+    },
+    "/api/account": {
+      "get": {
+        "summary": "Get account summary",
+        "description": "Returns the user's virtual account with positions, balance, and P&L",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/AccountSummary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/account/reset": {
+      "post": {
+        "summary": "Reset account",
+        "description": "Reset account to initial state, clearing all positions and orders",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newCapital": {
+                    "type": "number",
+                    "description": "Optional new initial capital amount"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account reset successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/account/history": {
+      "get": {
+        "summary": "Get account history",
+        "description": "Returns the account's value history for charting",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "snapshotType",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "minute",
+                "hourly",
+                "daily",
+                "weekly"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account history"
+          }
+        }
+      }
+    },
+    "/api/account/positions": {
+      "get": {
+        "summary": "Get all positions",
+        "description": "Returns all positions for the user's account",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of positions"
+          }
+        }
+      }
+    },
+    "/api/account/positions/{symbol}": {
+      "get": {
+        "summary": "Get position by symbol",
+        "description": "Returns the position for a specific symbol",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "symbol",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Position details"
+          },
+          "404": {
+            "description": "Position not found"
+          }
+        }
+      }
+    },
+    "/api/account/orders": {
+      "get": {
+        "summary": "Get orders",
+        "description": "Returns orders for the user's account",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "open",
+                  "partial",
+                  "filled",
+                  "cancelled",
+                  "rejected",
+                  "expired"
+                ]
+              }
+            }
+          },
+          {
+            "in": "query",
+            "name": "symbol",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "side",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "buy",
+                "sell"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of orders"
+          }
+        }
+      }
+    },
+    "/api/account/orders/{orderId}": {
+      "get": {
+        "summary": "Get order by ID",
+        "description": "Returns a specific order",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order details"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/api/account/orders/buy": {
+      "post": {
+        "summary": "Place a buy order",
+        "description": "Place a buy order (market, limit, stop, or stop-limit)",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "quantity",
+                  "orderType"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "orderType": {
+                    "type": "string",
+                    "enum": [
+                      "market",
+                      "limit",
+                      "stop",
+                      "stop_limit"
+                    ]
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Required for limit and stop-limit orders"
+                  },
+                  "stopPrice": {
+                    "type": "number",
+                    "description": "Required for stop and stop-limit orders"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order placed successfully"
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/account/orders/sell": {
+      "post": {
+        "summary": "Place a sell order",
+        "description": "Place a sell order (market, limit, stop, stop-limit, or take-profit)",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "quantity",
+                  "orderType"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "orderType": {
+                    "type": "string",
+                    "enum": [
+                      "market",
+                      "limit",
+                      "stop",
+                      "stop_limit",
+                      "take_profit"
+                    ]
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Required for limit and stop-limit orders"
+                  },
+                  "stopPrice": {
+                    "type": "number",
+                    "description": "Required for stop, stop-limit, and take-profit orders"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order placed successfully"
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/account/orders/{orderId}/cancel": {
+      "post": {
+        "summary": "Cancel an order",
+        "description": "Cancel a pending or open order",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order cancelled successfully"
+          },
+          "400": {
+            "description": "Cannot cancel order"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/api/account/orders/{orderId}/modify": {
+      "put": {
+        "summary": "Modify an order",
+        "description": "Modify price, stop price, or quantity of an open order",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "orderId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "price": {
+                    "type": "number"
+                  },
+                  "stopPrice": {
+                    "type": "number"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order modified successfully"
+          },
+          "400": {
+            "description": "Cannot modify order"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/api/account/orders/stop-loss": {
+      "post": {
+        "summary": "Place a stop-loss order",
+        "description": "Place a stop-loss order that triggers a market order when price reaches stop price",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "side",
+                  "quantity",
+                  "stopPrice"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "buy",
+                      "sell"
+                    ]
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "stopPrice": {
+                    "type": "number"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Stop-loss order placed successfully"
+          }
+        }
+      }
+    },
+    "/api/account/orders/stop-limit": {
+      "post": {
+        "summary": "Place a stop-limit order",
+        "description": "Place a stop-limit order that becomes a limit order when price reaches stop price",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "side",
+                  "quantity",
+                  "stopPrice",
+                  "limitPrice"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "buy",
+                      "sell"
+                    ]
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "stopPrice": {
+                    "type": "number"
+                  },
+                  "limitPrice": {
+                    "type": "number"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Stop-limit order placed successfully"
+          }
+        }
+      }
+    },
+    "/api/account/orders/take-profit": {
+      "post": {
+        "summary": "Place a take-profit order",
+        "description": "Place a take-profit order to sell when price reaches target",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "quantity",
+                  "targetPrice"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "targetPrice": {
+                    "type": "number"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Take-profit order placed successfully"
+          }
+        }
+      }
+    },
+    "/api/account/orders/bracket": {
+      "post": {
+        "summary": "Place a bracket order (OCO)",
+        "description": "Place a bracket order combining stop-loss and take-profit orders",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "symbol",
+                  "quantity",
+                  "stopLossPrice",
+                  "takeProfitPrice"
+                ],
+                "properties": {
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  },
+                  "stopLossPrice": {
+                    "type": "number"
+                  },
+                  "takeProfitPrice": {
+                    "type": "number"
+                  },
+                  "timeInForce": {
+                    "type": "string",
+                    "enum": [
+                      "GTC",
+                      "IOC",
+                      "FOK",
+                      "GTD"
+                    ]
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bracket order placed successfully"
+          }
+        }
+      }
+    },
+    "/api/account/transactions": {
+      "get": {
+        "summary": "Get transaction history",
+        "description": "Returns transaction history for the user's account",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "deposit",
+                "withdraw",
+                "buy",
+                "sell",
+                "dividend",
+                "fee",
+                "adjustment",
+                "reset",
+                "frozen",
+                "unfrozen"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "symbol",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transaction history"
+          }
+        }
+      }
+    },
+    "/api/account/refresh-prices": {
+      "post": {
+        "summary": "Refresh position prices",
+        "description": "Update all position prices with current market data",
+        "tags": [
+          "Virtual Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prices refreshed successfully"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -15,10 +15,15 @@ import * as path from 'path';
 import YAML from 'yamljs';
 import { generateOpenApiSpec } from '../src/api/swaggerConfig';
 
-const outputPaths = [
+const yamlOutputPaths = [
   path.join(__dirname, '../docs/api/openapi.yaml'),
   path.join(__dirname, '../public/openapi.yaml'),
   path.join(__dirname, '../dist/client/openapi.yaml'),
+];
+
+const jsonOutputPaths = [
+  path.join(__dirname, '../docs/api/openapi.json'),
+  path.join(__dirname, '../public/openapi.json'),
 ];
 
 function main() {
@@ -31,7 +36,7 @@ function main() {
     const yamlContent = YAML.stringify(spec, 10, 2);
     
     // Ensure output directories exist
-    const dirs = new Set(outputPaths.map(p => path.dirname(p)));
+    const dirs = new Set([...yamlOutputPaths, ...jsonOutputPaths].map(p => path.dirname(p)));
     dirs.forEach(dir => {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
@@ -39,16 +44,18 @@ function main() {
       }
     });
     
-    // Write to all output paths
-    outputPaths.forEach(outputPath => {
+    // Write YAML to all output paths
+    yamlOutputPaths.forEach(outputPath => {
       fs.writeFileSync(outputPath, yamlContent, 'utf-8');
-      console.log(`✅ Written: ${outputPath}`);
+      console.log(`✅ Written (YAML): ${outputPath}`);
     });
     
-    // Also write JSON version
-    const jsonPath = path.join(__dirname, '../docs/api/openapi.json');
-    fs.writeFileSync(jsonPath, JSON.stringify(spec, null, 2), 'utf-8');
-    console.log(`✅ Written: ${jsonPath}`);
+    // Write JSON to all output paths
+    const jsonContent = JSON.stringify(spec, null, 2);
+    jsonOutputPaths.forEach(outputPath => {
+      fs.writeFileSync(outputPath, jsonContent, 'utf-8');
+      console.log(`✅ Written (JSON): ${outputPath}`);
+    });
     
     console.log('\n🎉 OpenAPI specification generated successfully!');
     console.log(`📊 Total endpoints documented: ${Object.keys(spec.paths || {}).length}`);

--- a/src/client/pages/ApiDocsPage.tsx
+++ b/src/client/pages/ApiDocsPage.tsx
@@ -29,17 +29,38 @@ const ApiDocsPage: React.FC = () => {
   const { isMobile, isTablet } = useMediaQuery();
 
   useEffect(() => {
-    // Fetch the OpenAPI spec - try static file first, then backend API
+    // Fetch the OpenAPI spec - try static JSON first (works in production without backend)
     const loadSpec = async () => {
-      // Try static openapi.yaml first (works in production without backend)
+      // Try static openapi.json first (works in production without backend, no YAML parser needed)
       try {
-        const staticResponse = await fetch('/openapi.yaml');
+        const staticResponse = await fetch('/openapi.json');
         if (staticResponse.ok) {
-          const yamlText = await staticResponse.text();
-          const specData = YAML.parse(yamlText);
+          const specData = await staticResponse.json();
+          console.log('Loaded OpenAPI spec from static JSON');
           setSpec(specData);
           setLoading(false);
           return;
+        }
+      } catch (err) {
+        console.log('Static openapi.json not available, trying YAML...');
+      }
+
+      // Try static openapi.yaml as fallback
+      try {
+        const yamlResponse = await fetch('/openapi.yaml');
+        if (yamlResponse.ok) {
+          const yamlText = await yamlResponse.text();
+          // @ts-ignore
+          if (window.jsyaml) {
+            // @ts-ignore
+            const specData = window.jsyaml.load(yamlText);
+            console.log('Loaded OpenAPI spec from static YAML');
+            setSpec(specData);
+            setLoading(false);
+            return;
+          } else {
+            console.warn('js-yaml not loaded, cannot parse YAML');
+          }
         }
       } catch (err) {
         console.log('Static openapi.yaml not available, trying backend...');
@@ -50,6 +71,7 @@ const ApiDocsPage: React.FC = () => {
         const response = await fetch('/docs/api/openapi.json');
         if (response.ok) {
           const specData = await response.json();
+          console.log('Loaded OpenAPI spec from backend');
           setSpec(specData);
           setLoading(false);
           return;
@@ -70,11 +92,10 @@ const ApiDocsPage: React.FC = () => {
     setError(null);
     
     try {
-      // Try static file first
-      const staticResponse = await fetch('/openapi.yaml');
+      // Try static JSON first
+      const staticResponse = await fetch('/openapi.json');
       if (staticResponse.ok) {
-        const yamlText = await staticResponse.text();
-        const specData = YAML.parse(yamlText);
+        const specData = await staticResponse.json();
         setSpec(specData);
         setLoading(false);
         return;
@@ -331,23 +352,6 @@ const ApiDocsPage: React.FC = () => {
       </div>
     </div>
   );
-};
-
-// Simple YAML parser for fallback
-const YAML = {
-  parse: (yaml: string): object => {
-    try {
-      // @ts-ignore
-      if (window.jsyaml) {
-        // @ts-ignore
-        return window.jsyaml.load(yaml);
-      }
-      return JSON.parse(yaml);
-    } catch {
-      console.warn('YAML parsing failed, returning empty object');
-      return {};
-    }
-  }
 };
 
 export default ApiDocsPage;


### PR DESCRIPTION
## Summary

Fixes #408

### Problem

API Documentation page shows blank content with "正在连接服务器..." status. The previous fix (PR #407) tried to load `/openapi.yaml` but failed because:

1. The code used `window.jsyaml` to parse YAML
2. `js-yaml` library was never installed or loaded
3. When `window.jsyaml` is undefined, it fell back to `JSON.parse(yamlString)` which fails on YAML format
4. After parsing failure, it returned empty object `{}` resulting in blank page

### Solution

1. **Generate JSON format**: Modified `scripts/generate-openapi.ts` to also output `public/openapi.json`
2. **Load JSON first**: `ApiDocsPage.tsx` now prioritizes `/openapi.json` (native `JSON.parse`, no library needed)
3. **Proper fallback chain**: 
   - First: `/openapi.json` (static, works in production)
   - Second: `/openapi.yaml` (only if js-yaml loaded)
   - Third: `/docs/api/openapi.json` (backend endpoint for development)

### Testing

- Build succeeds: `npm run build` completes
- JSON generated: `public/openapi.json` (148KB)
- Also written to `dist/client/openapi.json` for Vercel deployment

### Files Changed

- `scripts/generate-openapi.ts`: Add JSON output to public/ and docs/api/
- `src/client/pages/ApiDocsPage.tsx`: Change loading priority to JSON first
- `public/openapi.json`: New file (generated)