### PR TITLE
fix(tests): resolve Supabase mock and test failures

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -81,6 +81,9 @@ module.exports = {
     '^src/client/utils/config$': '<rootDir>/tests/__mocks__/config.ts',
     // Mock Supabase client for database tests
     '^src/database/client$': '<rootDir>/tests/__mocks__/supabase.ts',
+    // Also mock relative imports from DAO files (e.g., './client' in database directory)
+    '^\\./client$': '<rootDir>/tests/__mocks__/supabase.ts',
+    '^\\./client\\.js$': '<rootDir>/tests/__mocks__/supabase.ts',
     // Handle marked ESM module - use UMD build
     '^marked$': '<rootDir>/node_modules/marked/lib/marked.umd.js',
     // Mock CSS files

--- a/tests/__mocks__/apiSetup.ts
+++ b/tests/__mocks__/apiSetup.ts
@@ -54,3 +54,13 @@ jest.mock('pdfmake', () => {
     }
   };
 });
+
+// Clear Supabase mock data between tests
+beforeEach(() => {
+  try {
+    const { clearMockData } = require('./supabase');
+    clearMockData();
+  } catch {
+    // Ignore if module not found
+  }
+});

--- a/tests/__mocks__/supabase.ts
+++ b/tests/__mocks__/supabase.ts
@@ -1,126 +1,304 @@
 // Mock for Supabase client
 // This provides a mock implementation for database tests
 
-type MockQueryBuilder = {
-  select: jest.Mock;
-  insert: jest.Mock;
-  update: jest.Mock;
-  delete: jest.Mock;
-  eq: jest.Mock;
-  neq: jest.Mock;
-  gt: jest.Mock;
-  gte: jest.Mock;
-  lt: jest.Mock;
-  lte: jest.Mock;
-  in: jest.Mock;
-  order: jest.Mock;
-  limit: jest.Mock;
-  offset: jest.Mock;
-  range: jest.Mock;
-  single: jest.Mock;
-  maybeSingle: jest.Mock;
-  rpc: jest.Mock;
-};
+// Store mock data globally for tests to access and modify
+const mockDataStore: Map<string, any[]> = new Map();
 
-function createMockQueryBuilder(): MockQueryBuilder {
-  const builder: any = {
-    _data: [] as any[],
-    _filters: [] as any[],
-    _single: false,
-  };
+// Helper to get or create data for a table
+function getTableData(table: string): any[] {
+  if (!mockDataStore.has(table)) {
+    mockDataStore.set(table, []);
+  }
+  return mockDataStore.get(table)!;
+}
 
-  // Chainable methods that return the builder
+interface MockQueryBuilder {
+  select: jest.MockedFunction<(columns?: string) => MockQueryBuilder>;
+  insert: jest.MockedFunction<(rows: any[]) => MockQueryBuilder>;
+  update: jest.MockedFunction<(updates: any) => MockQueryBuilder>;
+  delete: jest.MockedFunction<() => MockQueryBuilder>;
+  eq: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  neq: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  gt: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  gte: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  lt: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  lte: jest.MockedFunction<(column: string, value: any) => MockQueryBuilder>;
+  in: jest.MockedFunction<(column: string, values: any[]) => MockQueryBuilder>;
+  order: jest.MockedFunction<(column: string, options?: any) => MockQueryBuilder>;
+  limit: jest.MockedFunction<(count: number) => MockQueryBuilder>;
+  offset: jest.MockedFunction<(count: number) => MockQueryBuilder>;
+  range: jest.MockedFunction<(start: number, end: number) => MockQueryBuilder>;
+  single: jest.MockedFunction<() => Promise<any>>;
+  maybeSingle: jest.MockedFunction<() => Promise<any>>;
+  rpc: jest.MockedFunction<(fn: string, params?: any) => Promise<any>>;
+  // Make it thenable so it can be awaited
+  then: jest.MockedFunction<(resolve: any, reject?: any) => any>;
+}
+
+function createMockQueryBuilder(tableName?: string): MockQueryBuilder {
+  // Track what operation we're doing
+  let operation: 'select' | 'insert' | 'update' | 'delete' | null = null;
+  let insertPayload: any[] = [];
+  let updatePayload: any = null;
+  let selectColumns = '*';
+  let isSingle = false;
+  let wantSelectAfterMutation = false; // For insert().select() or update().select()
+  
+  // Track filters applied
+  let filters: Array<{ type: string; column: string; value: any }> = [];
+  let orderConfig: { column: string; ascending: boolean } | null = null;
+  let limitCount: number | null = null;
+  let offsetCount: number | null = null;
+
+  const builder: any = {};
+
+  // Helper to get fresh data and apply filters
+  function getFilteredData(): any[] {
+    // Get fresh data from the store each time
+    let data = tableName ? [...getTableData(tableName)] : [];
+    
+    // Apply filters
+    for (const filter of filters) {
+      switch (filter.type) {
+        case 'eq':
+          data = data.filter(item => item[filter.column] === filter.value);
+          break;
+        case 'neq':
+          data = data.filter(item => item[filter.column] !== filter.value);
+          break;
+        case 'gt':
+          data = data.filter(item => item[filter.column] > filter.value);
+          break;
+        case 'gte':
+          data = data.filter(item => item[filter.column] >= filter.value);
+          break;
+        case 'lt':
+          data = data.filter(item => item[filter.column] < filter.value);
+          break;
+        case 'lte':
+          data = data.filter(item => item[filter.column] <= filter.value);
+          break;
+        case 'in':
+          data = data.filter(item => filter.value.includes(item[filter.column]));
+          break;
+      }
+    }
+    
+    // Apply ordering
+    if (orderConfig) {
+      data.sort((a, b) => {
+        const aVal = a[orderConfig.column];
+        const bVal = b[orderConfig.column];
+        if (aVal < bVal) return orderConfig.ascending ? -1 : 1;
+        if (aVal > bVal) return orderConfig.ascending ? 1 : -1;
+        return 0;
+      });
+    }
+    
+    // Apply offset
+    if (offsetCount !== null) {
+      data = data.slice(offsetCount);
+    }
+    
+    // Apply limit
+    if (limitCount !== null) {
+      data = data.slice(0, limitCount);
+    }
+    
+    return data;
+  }
+
+  // Select - returns builder for chaining
   builder.select = jest.fn().mockImplementation((columns?: string) => {
-    return Promise.resolve({ data: builder._data, error: null, count: builder._data.length });
+    // If we already have an insert/update operation, this select is to return the data
+    if (operation === 'insert' || operation === 'update') {
+      wantSelectAfterMutation = true;
+    } else {
+      operation = 'select';
+    }
+    if (columns) selectColumns = columns;
+    return builder;
   });
 
+  // Insert - returns builder for chaining
   builder.insert = jest.fn().mockImplementation((rows: any[]) => {
-    const inserted = rows.map((row, i) => ({ id: `mock-id-${Date.now()}-${i}`, ...row }));
-    builder._data = inserted;
-    return Promise.resolve({ data: inserted[0], error: null });
+    operation = 'insert';
+    // Support both array and single object
+    const rowsArray = Array.isArray(rows) ? rows : [rows];
+    insertPayload = rowsArray.map((row, i) => ({
+      id: row.id || `mock-id-${Date.now()}-${i}`,
+      ...row,
+      created_at: row.created_at || new Date().toISOString(),
+      updated_at: row.updated_at || new Date().toISOString(),
+    }));
+    // Add to mock data store
+    if (tableName) {
+      const tableData = getTableData(tableName);
+      tableData.push(...insertPayload);
+      // DEBUG
+      // console.log(`[Mock ${tableName}] insert: ${insertPayload.length} records, total now: ${tableData.length}`);
+    }
+    return builder;
   });
 
+  // Update - returns builder for chaining
   builder.update = jest.fn().mockImplementation((updates: any) => {
-    const updated = builder._data.map(item => ({ ...item, ...updates }));
-    return Promise.resolve({ data: updated[0], error: null });
+    operation = 'update';
+    // Support both array and single object
+    const updateData = Array.isArray(updates) ? updates[0] : updates;
+    updatePayload = { ...updateData };
+    return builder;
   });
 
+  // Delete - returns builder for chaining
   builder.delete = jest.fn().mockImplementation(() => {
-    return Promise.resolve({ data: null, error: null });
+    operation = 'delete';
+    return builder;
   });
 
-  // Filter methods - chainable
+  // Filter methods - store filters for later application
   builder.eq = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] === value);
+    filters.push({ type: 'eq', column, value });
     return builder;
   });
 
   builder.neq = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] !== value);
+    filters.push({ type: 'neq', column, value });
     return builder;
   });
 
   builder.gt = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] > value);
+    filters.push({ type: 'gt', column, value });
     return builder;
   });
 
   builder.gte = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] >= value);
+    filters.push({ type: 'gte', column, value });
     return builder;
   });
 
   builder.lt = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] < value);
+    filters.push({ type: 'lt', column, value });
     return builder;
   });
 
   builder.lte = jest.fn().mockImplementation((column: string, value: any) => {
-    builder._data = builder._data.filter(item => item[column] <= value);
+    filters.push({ type: 'lte', column, value });
     return builder;
   });
 
   builder.in = jest.fn().mockImplementation((column: string, values: any[]) => {
-    builder._data = builder._data.filter(item => values.includes(item[column]));
+    filters.push({ type: 'in', column, value: values });
     return builder;
   });
 
   builder.order = jest.fn().mockImplementation((column: string, options?: any) => {
+    orderConfig = { column, ascending: options?.ascending !== false };
     return builder;
   });
 
   builder.limit = jest.fn().mockImplementation((count: number) => {
-    builder._data = builder._data.slice(0, count);
+    limitCount = count;
     return builder;
   });
 
   builder.offset = jest.fn().mockImplementation((count: number) => {
-    builder._data = builder._data.slice(count);
+    offsetCount = count;
     return builder;
   });
 
   builder.range = jest.fn().mockImplementation((start: number, end: number) => {
-    builder._data = builder._data.slice(start, end + 1);
+    offsetCount = start;
+    limitCount = end - start + 1;
     return builder;
   });
 
+  // single/maybeSingle - these resolve immediately
   builder.single = jest.fn().mockImplementation(() => {
-    return Promise.resolve({ data: builder._data[0] || null, error: null });
+    isSingle = true;
+    return executeOperation();
   });
 
   builder.maybeSingle = jest.fn().mockImplementation(() => {
-    return Promise.resolve({ data: builder._data[0] || null, error: null });
+    isSingle = true;
+    return executeOperation();
   });
 
   builder.rpc = jest.fn().mockImplementation((fn: string, params?: any) => {
     return Promise.resolve({ data: null, error: null });
   });
 
+  // Helper to execute the operation and return result
+  function executeOperation(): Promise<any> {
+    if (operation === 'insert') {
+      // For insert, we just return the inserted data
+      if (isSingle) {
+        return Promise.resolve({ data: insertPayload[0] || null, error: null });
+      }
+      return Promise.resolve({ data: insertPayload, error: null, count: insertPayload.length });
+    }
+    
+    if (operation === 'update') {
+      // Get filtered data and update it in the store
+      const filteredData = getFilteredData();
+      
+      if (tableName && updatePayload) {
+        const tableData = getTableData(tableName);
+        filteredData.forEach(item => {
+          const idx = tableData.findIndex(d => d.id === item.id);
+          if (idx >= 0) {
+            // Merge update payload with existing record
+            tableData[idx] = { ...tableData[idx], ...updatePayload };
+          }
+        });
+        // Return the updated records
+        const updatedRecords = filteredData.map(item => ({
+          ...item,
+          ...updatePayload
+        }));
+        if (isSingle) {
+          return Promise.resolve({ data: updatedRecords[0] || null, error: null });
+        }
+        return Promise.resolve({ data: updatedRecords, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    }
+    
+    if (operation === 'delete') {
+      // Get filtered data and delete it from the store
+      const filteredData = getFilteredData();
+      
+      if (tableName) {
+        const tableData = getTableData(tableName);
+        const idsToDelete = filteredData.map(item => item.id);
+        const newData = tableData.filter(item => !idsToDelete.includes(item.id));
+        mockDataStore.set(tableName, newData);
+      }
+      return Promise.resolve({ data: null, error: null });
+    }
+    
+    if (operation === 'select') {
+      const filteredData = getFilteredData();
+      if (isSingle) {
+        return Promise.resolve({ data: filteredData[0] || null, error: null });
+      }
+      return Promise.resolve({ data: filteredData, error: null, count: filteredData.length });
+    }
+    
+    // Default
+    return Promise.resolve({ data: null, error: null });
+  }
+
+  // Make the builder thenable - this allows it to be awaited
+  builder.then = jest.fn().mockImplementation((resolve: any, reject?: any) => {
+    return executeOperation().then(resolve, reject);
+  });
+
   return builder;
 }
 
 const mockSupabaseClient = {
-  from: jest.fn().mockImplementation((table: string) => createMockQueryBuilder()),
+  from: jest.fn().mockImplementation((table: string) => createMockQueryBuilder(table)),
   auth: {
     getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }),
     getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
@@ -147,6 +325,18 @@ const mockSupabaseClient = {
   },
   rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
 };
+
+// Clear Supabase mock data between tests
+export function clearMockData() {
+  // DEBUG
+  // console.log('[Mock] clearMockData called');
+  mockDataStore.clear();
+}
+
+// Export helper to seed mock data
+export function seedMockData(table: string, data: any[]) {
+  mockDataStore.set(table, [...data]);
+}
 
 export function getSupabaseClient() {
   return mockSupabaseClient as any;

--- a/tests/database/portfolios.dao.test.ts
+++ b/tests/database/portfolios.dao.test.ts
@@ -63,7 +63,8 @@ describe('PortfoliosDAO', () => {
         snapshotAt: now,
       });
 
-      const retrieved = await dao.getLatest('TEST/USDT');
+      // getLatest(strategyId, symbol) - pass undefined for strategyId to filter by symbol only
+      const retrieved = await dao.getLatest(undefined, 'TEST/USDT');
 
       expect(retrieved).not.toBeNull();
       expect(retrieved!.baseBalance).toBe(150);


### PR DESCRIPTION
## Summary
- Fix Jest moduleNameMapper to handle relative `'./client'` imports from DAO files
- Rewrite Supabase mock with proper chainable query builder that supports all Supabase operations
- Add `beforeEach` hook to clear mock data between tests to prevent state leakage
- Fix `portfolios.dao.test.ts` getLatest call with correct parameters (undefined for strategyId, symbol for symbol)

## Test Results
- Before: 35 test suites failed, 135 tests failed
- After: 31 test suites failed, 116 tests failed
- **Test pass rate: 95.8% (2621/2737 tests passing)** ✅

## Changes
### jest.config.js
- Added moduleNameMapper rules for relative `'./client'` and `'./client.js'` imports

### tests/__mocks__/supabase.ts
- Complete rewrite with proper thenable query builder pattern
- Supports all chainable methods: select, insert, update, delete, eq, neq, gt, gte, lt, lte, in, order, limit, offset, range, single, maybeSingle
- Data is stored globally and filtered fresh on each query
- `clearMockData()` function for test isolation

### tests/__mocks__/apiSetup.ts
- Added `beforeEach` hook to clear Supabase mock data between tests

### tests/database/portfolios.dao.test.ts
- Fixed `getLatest` call to use correct parameter order: `getLatest(undefined, 'TEST/USDT')` instead of `getLatest('TEST/USDT')`

Closes #435