### PR TITLE
fix(i18n): Correct translation key syntax in LandingPage

### DIFF
--- a/src/client/pages/LandingPage.tsx
+++ b/src/client/pages/LandingPage.tsx
@@ -104,7 +104,8 @@ const LandingPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { isAuthenticated, isLoading } = useAuth();
-  const { t } = useTranslation('landing');
+  // Use both 'landing' and 'common' namespaces for translations
+  const { t } = useTranslation(['landing', 'common']);
   const [isMobile, setIsMobile] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [animateStats, setAnimateStats] = useState(false);
@@ -340,7 +341,7 @@ const LandingPage: React.FC = () => {
                 onClick={() => navigate('/login')}
                 className="landing-header__login"
               >
-                {t('common.button.login', { ns: 'common', defaultValue: '登录' })}
+                {t('common:button.login')}
               </Button>
               <Button
                 type="primary"
@@ -348,7 +349,7 @@ const LandingPage: React.FC = () => {
                 onClick={handleRegister}
                 className="landing-header__register"
               >
-                {t('common.button.register', { ns: 'common', defaultValue: '注册' })}
+                {t('common:button.register')}
               </Button>
             </>
           )}
@@ -430,7 +431,7 @@ const LandingPage: React.FC = () => {
                     </Button>
                   </Tooltip>
                 ))}
-                <Tooltip content={t('common.button.copy', { ns: 'common' })}>
+                <Tooltip content={t('common:button.copy')}>
                   <Button
                     shape="circle"
                     size="large"


### PR DESCRIPTION
## 问题
Issue #608 仍未完全修复。语言切换后，LandingPage 的登录/注册按钮仍显示中文。

## 根本原因
LandingPage.tsx 中使用了错误的 i18n 翻译键语法：
```tsx
const { t } = useTranslation('landing');
// ...
{t('common.button.login', { ns: 'common', defaultValue: '登录' })}
```

这种方式**不会正确从 `common` 命名空间获取翻译**，因为 `t` 函数只绑定到 `landing` 命名空间。

## 修复内容
1. 修改 `useTranslation('landing')` 为 `useTranslation(['landing', 'common'])`
2. 修复翻译键语法：`t('common.button.login', {ns:'common'})` → `t('common:button.login')`

## 测试
- 所有 LandingPage 相关测试通过（41 tests）

## 相关 Issue
Fixes #608