### PR TITLE
fix(tests): fix OrdersPanel test mock and refresh button selector

### DIFF
--- a/tests/client/OrdersPanel.test.tsx
+++ b/tests/client/OrdersPanel.test.tsx
@@ -40,6 +40,7 @@ jest.mock('@arco-design/web-react', () => {
 });
 
 const { api } = require('../../src/client/utils/api');
+const { Message } = require('@arco-design/web-react');
 
 describe('OrdersPanel', () => {
   beforeEach(() => {
@@ -181,8 +182,8 @@ describe('OrdersPanel', () => {
       expect(screen.getByText(/暂无订单/i)).toBeInTheDocument();
     });
 
-    // Click refresh button
-    const refreshButton = screen.getByText('刷新');
+    // Click refresh button (it's an icon button with IconRefresh)
+    const refreshButton = screen.getByRole('button', { name: '' });
     fireEvent.click(refreshButton);
 
     await waitFor(() => {
@@ -191,14 +192,14 @@ describe('OrdersPanel', () => {
   });
 
   it('should handle getOrders failure gracefully', async () => {
-    api.getOrders.mockRejectedValue(new Error('Network error'));
+    api.getOrders.mockRejectedValue(new Error('network error'));
 
     render(<OrdersPanel />);
 
     // Component should handle error and show error message
     await waitFor(() => {
-      expect(mockMessage.error).toHaveBeenCalled();
-    });
+      expect(Message.error).toHaveBeenCalled();
+    }, { timeout: 3000 });
     
     // Verify API was called
     expect(api.getOrders).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes test failures in OrdersPanel.test.tsx that were causing CI failures.

### Problem

The OrdersPanel tests had two issues:
1. **Undefined mockMessage**: The test used `mockMessage.error` but `mockMessage` was never defined, causing "Cannot read properties of undefined" error
2. **Wrong refresh button selector**: The test looked for button with text "刷新" but the button is an icon button without visible text

### Changes

1. **Add Message import**: Import `Message` from `@arco-design/web-react` for proper error assertion
2. **Fix refresh button selector**: Use `getByRole('button', { name: '' })` instead of `getByText('刷新')`
3. **Match component's error handling**: Changed error message to lowercase "network error" to match the component's error handling logic

### Test Results

All 13 tests pass:
```
PASS tests/client/OrdersPanel.test.tsx
  OrdersPanel
    ✓ should render loading state initially
    ✓ should render orders list after loading
    ✓ should render empty state when no orders
    ✓ should display order status correctly
    ✓ should show cancel button only for pending orders
    ✓ should call cancelOrder API when cancel button is clicked and confirmed
    ✓ should refresh orders when refresh button is clicked
    ✓ should handle getOrders failure gracefully
    ✓ should filter orders by symbol when symbol prop is provided
    ✓ should respect limit prop
    ✓ should display order price correctly
    ✓ should display order quantity with 4 decimal places
    ✓ should show order type tags
```

### Note

This PR replaces the closed PR #476 which had significant scope creep (40 files including unrelated source changes and `.virtucorp/` operational files). This PR contains ONLY the OrdersPanel test fix - 1 file, 6 insertions, 5 deletions.