### PR TITLE
fix: Add LanguageSwitcher and ThemeToggle to landing page header

### DIFF
--- a/src/client/pages/LandingPage.css
+++ b/src/client/pages/LandingPage.css
@@ -1103,3 +1103,87 @@
     border: 2px solid currentColor;
   }
 }
+
+/* ============================================
+   Landing Header
+   Issue #595: Language Switcher on landing page
+   ============================================ */
+
+.landing-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-3) var(--spacing-6);
+  background: var(--color-bg-1);
+  border-bottom: 1px solid var(--color-border-1);
+  backdrop-filter: blur(12px);
+  transition: all var(--duration-200) var(--ease-in-out);
+}
+
+.dark .landing-header {
+  background: rgba(23, 23, 23, 0.9);
+}
+
+.landing-header__logo {
+  display: flex;
+  align-items: center;
+}
+
+.landing-header__brand {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-secondary-500) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  cursor: pointer;
+  transition: opacity var(--duration-150) var(--ease-in-out);
+}
+
+.landing-header__brand:hover {
+  opacity: 0.85;
+}
+
+.landing-header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.landing-header__login {
+  color: var(--color-text-2);
+  font-weight: var(--font-weight-medium);
+}
+
+.landing-header__login:hover {
+  color: var(--color-primary);
+}
+
+.landing-header__register {
+  font-weight: var(--font-weight-medium);
+}
+
+/* Adjust hero section to account for fixed header */
+.hero-section {
+  padding-top: calc(var(--spacing-12) + 60px);
+}
+
+/* Mobile styles for landing header */
+@media (max-width: 768px) {
+  .landing-header {
+    padding: var(--spacing-2) var(--spacing-4);
+  }
+
+  .landing-header__brand {
+    font-size: var(--font-size-lg);
+  }
+
+  .hero-section {
+    padding-top: calc(var(--spacing-8) + 56px);
+  }
+}

--- a/src/client/pages/LandingPage.tsx
+++ b/src/client/pages/LandingPage.tsx
@@ -48,6 +48,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useSEO, PAGE_SEO_CONFIGS } from '../hooks/useSEO';
 import { useTranslation } from 'react-i18next';
+import ThemeToggle from '../components/ThemeToggle';
+import { LanguageSwitcher } from '../components/LanguageSwitcher';
 import './LandingPage.css';
 
 const { Title, Text, Paragraph } = Typography;
@@ -317,6 +319,42 @@ const LandingPage: React.FC = () => {
 
   return (
     <div className="landing-page">
+      {/* ============================================ */}
+      {/* Landing Header with Language Switcher and Theme Toggle */}
+      {/* Issue #595: Add Language Switcher to landing page */}
+      {/* ============================================ */}
+      <header className="landing-header">
+        <div className="landing-header__logo">
+          <span className="landing-header__brand" onClick={() => navigate('/')}>
+            AlphaArena
+          </span>
+        </div>
+        <div className="landing-header__actions">
+          <LanguageSwitcher compact={isMobile} />
+          <ThemeToggle compact={isMobile} />
+          {!isMobile && (
+            <>
+              <Button
+                type="text"
+                size="small"
+                onClick={() => navigate('/login')}
+                className="landing-header__login"
+              >
+                {t('common.button.login', { ns: 'common', defaultValue: '登录' })}
+              </Button>
+              <Button
+                type="primary"
+                size="small"
+                onClick={handleRegister}
+                className="landing-header__register"
+              >
+                {t('common.button.register', { ns: 'common', defaultValue: '注册' })}
+              </Button>
+            </>
+          )}
+        </div>
+      </header>
+
       {/* ============================================ */}
       {/* Hero Section */}
       {/* ============================================ */}


### PR DESCRIPTION
## Summary

Fixes #595, #596

### Problem
Language Switcher and Theme Toggle buttons were not visible on the landing page. Users could not:
- Switch between zh-CN and en-US languages (#595)
- Toggle between light/dark themes (#596)

### Root Cause
The landing page is a standalone marketing page that does not use the MainLayout component. The MainLayout contains the header with LanguageSwitcher and ThemeToggle, but AppLayout skips MainLayout for public routes (`/`, `/landing`, `/login`, `/register`).

### Solution
Added a minimal fixed header to the LandingPage component that includes:
- AlphaArena brand logo (clickable, navigates to home)
- LanguageSwitcher component (Issue #595)
- ThemeToggle component (Issue #596)
- Login and Register buttons (desktop only)

The header is styled to match the landing page's modern design with:
- Fixed positioning at top
- Backdrop blur effect
- Gradient branding for the logo
- Responsive design (compact on mobile)

### Testing
- Build succeeded without errors
- Header displays correctly on landing page
- LanguageSwitcher dropdown works
- ThemeToggle works
- Responsive on mobile devices

### Screenshot
The header appears at the top of the landing page with the language switcher and theme toggle visible.