### PR TITLE
fix: ensure form label color is visible on all themes

### DIFF
--- a/src/client/styles/arco-theme.css
+++ b/src/client/styles/arco-theme.css
@@ -435,6 +435,33 @@
   color: var(--color-text-1);
 }
 
+/* Fix: Ensure form label is always visible on both themes */
+/* This prevents dark theme text color being applied on light backgrounds */
+.arco-form-item .arco-form-label-item > label {
+  color: var(--color-text-1) !important;
+}
+
+/* Ensure label color remains correct when input is focused */
+.arco-form-item:focus-within .arco-form-label-item > label,
+.arco-form-item-has-focus .arco-form-label-item > label,
+.arco-input-focused ~ .arco-form-label-item > label,
+.arco-input-inner-wrapper-focus ~ .arco-form-label-item > label {
+  color: var(--color-text-1) !important;
+}
+
+/* Light theme explicit label color */
+:root .arco-form-label-item > label,
+:root.light .arco-form-label-item > label,
+:root[data-theme='light'] .arco-form-label-item > label {
+  color: var(--color-text-1) !important;
+}
+
+/* Dark theme explicit label color */
+:root.dark .arco-form-label-item > label,
+:root[data-theme='dark'] .arco-form-label-item > label {
+  color: var(--color-text-1) !important;
+}
+
 /* Spin Enhancements */
 .arco-spin-dot-item {
   background-color: var(--color-primary);


### PR DESCRIPTION
## Summary
- Fixes #582: 输入框聚焦时 label 样式问题
- Added explicit CSS rules for form label color on both light and dark themes
- Added focus state selectors to prevent color changes on input focus
- Used `!important` to ensure color is applied correctly regardless of specificity

## Problem
输入框聚焦时 label 文字变成白色，但背景是浅色，导致文字不可见。

## Solution
1. 添加了明确的 CSS 规则，确保 form label 在所有主题下都使用正确的颜色
2. 添加了 `focus-within` 和其他 focus 状态选择器，防止输入框聚焦时颜色改变
3. 使用 `!important` 确保样式优先级正确

## Testing
- 构建成功
- CSS 规则已正确应用到构建后的文件中

## Files Changed
- `src/client/styles/arco-theme.css` - 添加了 form label 的主题颜色修复