### PR TITLE
fix: resolve test syntax errors (Issue #435)

### DIFF
--- a/tests/client/OrdersPanel.test.tsx
+++ b/tests/client/OrdersPanel.test.tsx
@@ -191,7 +191,6 @@ describe('OrdersPanel', () => {
   });
 
   it('should handle getOrders failure gracefully', async () => {
-import mockMessage from '@arco-design/web-react';
     api.getOrders.mockRejectedValue(new Error('Network error'));
 
     render(<OrdersPanel />);

--- a/tests/webhook/webhookManager.test.ts
+++ b/tests/webhook/webhookManager.test.ts
@@ -4,6 +4,7 @@
 
 import { WebhookManager } from '../../src/webhook/WebhookManager';
 import { WebhookConfig, WebhookEventType } from '../../src/webhook/types';
+import EventEmitter from 'events';
 
 // Mock WebhookStorage
 jest.mock('../../src/webhook/WebhookStorage', () => {
@@ -79,7 +80,6 @@ jest.mock('../../src/webhook/WebhookStorage', () => {
 
 // Mock WebhookSender
 jest.mock('../../src/webhook/WebhookSender', () => {
-import EventEmitter from 'events';
   return {
     WebhookSender: jest.fn().mockImplementation(() => {
       const emitter = new EventEmitter();


### PR DESCRIPTION
## Summary
修复测试文件中的语法错误，这些错误导致 Jest 无法解析测试文件。

## Changes
- `tests/client/OrdersPanel.test.tsx`: 删除错误放置的 import 语句
- `tests/webhook/webhookManager.test.ts`: 将 EventEmitter import 移到文件顶部

## Test Results
- Before: 37 failed test suites, 136 failed tests
- After: 34 failed test suites, 134 failed tests
- Fixed: 3 test suites, 2 tests

## Related Issue
Fixes part of #435