### PR TITLE
fix(smoke-test): update navigation assertions to match left sidebar UI

### DIFF
--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -15,11 +15,11 @@ tasks:
       - aiAssert: "连接状态提示（蓝色降级模式、黄色警告或红色断开提示）是可接受的预期行为，因为本地预览模式没有后端服务"
   - name: "Navigation Test"
     flow:
-      - aiAssert: "底部导航栏可见，包含多个导航按钮（如行情、仪表板、交易、策略等）"
-      - ai: "点击导航栏中的「仪表板」或 Dashboard 按钮"
+      - aiAssert: "左侧导航栏可见，包含多个导航菜单项（如行情、Dashboard、Strategies、Trades等）"
+      - ai: "点击左侧导航栏中的 Dashboard 菜单项"
       - sleep: 2000
       - aiAssert: "页面显示了仪表板相关内容（如统计卡片、图表、策略概览等）"
-      - ai: "点击导航栏中的「交易」或 Trades 按钮"
+      - ai: "点击左侧导航栏中的 Trades 菜单项"
       - sleep: 2000
       - aiAssert: "页面显示了交易相关内容（如交易记录列表、订单历史等）"
       - aiAssert: "导航切换流畅，页面内容正确显示，没有错误或白屏"


### PR DESCRIPTION
## 问题描述
smoke-test.yaml 中的导航测试断言期望底部导航栏，但当前 UI 采用左侧边栏导航布局。

## 修改内容
- 将导航断言从底部导航栏改为左侧导航栏
- 更新导航菜单项名称以匹配实际 UI（行情、Dashboard、Strategies、Trades）
- 修正导航测试步骤描述

## 测试
- 本地已验证 UI 确实采用左侧边栏导航
- 测试配置修改不影响产品功能