### PR TITLE
fix: API docs page blank due to missing openapi.json in dist (Issue #416)

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -24,6 +24,7 @@ const yamlOutputPaths = [
 const jsonOutputPaths = [
   path.join(__dirname, '../docs/api/openapi.json'),
   path.join(__dirname, '../public/openapi.json'),
+  path.join(__dirname, '../dist/client/openapi.json'), // Also output to dist for Vercel deployment
 ];
 
 function main() {


### PR DESCRIPTION
## Summary

Fixes #416

### Root Cause Analysis

The API documentation page was blank because `openapi.json` was not being deployed to Vercel.

**Build script order:**
```
"build": "tsc && vite build && npm run generate:openapi"
```

**Problem:**
1. `vite build` runs first, copying files from `public/` to `dist/client/`
2. `generate:openapi` runs AFTER, writing `openapi.json` only to `public/`
3. Result: `dist/client/openapi.json` is never created during the build process

### Fix

Added `dist/client/openapi.json` to the output paths in `generate-openapi.ts`, ensuring the file is written directly to the dist folder during build.

### Previous Fix Attempts

| PR | What it did | Why it failed |
|----|------------|---------------|
| #407 | Fixed navigation highlighting, tried to load YAML | `js-yaml` library was not loaded |
| #412 | Generated JSON, prioritized JSON loading | JSON file missing from `dist/client/` |
| **This PR** | Writes JSON directly to `dist/client/` | ✅ |

### Testing

1. Ran `npm run generate:openapi` - confirmed JSON is written to all three locations
2. Verified `dist/client/openapi.json` contains valid OpenAPI spec with 115 endpoints

### How to Verify After Deployment

1. Visit https://alpha-arena-two.vercel.app/docs/api
2. The page should now display the Swagger UI with all API endpoints listed