### PR TITLE
feat(i18n): implement language switcher component

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -29,6 +29,7 @@ import BalanceDisplay from './components/BalanceDisplay';
 import ThemeToggle from './components/ThemeToggle';
 import SettingsPanel from './components/SettingsPanel';
 import NotificationCenter from './components/NotificationCenter';
+import { LanguageSwitcher } from './components/LanguageSwitcher'; // Issue #586
 import OfflineIndicator from './components/OfflineIndicator';
 import MobileBottomNav from './components/MobileBottomNav';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -348,6 +349,7 @@ const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             </h1>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }} role="toolbar" aria-label="工具栏">
+            <LanguageSwitcher compact={isMobile} />
             <ThemeToggle compact={isMobile} />
             <span data-onboarding="notification-bell"><NotificationCenter compact={isMobile} /></span>
             <SettingsPanel compact={isMobile} />

--- a/src/client/components/LanguageSwitcher.css
+++ b/src/client/components/LanguageSwitcher.css
@@ -1,0 +1,206 @@
+/**
+ * Language Switcher Styles
+ * 
+ * Issue #586: 语言切换功能实现
+ */
+
+/* Main switcher button */
+.language-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  color: var(--color-text-2);
+  font-size: 14px;
+}
+
+.language-switcher:hover {
+  color: var(--color-text-1);
+  background: var(--color-fill-2);
+}
+
+.language-switcher--changing {
+  opacity: 0.7;
+}
+
+.language-switcher__label {
+  font-weight: 500;
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dropdown container */
+.language-dropdown {
+  min-width: 160px;
+  padding: 8px 0;
+  background: var(--color-bg-2);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  animation: language-dropdown-fade-in 0.2s ease;
+}
+
+@keyframes language-dropdown-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.language-dropdown__header {
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 4px;
+}
+
+.language-dropdown__options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Language option item */
+.language-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  position: relative;
+}
+
+.language-option:hover {
+  background: var(--color-fill-2);
+}
+
+.language-option--active {
+  background: var(--color-primary-light-1);
+}
+
+.language-option__name {
+  font-weight: 500;
+  color: var(--color-text-1);
+  font-size: 14px;
+}
+
+.language-option__native {
+  font-size: 12px;
+  color: var(--color-text-3);
+  margin-left: auto;
+}
+
+.language-option__check {
+  color: var(--color-primary);
+  font-size: 14px;
+  margin-left: auto;
+}
+
+.language-option--active .language-option__name {
+  color: var(--color-primary);
+}
+
+/* Keyboard focus styles */
+.language-option:focus {
+  outline: none;
+  background: var(--color-fill-2);
+}
+
+.language-option:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  border-radius: 4px;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .language-switcher {
+    padding: 8px !important;
+  }
+  
+  .language-switcher__label {
+    display: none;
+  }
+  
+  .language-dropdown {
+    min-width: 140px;
+  }
+  
+  .language-option {
+    padding: 12px 16px;
+  }
+  
+  .language-option__native {
+    display: none;
+  }
+}
+
+/* Compact mode adjustments */
+.language-switcher.compact {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+/* Animation for language change */
+.language-switcher--changing .language-switcher__label {
+  animation: language-change-pulse 0.6s ease infinite;
+}
+
+@keyframes language-change-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .language-dropdown {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme='dark'] .language-option:hover {
+  background: var(--color-fill-3);
+}
+
+[data-theme='dark'] .language-option--active {
+  background: rgba(var(--primary-6), 0.15);
+}
+
+/* Transition animation for content changes */
+@keyframes language-content-fade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Apply fade animation to translated content */
+.language-transition-enter {
+  animation: language-content-fade 0.3s ease;
+}
+
+/* Accessibility: Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  .language-dropdown,
+  .language-option,
+  .language-switcher--changing .language-switcher__label {
+    animation: none;
+    transition: none;
+  }
+}

--- a/src/client/components/LanguageSwitcher.tsx
+++ b/src/client/components/LanguageSwitcher.tsx
@@ -1,0 +1,197 @@
+/**
+ * Language Switcher Component
+ * 
+ * A dropdown-based language switcher that allows users to change the interface language.
+ * 
+ * Features:
+ * - Dropdown menu with language options
+ * - Current language indicator with globe icon
+ * - Smooth transition animations
+ * - Mobile-responsive design
+ * - Keyboard accessible
+ * 
+ * Issue #586: 语言切换功能实现
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Dropdown, Button, Space, Tooltip } from '@arco-design/web-react';
+import {
+  IconLanguage,
+  IconCheck,
+} from '@arco-design/web-react/icon';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useLocaleContext, useLanguage, SupportedLanguage, SUPPORTED_LANGUAGES } from '../i18n/mod';
+import { useAuth } from '../hooks/useAuth';
+import { useTranslation } from 'react-i18next';
+import './LanguageSwitcher.css';
+
+interface LanguageSwitcherProps {
+  /** Compact mode for mobile view */
+  compact?: boolean;
+  /** Show as icon-only button */
+  iconOnly?: boolean;
+}
+
+/**
+ * Language Switcher Component
+ */
+export function LanguageSwitcher({ compact = false, iconOnly = false }: LanguageSwitcherProps) {
+  const { currentLanguage, changeLanguage, supportedLanguages } = useLocaleContext();
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated } = useAuth();
+  const [isChanging, setIsChanging] = useState(false);
+
+  // Handle language change
+  const handleLanguageChange = useCallback(async (lang: SupportedLanguage) => {
+    if (lang === currentLanguage || isChanging) return;
+
+    setIsChanging(true);
+    try {
+      await changeLanguage(lang);
+
+      // Update URL with lang parameter
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.set('lang', lang);
+      navigate(
+        { pathname: location.pathname, search: searchParams.toString() },
+        { replace: true }
+      );
+
+      // Save to user preferences if logged in
+      if (isAuthenticated) {
+        try {
+          await fetch('/api/user/preferences', {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ language: lang }),
+          });
+        } catch (error) {
+          console.warn('Failed to save language preference to server:', error);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to change language:', error);
+    } finally {
+      setIsChanging(false);
+    }
+  }, [currentLanguage, isChanging, changeLanguage, location, navigate, isAuthenticated]);
+
+  // Build dropdown menu items
+  const menuItems = supportedLanguages.map(lang => ({
+    key: lang.code,
+    label: (
+      <div className="language-option">
+        <span className="language-option__name">{lang.nativeName}</span>
+        <span className="language-option__native">{lang.name}</span>
+        {currentLanguage === lang.code && (
+          <IconCheck className="language-option__check" />
+        )}
+      </div>
+    ),
+    onClick: () => handleLanguageChange(lang.code),
+  }));
+
+  // Get current language display name
+  const currentLangInfo = SUPPORTED_LANGUAGES[currentLanguage] || SUPPORTED_LANGUAGES['zh-CN'];
+
+  // Button content based on mode
+  const buttonContent = iconOnly ? (
+    <IconLanguage />
+  ) : compact ? (
+    <IconLanguage />
+  ) : (
+    <Space size={4}>
+      <IconLanguage />
+      <span className="language-switcher__label">{currentLangInfo.nativeName}</span>
+    </Space>
+  );
+
+  return (
+    <Dropdown
+      trigger="click"
+      position="bottomRight"
+      droplist={
+        <div className="language-dropdown">
+          <div className="language-dropdown__header">
+            {t('language.switchTo')}
+          </div>
+          <div className="language-dropdown__options">
+            {menuItems.map(item => (
+              <div
+                key={item.key}
+                className={`language-option ${currentLanguage === item.key ? 'language-option--active' : ''}`}
+                onClick={item.onClick}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    item.onClick();
+                  }
+                }}
+              >
+                {item.label}
+              </div>
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <Tooltip content={t('language.switchTo')} position="bottom">
+        <Button
+          type="text"
+          className={`language-switcher ${isChanging ? 'language-switcher--changing' : ''}`}
+          loading={isChanging}
+          aria-label={t('language.switchTo')}
+          aria-haspopup="listbox"
+        >
+          {buttonContent}
+        </Button>
+      </Tooltip>
+    </Dropdown>
+  );
+}
+
+/**
+ * Hook to sync language from URL parameter
+ * Should be used in the root component
+ */
+export function useLanguageUrlSync() {
+  const location = useLocation();
+  const { changeLanguage, currentLanguage } = useLanguage();
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const langParam = searchParams.get('lang');
+
+    if (langParam && langParam !== currentLanguage) {
+      const supportedLangs = Object.keys(SUPPORTED_LANGUAGES) as SupportedLanguage[];
+      if (supportedLangs.includes(langParam as SupportedLanguage)) {
+        changeLanguage(langParam as SupportedLanguage);
+      }
+    }
+  }, [location.search, currentLanguage, changeLanguage]);
+}
+
+/**
+ * Hook to sync language with user preferences on login
+ */
+export function useLanguageUserSync() {
+  const { isAuthenticated, user } = useAuth();
+  const { changeLanguage, currentLanguage } = useLanguage();
+
+  useEffect(() => {
+    // When user logs in, fetch their language preference
+    if (isAuthenticated && user) {
+      const savedLang = localStorage.getItem('i18nextLng');
+      // Prefer the server-side preference if available
+      // For now, we'll keep the localStorage preference
+      // This can be enhanced later with a user preferences API
+    }
+  }, [isAuthenticated, user, changeLanguage, currentLanguage]);
+}
+
+export default LanguageSwitcher;

--- a/src/client/i18n/hooks.ts
+++ b/src/client/i18n/hooks.ts
@@ -6,7 +6,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { useCallback, useMemo } from 'react';
-import { i18n, SupportedLanguage, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '../i18n';
+import i18n, { SupportedLanguage, SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './index';
 
 // Re-export useTranslation from react-i18next for convenience
 export { useTranslation } from 'react-i18next';

--- a/src/client/i18n/index.ts
+++ b/src/client/i18n/index.ts
@@ -170,8 +170,10 @@ i18n
     },
     
     // Language detection configuration
+    // Issue #586: Added querystring support for URL parameter ?lang=en
     detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
+      order: ['querystring', 'localStorage', 'navigator', 'htmlTag'],
+      lookupQuerystring: 'lang',
       lookupLocalStorage: 'i18nextLng',
       caches: ['localStorage'],
     },

--- a/src/client/i18n/mod.ts
+++ b/src/client/i18n/mod.ts
@@ -10,7 +10,10 @@ export { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from './index';
 export type { SupportedLanguage } from './index';
 
 // Locale Provider for React apps
-export { LocaleProvider, LanguageSwitcher, useLocaleContext } from './LocaleProvider';
+export { LocaleProvider, useLocaleContext } from './LocaleProvider';
+
+// Language Switcher component (Issue #586)
+export { LanguageSwitcher } from '../components/LanguageSwitcher';
 
 // Hooks for translations and formatting
 export {


### PR DESCRIPTION
## Summary
Implements Issue #586: 语言切换功能实现

### Features Implemented

#### 1. Language Switcher Component
- Dropdown-based UI with smooth fade-in animations
- Globe icon with current language display
- Support for **zh-CN (简体中文)** and **en-US (English)**
- Shows current selected language with checkmark indicator

#### 2. Language Persistence
- **localStorage persistence**: Already working via i18next-browser-languagedetector
- **User preference sync**: Prepared for backend sync (API call on language change for authenticated users)

#### 3. Language Detection
- Browser language detection (navigator)
- localStorage preference
- **URL parameter support**: `?lang=en-US` or `?lang=zh-CN`
- Fallback to zh-CN for unsupported languages

#### 4. Responsive Design
- Desktop: Full dropdown with language names
- Mobile: Compact icon-only button
- Smooth transitions and animations

#### 5. Accessibility
- Keyboard navigation support
- ARIA labels and roles
- Reduced motion support

### Test Plan
- [x] Build passes
- [x] i18n tests pass
- [ ] Manual testing on preview deployment

### Acceptance Criteria Checklist
- [x] 语言切换器组件可用
- [x] 切换语言后全站更新
- [x] 语言偏好持久化
- [ ] 已登录用户语言偏好同步到服务器 (prepared, needs backend API)