### PR TITLE
fix: detect and handle Supabase Realtime service outages (Issue #484)

### DIFF
--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -1,0 +1,28 @@
+web:
+  url: "https://alphaarena-eight.vercel.app"
+
+tasks:
+  - name: "Homepage Load"
+    flow:
+      - aiWaitFor: "页面完全加载，没有 loading 状态"
+      - aiAssert: "页面标题包含 AlphaArena 或类似股票/交易相关的文字"
+      - aiAssert: "页面主要内容区域可见，没有空白或错误提示"
+      - aiAssert: "没有明显的 404 或 500 错误页面"
+      - aiAssert: "页面布局正常，没有元素重叠或错位"
+  - name: "Navigation Test"
+    flow:
+      - aiAssert: "导航栏或菜单区域可见"
+      - ai: "尝试找到并点击主要的导航链接或按钮（如首页、股票列表等）"
+      - aiWaitFor: "页面响应导航操作，URL 或内容发生变化"
+      - aiAssert: "导航后页面内容正确显示，没有错误"
+  - name: "Core Functionality"
+    flow:
+      - aiAssert: "股票列表或交易相关的核心组件可见"
+      - aiAssert: "可以查看股票信息或价格数据"
+      - aiAssert: "页面交互元素（按钮、输入框等）响应正常"
+      - ai: "滚动页面查看更多内容，验证无限加载或分页功能正常"
+  - name: "Console Error Check"
+    flow:
+      - aiAssert: "页面没有显示 JavaScript 错误弹窗"
+      - aiAssert: "页面没有显示 API 错误或网络错误提示"
+      - aiAssert: "所有图片和资源正常加载，没有破损的图片图标"

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,0 +1,10 @@
+{
+  "lastDispatch": {
+    "digestHash": "spawn_dev_bugfix|bug:484|prs:0|ready:1|no-sprint",
+    "timestamp": 1774047286134,
+    "consecutiveCount": 1
+  },
+  "highWaterMark": 43,
+  "paused": false,
+  "pauseReason": ""
+}

--- a/.virtucorp/sprint.json
+++ b/.virtucorp/sprint.json
@@ -1,0 +1,65 @@
+{
+  "sprint": {
+    "number": 43,
+    "title": "Sprint 43: 技术债务收尾与准备",
+    "milestone": 44,
+    "status": "completed",
+    "period": {
+      "start": "2026-03-20",
+      "end": "2026-03-20"
+    },
+    "goals": "清理剩余技术债务，提升代码质量",
+    "issues": {
+      "completed": [
+        {
+          "number": 473,
+          "title": "Sprint 43 准备工作",
+          "priority": "P2",
+          "type": "chore",
+          "status": "closed"
+        },
+        {
+          "number": 474,
+          "title": "修复剩余测试失败 (~16个套件)",
+          "priority": "P1",
+          "type": "bug",
+          "status": "closed",
+          "pr": 479
+        },
+        {
+          "number": 475,
+          "title": "清理 ESLint 错误 (~116个)",
+          "priority": "P2",
+          "type": "chore",
+          "status": "closed",
+          "pr": 480
+        }
+      ],
+      "total": 3,
+      "completed": 3
+    },
+    "metrics": {
+      "pr_merged": 2,
+      "issues_closed": 3,
+      "eslint_reduction": "74% (116 → 30)",
+      "test_suites_fixed": 16
+    },
+    "retrospective": {
+      "what_went_well": [
+        "测试失败修复：成功修复了 16 个测试套件的失败问题",
+        "ESlint 清理：错误数量从 116 个减少到 30 个，减少 74%",
+        "PR 快速合并：Issue #474 和 #475 都在同一天完成并合并"
+      ],
+      "what_could_improve": [
+        "仍有 30 个 ESLint 错误待清理",
+        "部分测试失败根因是 mock 问题，需要更好的测试基础设施"
+      ],
+      "action_items": [
+        "继续清理剩余 ESLint 错误",
+        "改进测试 mock 层以减少类似的测试失败"
+      ]
+    },
+    "completed_at": "2026-03-20T19:51:41Z"
+  },
+  "next_sprint": null
+}

--- a/src/client/components/OfflineIndicator.tsx
+++ b/src/client/components/OfflineIndicator.tsx
@@ -5,12 +5,14 @@
  * Shows reconnection progress and auto-hides when reconnected
  * 
  * Updated for Issue #178: Handle "degraded" state when Realtime fails but REST API works
+ * Updated for Issue #484: Detect and report Realtime service outages
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, Tag, Progress, Button } from '@arco-design/web-react';
 import { IconSync, IconCheckCircle, IconExclamationCircle, IconRefresh } from '@arco-design/web-react/icon';
 import { useConnection } from '../store/connectionStore';
+import { getRealtimeClient, ServiceHealth } from '../utils/realtime';
 
 const _ReconnectingIcon = IconSync;
 const _ConnectedIcon = IconCheckCircle;
@@ -19,6 +21,19 @@ const RefreshIcon = IconRefresh;
 
 const OfflineIndicator: React.FC = () => {
   const { status, isOnline, quality, lastDisconnectedAt: _lastDisconnectedAt, isRestApiAvailable, checkRestApiHealth } = useConnection();
+  const [serviceHealth, setServiceHealth] = useState<ServiceHealth | null>(null);
+
+  // Subscribe to Realtime service health changes
+  useEffect(() => {
+    const client = getRealtimeClient();
+    const unsubscribe = client.onHealthChange((health) => {
+      setServiceHealth(health);
+    });
+    
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   // Don't show if connected and online and not stale
   if (status === 'connected' && isOnline && !quality.isStale) {
@@ -29,19 +44,29 @@ const OfflineIndicator: React.FC = () => {
   // This is intentional - we want to show the app is functional, just without real-time updates
   // The user can still see data updates via REST API polling every 3 seconds
   if (status === 'degraded' && isRestApiAvailable) {
+    // Check if the service is detected as down
+    const isServiceDown = serviceHealth?.status === 'down';
+    const errorMessage = serviceHealth?.errorMessage;
+    
     return (
       <Alert
         type="warning"
         content={
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <span style={{ flex: 1 }}>
-              ⚠️ 实时推送暂时不可用，数据每 3 秒自动更新
+              {isServiceDown 
+                ? `⚠️ 实时推送服务暂时不可用（${errorMessage || '服务异常'}），数据每 3 秒自动更新`
+                : '⚠️ 实时推送暂时不可用，数据每 3 秒自动更新'
+              }
             </span>
             <Tag color="orange">降级模式</Tag>
             <Button 
               size="small" 
               icon={<RefreshIcon />}
-              onClick={() => checkRestApiHealth()}
+              onClick={() => {
+                checkRestApiHealth();
+                getRealtimeClient().checkServiceHealth();
+              }}
             >
               刷新数据
             </Button>

--- a/src/client/utils/realtime.ts
+++ b/src/client/utils/realtime.ts
@@ -22,6 +22,11 @@ const CONNECTION_TIMEOUT = 10000; // 10 seconds timeout for subscription
 const STALE_CONNECTION_THRESHOLD = 60000; // 60 seconds without ping = stale
 const PING_INTERVAL = 15000; // 15 seconds ping interval
 
+// Service health settings
+const MAX_CONSECUTIVE_FAILURES = 3; // After this many failures, consider service down
+const SERVICE_DOWN_COOLDOWN = 60000; // 1 minute cooldown before trying again after service is marked down
+const HEALTH_CHECK_INTERVAL = 30000; // Check service health every 30 seconds when in degraded mode
+
 // Connection states
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
@@ -31,6 +36,19 @@ export interface ConnectionQuality {
   isStale: boolean;
   reconnectAttempts: number;
   lastReconnectAt: number | null;
+}
+
+/**
+ * Service health status for Realtime
+ */
+export type ServiceHealthStatus = 'healthy' | 'degraded' | 'down' | 'unknown';
+
+export interface ServiceHealth {
+  status: ServiceHealthStatus;
+  consecutiveFailures: number;
+  lastHealthCheckAt: number | null;
+  lastSuccessfulConnectionAt: number | null;
+  errorMessage: string | null;
 }
 
 export interface RealtimeMessage {
@@ -92,6 +110,16 @@ export class RealtimeClient {
     lastReconnectAt: null,
   };
   
+  // Service health tracking
+  private serviceHealth: ServiceHealth = {
+    status: 'unknown',
+    consecutiveFailures: 0,
+    lastHealthCheckAt: null,
+    lastSuccessfulConnectionAt: null,
+    errorMessage: null,
+  };
+  private healthCheckTimer: NodeJS.Timeout | null = null;
+  
   // Message queue for offline actions
   private messageQueue: QueuedMessage[] = [];
   private isProcessingQueue: boolean = false;
@@ -99,6 +127,7 @@ export class RealtimeClient {
   // Event listeners for connection state changes
   private connectionListeners: Array<(status: ConnectionStatus) => void> = [];
   private qualityListeners: Array<(quality: ConnectionQuality) => void> = [];
+  private healthListeners: Array<(health: ServiceHealth) => void> = [];
 
   constructor() {
     const config = validateConfig();
@@ -164,6 +193,90 @@ export class RealtimeClient {
     this.pingTimer = setInterval(() => {
       this.checkConnectionHealth();
     }, PING_INTERVAL);
+  }
+
+  /**
+   * Start periodic health checks when in degraded mode
+   */
+  private startHealthCheckTimer() {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+    }
+
+    this.healthCheckTimer = setInterval(() => {
+      // Only check if service is marked as down
+      if (this.serviceHealth.status === 'down') {
+        console.log('[RealtimeClient] Periodic health check - attempting to reconnect...');
+        this.serviceHealth.status = 'degraded';
+        this.serviceHealth.consecutiveFailures = 0;
+        this.notifyHealthListeners();
+        
+        // Try to reconnect
+        const topics = Array.from(this.subscribedTopics);
+        if (topics.length > 0) {
+          this.subscribe(topics[0]).catch(() => {});
+        }
+      }
+    }, HEALTH_CHECK_INTERVAL);
+  }
+
+  /**
+   * Stop health check timer
+   */
+  private stopHealthCheckTimer() {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
+    }
+  }
+
+  /**
+   * Record a connection failure and update service health
+   */
+  private recordFailure(error: string) {
+    this.serviceHealth.consecutiveFailures++;
+    this.serviceHealth.lastHealthCheckAt = Date.now();
+    this.serviceHealth.errorMessage = error;
+
+    if (this.serviceHealth.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      const previousStatus = this.serviceHealth.status;
+      this.serviceHealth.status = 'down';
+      
+      if (previousStatus !== 'down') {
+        console.error('[RealtimeClient] 🚨 Realtime service appears to be DOWN');
+        console.error('[RealtimeClient] Error:', error);
+        console.error('[RealtimeClient] Switching to degraded mode - will use HTTP polling fallback');
+        console.error('[RealtimeClient] Will attempt to reconnect in', SERVICE_DOWN_COOLDOWN / 1000, 'seconds');
+        
+        // Start health check timer for periodic reconnection attempts
+        this.startHealthCheckTimer();
+      }
+    } else {
+      this.serviceHealth.status = 'degraded';
+      console.warn(`[RealtimeClient] Connection failure ${this.serviceHealth.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}: ${error}`);
+    }
+
+    this.notifyHealthListeners();
+  }
+
+  /**
+   * Record a successful connection
+   */
+  private recordSuccess() {
+    const wasDown = this.serviceHealth.status === 'down';
+    
+    this.serviceHealth.consecutiveFailures = 0;
+    this.serviceHealth.lastHealthCheckAt = Date.now();
+    this.serviceHealth.lastSuccessfulConnectionAt = Date.now();
+    this.serviceHealth.errorMessage = null;
+    this.serviceHealth.status = 'healthy';
+
+    if (wasDown) {
+      console.log('[RealtimeClient] ✅ Realtime service is back online!');
+      this.stopHealthCheckTimer();
+    }
+
+    this.notifyHealthListeners();
   }
 
   /**
@@ -233,6 +346,16 @@ export class RealtimeClient {
    * Subscribe to a channel with automatic reconnection and timeout handling
    */
   public async subscribe(topic: string): Promise<RealtimeChannel> {
+    // Check if service is marked as down
+    if (this.serviceHealth.status === 'down') {
+      const timeSinceLastCheck = Date.now() - (this.serviceHealth.lastHealthCheckAt || 0);
+      if (timeSinceLastCheck < SERVICE_DOWN_COOLDOWN) {
+        throw new Error('Realtime service is currently unavailable. Using HTTP polling fallback.');
+      }
+      // Cooldown period passed, try again
+      this.serviceHealth.status = 'degraded';
+    }
+
     // If already successfully subscribed, return the existing channel
     if (this.subscribedTopics.has(topic) && this.channels.has(topic)) {
       return this.channels.get(topic)!;
@@ -254,19 +377,28 @@ export class RealtimeClient {
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
+        const errorMsg = `订阅超时：${topic}`;
         console.error(`[RealtimeClient] Subscription timeout for ${topic}`);
+        
+        // Record failure for health tracking
+        this.recordFailure(errorMsg);
+        
         // Update connection status to disconnected on timeout
         this.subscribedTopics.delete(topic);
         this.connectionStatus = 'disconnected';
         this.notifyConnectionListeners();
         this.handleReconnect(topic);
-        reject(new Error(`订阅超时：${topic}`));
+        reject(new Error(errorMsg));
       }, CONNECTION_TIMEOUT);
 
       channel.subscribe((status) => {
         if (status === 'SUBSCRIBED') {
           clearTimeout(timeout);
           console.log(`[RealtimeClient] Subscribed to ${topic}`);
+          
+          // Record successful connection
+          this.recordSuccess();
+          
           this.subscribedTopics.add(topic);
           this.connectionStatus = 'connected';
           this.reconnectDelay = INITIAL_RECONNECT_DELAY; // Reset on success
@@ -280,13 +412,18 @@ export class RealtimeClient {
           resolve(channel);
         } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
           clearTimeout(timeout);
+          const errorMsg = `订阅失败：${status}`;
           console.error(`[RealtimeClient] Subscription error for ${topic}:`, status);
+          
+          // Record failure for health tracking
+          this.recordFailure(errorMsg);
+          
           // Update connection status on error
           this.subscribedTopics.delete(topic);
           this.connectionStatus = 'disconnected';
           this.notifyConnectionListeners();
           this.handleReconnect(topic);
-          reject(new Error(`订阅失败：${status}`));
+          reject(new Error(errorMsg));
         }
       });
     });
@@ -612,6 +749,32 @@ export class RealtimeClient {
     this.qualityListeners.forEach(cb => cb({ ...this.connectionQuality }));
   }
 
+  private notifyHealthListeners() {
+    this.healthListeners.forEach(cb => cb({ ...this.serviceHealth }));
+  }
+
+  /**
+   * Subscribe to service health changes
+   */
+  public onHealthChange(callback: (health: ServiceHealth) => void): () => void {
+    this.healthListeners.push(callback);
+    // Immediately notify of current state
+    callback({ ...this.serviceHealth });
+    return () => {
+      const index = this.healthListeners.indexOf(callback);
+      if (index !== -1) {
+        this.healthListeners.splice(index, 1);
+      }
+    };
+  }
+
+  /**
+   * Get service health status
+   */
+  public getServiceHealth(): ServiceHealth {
+    return { ...this.serviceHealth };
+  }
+
   /**
    * Unsubscribe from a channel
    */
@@ -667,6 +830,8 @@ export class RealtimeClient {
       this.pingTimer = null;
     }
 
+    this.stopHealthCheckTimer();
+
     if (this.reconnectTimers.size > 0) {
       this.reconnectTimers.forEach((timer) => clearTimeout(timer));
       this.reconnectTimers.clear();
@@ -680,6 +845,13 @@ export class RealtimeClient {
       isStale: false,
       reconnectAttempts: 0,
       lastReconnectAt: null,
+    };
+    this.serviceHealth = {
+      status: 'unknown',
+      consecutiveFailures: 0,
+      lastHealthCheckAt: null,
+      lastSuccessfulConnectionAt: null,
+      errorMessage: null,
     };
   }
 
@@ -709,6 +881,73 @@ export class RealtimeClient {
    */
   public getQueuedMessageCount(): number {
     return this.messageQueue.length;
+  }
+
+  /**
+   * Check Realtime service health via HTTP endpoint
+   * This is useful for detecting if the service is down before attempting WebSocket connection
+   */
+  public async checkServiceHealth(): Promise<{ healthy: boolean; status: number; message: string }> {
+    const config = validateConfig();
+    const supabaseUrl = config.supabaseUrl;
+    const supabaseKey = config.supabaseAnonKey;
+
+    if (!supabaseUrl || !supabaseKey) {
+      return {
+        healthy: false,
+        status: 0,
+        message: 'Supabase configuration missing',
+      };
+    }
+
+    try {
+      // Try to hit the Realtime health endpoint
+      const healthUrl = `${supabaseUrl}/realtime/v1/health?apikey=${supabaseKey}`;
+      
+      const response = await fetch(healthUrl, {
+        method: 'GET',
+        headers: {
+          'apikey': supabaseKey,
+        },
+      });
+
+      if (response.ok) {
+        this.serviceHealth.status = 'healthy';
+        this.serviceHealth.errorMessage = null;
+        this.notifyHealthListeners();
+        return {
+          healthy: true,
+          status: response.status,
+          message: 'Realtime service is healthy',
+        };
+      } else {
+        const message = response.status === 500 
+          ? 'Realtime service is experiencing issues (500 error)'
+          : `Realtime service returned status ${response.status}`;
+        
+        this.serviceHealth.status = 'down';
+        this.serviceHealth.errorMessage = message;
+        this.notifyHealthListeners();
+        
+        return {
+          healthy: false,
+          status: response.status,
+          message,
+        };
+      }
+    } catch (error) {
+      const message = `Failed to check Realtime health: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      
+      this.serviceHealth.status = 'down';
+      this.serviceHealth.errorMessage = message;
+      this.notifyHealthListeners();
+      
+      return {
+        healthy: false,
+        status: 0,
+        message,
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #484 by implementing better detection and handling of Supabase Realtime service outages.

## Root Cause Analysis

**The Supabase Realtime WebSocket endpoint is returning 500 errors from Cloudflare.** This is a **Supabase infrastructure issue**, not an application code bug.

### Evidence
- `/realtime/v1/websocket` → 500 error (Cloudflare Worker exception)
- `/realtime/v1/health` → 500 error
- REST API and Edge Functions work fine

### Diagnosis
```
curl -s "https://plnylmnckssnfpwznpwf.supabase.co/realtime/v1/health?apikey=..."
# Returns: Cloudflare Error 1101 - Worker threw exception
```

## Changes

### 1. Service Health Tracking
- Added `ServiceHealth` interface with status tracking (healthy/degraded/down/unknown)
- Track consecutive failures and mark service as 'down' after 3 failures
- Implement 1-minute cooldown before retrying after service is marked down

### 2. Improved Error Handling
- `recordFailure()` - Track connection failures and update service health
- `recordSuccess()` - Reset failure counters on successful connection
- Periodic health check timer to attempt reconnection when service recovers

### 3. User Experience Improvements
- Show more informative error messages when service is detected as down
- App continues to work in degraded mode (HTTP polling every 3 seconds)
- `checkServiceHealth()` method for explicit health checks

### 4. Component Updates
- `OfflineIndicator` now shows service status (e.g., "500 error")
- Subscribe to Realtime health changes for real-time status updates

## Testing

1. Build succeeds ✅
2. App continues to function in degraded mode ✅
3. Health tracking detects consecutive failures ✅
4. Automatic reconnection attempts after cooldown ✅

## Related Issues

- Related: #483 (fixed stuck 'connecting' state logic)
- Fixes: #484

## Note

**This is a workaround, not a complete fix.** The underlying issue is with Supabase's Realtime service infrastructure. The app now handles the outage gracefully by:
1. Detecting the service is down
2. Stopping unnecessary reconnection attempts
3. Using HTTP polling fallback
4. Automatically retrying when service recovers

For a complete fix, Supabase support should be contacted to investigate the 500 errors on the Realtime WebSocket endpoint.