### PR TITLE
fix: smoke test network idle timeout for WebSocket apps

### DIFF
--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -3,6 +3,12 @@ web:
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
   url: "https://alphaarena-eight.vercel.app"
+  # Network idle configuration for apps with WebSocket connections
+  # The production site has WebSocket connections (Supabase Realtime) for real-time market data
+  # These keep the network active, so we need a longer timeout and continue on network idle errors
+  waitForNetworkIdle:
+    timeout: 10000
+    continueOnNetworkIdleError: true
 
 tasks:
   - name: "Landing Page - Unauthenticated User"


### PR DESCRIPTION
## Summary
- Fixes the smoke test "network idle timeout" error when testing the production site
- Adds `waitForNetworkIdle` configuration to handle apps with WebSocket connections

## Problem
The production site uses Supabase Realtime (WebSocket) for real-time market data. WebSocket connections send periodic heartbeats (every 15 seconds) which keep the network "active". MidsceneJS\'s default 2000ms network idle timeout was causing the test to fail even though all assertions passed.

## Solution
Added `waitForNetworkIdle` configuration to the smoke test YAML:
- Increased timeout to 10000ms (10 seconds) to allow more time for network to settle
- Set `continueOnNetworkIdleError: true` to continue testing even if network idle isn\'t reached

## Testing
Ran the smoke test locally with `npx midscene .virtucorp/acceptance/smoke-test.yaml --headed`:
- All 4 test tasks passed successfully
- Landing Page - Unauthenticated User ✅
- Landing Page - Navigation Links ✅  
- Landing Page - Interactive Elements ✅
- Console Error Check ✅

Fixes #534