### PR TITLE
fix: Landing Page 移除不必要的实时推送服务

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -318,6 +318,8 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       )}
 
       <Layout>
+        {/* Offline indicator - only shown for authenticated users */}
+        <OfflineIndicator />
         <Header
           style={{
             padding: '0 16px',
@@ -550,8 +552,13 @@ const AppRoutes: React.FC = () => {
 };
 
 // Wrapper component to use the hook inside ConnectionProvider
+// Issue #579: Only initialize realtime connection for authenticated users
 function RealtimeConnectionSync() {
-  useRealtimeConnection();
+  const { isAuthenticated } = useAuth();
+  
+  // Only initialize realtime connection when user is authenticated
+  // This prevents unnecessary WebSocket connections on Landing Page
+  useRealtimeConnection(isAuthenticated);
   return null;
 }
 
@@ -611,7 +618,6 @@ function App() {
         <RealtimeConnectionSync />
         <BrowserRouter>
           <RouteRestorer />
-          <OfflineIndicator />
           <AppLayout>
             <AppRoutes />
           </AppLayout>

--- a/src/client/hooks/useRealtimeConnection.ts
+++ b/src/client/hooks/useRealtimeConnection.ts
@@ -2,15 +2,39 @@ import { useEffect, useRef } from 'react';
 import { useConnection } from '../store/connectionStore';
 import { getRealtimeClient } from '../utils/realtime';
 
-export function useRealtimeConnection() {
+/**
+ * Hook to manage realtime connection
+ * Issue #579: Only initializes connection when shouldConnect is true
+ * 
+ * @param shouldConnect - Whether to initialize the realtime connection (default: true for backward compatibility)
+ *                         Set to false on public pages like Landing Page to avoid unnecessary connections
+ */
+export function useRealtimeConnection(shouldConnect: boolean = true) {
   const { setStatus, updateQuality, setRealtimeConnected } = useConnection();
   const clientRef = useRef<any>(null);
   const isMountedRef = useRef<boolean>(false);
+  const wasConnectedRef = useRef<boolean>(false);
 
   useEffect(() => {
+    // Don't initialize connection if shouldConnect is false
+    if (!shouldConnect) {
+      // If we were previously connected, disconnect now
+      if (wasConnectedRef.current && clientRef.current) {
+        const client = clientRef.current;
+        client.unsubscribeAll().catch((err: Error) => {
+          console.warn('[useRealtimeConnection] Error during disconnect:', err);
+        });
+        setRealtimeConnected(false);
+        setStatus('disconnected');
+        wasConnectedRef.current = false;
+      }
+      return;
+    }
+
     isMountedRef.current = true;
     const client = getRealtimeClient();
     clientRef.current = client;
+    wasConnectedRef.current = true;
 
     // Subscribe to connection state changes
     const unsubscribe = client.onConnectionChange((status: string) => {
@@ -36,5 +60,5 @@ export function useRealtimeConnection() {
       unsubscribe();
       unsubscribeQuality();
     };
-  }, [setStatus, updateQuality, setRealtimeConnected]);
+  }, [shouldConnect, setStatus, updateQuality, setRealtimeConnected]);
 }


### PR DESCRIPTION
## Issue #579

### 问题描述
Landing Page 对未认证用户加载了不必要的实时推送服务（WebSocket、Supabase Realtime 等），影响用户体验：
- 增加首屏加载时间
- 消耗不必要的网络资源
- 未认证用户不需要实时连接

### 解决方案
1. 修改  hook，添加  参数
2. 只在用户已认证时才初始化实时连接
3. 将  移入 ，只对认证用户显示

### 技术细节
- `src/client/hooks/useRealtimeConnection.ts`: 添加条件初始化逻辑
- `src/client/App.tsx`: 根据认证状态决定是否初始化实时连接

### 测试
- 类型检查通过 (`tsc --noEmit`)
- Landing Page 访问时不会初始化 WebSocket 连接
- 登录后正常建立实时连接

### 影响范围
- ✅ Landing Page 首屏加载更快
- ✅ 减少未认证用户的网络请求
- ✅ 保持已认证用户的实时功能正常