### PR TITLE
feat(email): integrate SendGrid email service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@arco-design/web-react": "^2.66.11",
+        "@sendgrid/mail": "^8.1.6",
         "@supabase/supabase-js": "^2.99.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
@@ -4014,6 +4015,44 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "dependencies": {
     "@arco-design/web-react": "^2.66.11",
+    "@sendgrid/mail": "^8.1.6",
     "@supabase/supabase-js": "^2.99.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",

--- a/src/notification/EmailProviders.ts
+++ b/src/notification/EmailProviders.ts
@@ -4,6 +4,7 @@
  */
 
 import { createLogger } from '../utils/logger';
+import type { MailDataRequired, ClientResponse } from '@sendgrid/mail';
 
 const log = createLogger('EmailProviders');
 
@@ -121,18 +122,33 @@ export interface SendGridConfig {
 
 /**
  * SendGrid Email Provider
- * Note: Actual implementation requires @sendgrid/mail package
+ * Uses @sendgrid/mail package to send emails via SendGrid API
  */
 export class SendGridProvider implements IEmailProvider {
   readonly name = 'sendgrid';
   private apiKey: string | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any = null;
 
   constructor(config?: SendGridConfig) {
     this.apiKey = config?.apiKey ?? process.env.SENDGRID_API_KEY ?? null;
+    
+    if (this.apiKey) {
+      // Import and configure SendGrid client
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const sgMail = require('@sendgrid/mail');
+        sgMail.setApiKey(this.apiKey);
+        this.client = sgMail;
+        log.info('SendGrid client initialized successfully');
+      } catch (error) {
+        log.error('Failed to initialize SendGrid client', error);
+      }
+    }
   }
 
   get isConfigured(): boolean {
-    return !!this.apiKey;
+    return !!this.apiKey && !!this.client;
   }
 
   async send(message: EmailMessage): Promise<EmailSendResult> {
@@ -144,15 +160,126 @@ export class SendGridProvider implements IEmailProvider {
       };
     }
 
-    // Placeholder for actual SendGrid implementation
-    // To implement: install @sendgrid/mail and use it here
-    log.warn('SendGrid provider not fully implemented - falling back to mock');
-    
-    return {
-      success: false,
-      provider: 'sendgrid',
-      error: 'SendGrid integration not implemented. Install @sendgrid/mail and implement the send method.',
-    };
+    if (!this.client) {
+      return {
+        success: false,
+        provider: 'sendgrid',
+        error: 'SendGrid client not initialized',
+      };
+    }
+
+    try {
+      // Build SendGrid email data
+      const toList = Array.isArray(message.to) ? message.to : [message.to];
+      const toEmails = toList.map(a => (a.name ? `${a.name} <${a.email}>` : a.email));
+      
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const emailData: any = {
+        to: toEmails,
+        from: message.from 
+          ? (message.from.name ? `${message.from.name} <${message.from.email}>` : message.from.email)
+          : 'noreply@alphaarena.com',
+        subject: message.subject,
+      };
+
+      // Add content
+      if (message.text) {
+        emailData.text = message.text;
+      }
+      if (message.html) {
+        emailData.html = message.html;
+      }
+
+      // Add CC/BCC if provided
+      if (message.cc && message.cc.length > 0) {
+        emailData.cc = message.cc.map(a => (a.name ? `${a.name} <${a.email}>` : a.email));
+      }
+      if (message.bcc && message.bcc.length > 0) {
+        emailData.bcc = message.bcc.map(a => (a.name ? `${a.name} <${a.email}>` : a.email));
+      }
+
+      // Add reply-to if provided
+      if (message.replyTo) {
+        emailData.replyTo = message.replyTo.name 
+          ? `${message.replyTo.name} <${message.replyTo.email}>`
+          : message.replyTo.email;
+      }
+
+      // Add attachments if provided
+      if (message.attachments && message.attachments.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        emailData.attachments = message.attachments.map(att => ({
+          filename: att.filename,
+          content: att.content instanceof Buffer 
+            ? att.content.toString('base64') 
+            : att.content,
+          type: att.contentType,
+          contentId: att.contentId,
+        })) as any;
+      }
+
+      // Add custom headers if provided
+      if (message.headers) {
+        emailData.headers = message.headers;
+      }
+
+      // Add tags as custom arguments if provided
+      if (message.tags) {
+        emailData.customArgs = message.tags;
+      }
+
+      log.debug('Sending email via SendGrid', {
+        to: toEmails,
+        subject: message.subject,
+        hasHtml: !!message.html,
+        hasAttachments: !!(message.attachments?.length),
+      });
+
+      // Send the email
+      const [response] = await this.client.send(emailData) as [ClientResponse, object];
+
+      const messageId = response.headers?.['x-message-id'] as string | undefined;
+      
+      log.info('Email sent successfully via SendGrid', {
+        to: toEmails,
+        subject: message.subject,
+        messageId,
+        statusCode: response.statusCode,
+      });
+
+      return {
+        success: true,
+        messageId,
+        provider: 'sendgrid',
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorDetails: Record<string, unknown> = {
+        error: errorMessage,
+      };
+
+      // Extract SendGrid error details if available
+      if (error && typeof error === 'object' && 'response' in error) {
+        const sgError = error as { response?: { body?: { errors?: Array<{ message: string }> } } };
+        if (sgError.response?.body?.errors) {
+          errorDetails.sendGridErrors = sgError.response.body.errors.map(e => e.message).join('; ');
+        }
+      }
+
+      log.error('Failed to send email via SendGrid', error, {
+        to: Array.isArray(message.to) 
+          ? message.to.map(a => a.email).join(', ') 
+          : message.to.email,
+        subject: message.subject,
+        ...errorDetails,
+      });
+
+      return {
+        success: false,
+        provider: 'sendgrid',
+        error: errorMessage,
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Install `@sendgrid/mail` package for SendGrid API integration
- Implement `SendGridProvider.send()` method with full email support
- Support for CC, BCC, reply-to, attachments, headers, and tags
- Add proper error handling with detailed SendGrid error extraction
- Add comprehensive logging for debugging and monitoring

## Changes
- Added `@sendgrid/mail` dependency
- Updated `SendGridProvider` class with actual SendGrid API integration
- Support for all email fields (to, from, cc, bcc, reply-to, attachments, headers, tags)
- Mock mode available in development when `SENDGRID_API_KEY` is not set

## Environment Variables
- `SENDGRID_API_KEY` - SendGrid API key for authentication

## Testing
- Build passes successfully
- Mock mode works in development environment

Closes #437