### PR TITLE
fix(ui): resolve layout issues in trading pair list and offline indicator

### DIFF
--- a/src/client/components/OfflineIndicator.tsx
+++ b/src/client/components/OfflineIndicator.tsx
@@ -147,6 +147,12 @@ const OfflineIndicator: React.FC = () => {
 
   // Get status tag
   const getStatusTag = () => {
+    // Don't show tag for disconnected status - the message already says "连接已断开"
+    // This avoids redundant display like "连接已断开" + "已断开" tag
+    if (status === 'disconnected') {
+      return null;
+    }
+
     const statusConfig = {
       connected: { color: 'green', text: '已连接' },
       connecting: { color: 'blue', text: '连接中' },

--- a/src/client/components/TradingPairList.tsx
+++ b/src/client/components/TradingPairList.tsx
@@ -71,8 +71,8 @@ const TradingPairList: React.FC<TradingPairListProps> = ({
       width: 120,
       fixed: 'left',
       render: (symbol: string, record: TradingPair) => (
-        <div 
-          style={{ cursor: 'pointer', fontWeight: 500 }} 
+        <div
+          style={{ cursor: 'pointer', fontWeight: 500, whiteSpace: 'nowrap' }}
           onClick={() => onPairSelect?.(symbol)}
           tabIndex={0}
           onKeyDown={(e) => {


### PR DESCRIPTION
## 关联 Issue
Fixes #507

## 问题概述
冒烟测试检测到生产环境存在两个布局问题：

### 问题 1: 交易对列表文字错误换行
- **位置**: 左侧交易对列表
- **现象**: "GOOGL / USD" 被错误换行显示为 "GOOGL / US" 占一行，"D" 单独在下一行
- **根因**: 列宽度 120px 且未设置 `whiteSpace: 'nowrap'`，导致文本溢出换行

### 问题 2: 顶部通知栏冗余显示
- **位置**: 顶部红色通知栏
- **现象**: 左侧显示"连接已断开"，右侧又显示"已断开"标签
- **根因**: `getMessage()` 返回 "连接已断开"，`getStatusTag()` 同时返回 "已断开" 标签，造成信息重复

## 修复方案

### 修复 1: TradingPairList.tsx
```tsx
// 在交易对渲染的 div 样式中添加 whiteSpace: 'nowrap'
style={{ cursor: 'pointer', fontWeight: 500, whiteSpace: 'nowrap' }}
```

### 修复 2: OfflineIndicator.tsx
```tsx
// 当 status === 'disconnected' 时不显示状态标签，避免冗余
if (status === 'disconnected') {
  return null;
}
```

## 测试验证
- [x] TypeScript 类型检查通过
- [x] 相关单元测试通过 (OfflineIndicator.test.tsx)

## 预期效果
- 交易对代码在同一行显示，不再换行
- 通知栏信息简洁，不再重复显示状态