### PR TITLE
fix: P0 - Frontend Supabase client using wrong environment variables

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -22,4 +22,5 @@ VITE_SUPABASE_URL=https://plnylmnckssnfpwznpwf.supabase.co
 
 # ⚠️ SECURITY: Configure in Vercel Dashboard!
 # Get from: Supabase Dashboard → Settings → API → Project API keys (anon public)
-VITE_SUPABASE_ANON_KEY=
+# This is REQUIRED for frontend Supabase client to work
+# VITE_SUPABASE_ANON_KEY=your-anon-key-here

--- a/src/client/hooks/__tests__/useNotifications.test.ts
+++ b/src/client/hooks/__tests__/useNotifications.test.ts
@@ -5,11 +5,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useNotifications } from '../useNotifications';
-import { getSupabaseClient } from '../../../database/client';
+import { getFrontendSupabaseClient } from '../../utils/supabaseClient';
 
 // Mock supabase
-vi.mock('../../../database/client', () => ({
-  getSupabaseClient: vi.fn(),
+vi.mock('../../utils/supabaseClient', () => ({
+  getFrontendSupabaseClient: vi.fn(),
 }));
 
 // Mock fetch
@@ -27,7 +27,7 @@ const mockSupabase = {
 };
 
 // Setup mock
-vi.mocked(getSupabaseClient).mockReturnValue(mockSupabase as any);
+vi.mocked(getFrontendSupabaseClient).mockReturnValue(mockSupabase as any);
 
 describe('useNotifications Hook', () => {
   const mockUserId = 'user-123';

--- a/src/client/hooks/useNotifications.ts
+++ b/src/client/hooks/useNotifications.ts
@@ -4,9 +4,9 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { getSupabaseClient } from '../../database/client.js';
+import { getFrontendSupabaseClient } from '../utils/supabaseClient';
 
-const supabase = getSupabaseClient();
+const supabase = getFrontendSupabaseClient();
 
 export type NotificationType = 'SIGNAL' | 'RISK' | 'PERFORMANCE' | 'SYSTEM';
 export type NotificationPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';

--- a/src/client/utils/supabaseClient.ts
+++ b/src/client/utils/supabaseClient.ts
@@ -1,0 +1,57 @@
+/**
+ * Frontend Supabase Client
+ * 
+ * This is a frontend-specific Supabase client that uses Vite environment variables.
+ * It's separate from the server-side client in src/database/client.ts which uses process.env.
+ * 
+ * Used for:
+ * - Auth session management (getSession)
+ * - Realtime subscriptions
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { validateConfig } from './config';
+
+let frontendSupabaseClient: SupabaseClient | null = null;
+
+/**
+ * Get the frontend Supabase client
+ * Uses VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY environment variables
+ */
+export function getFrontendSupabaseClient(): SupabaseClient {
+  if (!frontendSupabaseClient) {
+    const config = validateConfig();
+    const supabaseUrl = config.supabaseUrl;
+    const supabaseAnonKey = config.supabaseAnonKey;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      console.error('[FrontendSupabaseClient] Missing Supabase configuration');
+      console.error('[FrontendSupabaseClient] VITE_SUPABASE_URL:', supabaseUrl || 'missing');
+      console.error('[FrontendSupabaseClient] VITE_SUPABASE_ANON_KEY:', supabaseAnonKey ? 'present' : 'missing');
+      
+      // Return a dummy client that won't crash but won't work
+      // This allows the app to load even if Supabase is not configured
+      frontendSupabaseClient = createClient('https://placeholder.supabase.co', 'placeholder-key', {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+        },
+      });
+      return frontendSupabaseClient;
+    }
+
+    frontendSupabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        storage: typeof window !== 'undefined' ? window.localStorage : undefined,
+      },
+    });
+    
+    console.log('[FrontendSupabaseClient] Client initialized successfully');
+  }
+
+  return frontendSupabaseClient;
+}
+
+export default getFrontendSupabaseClient;


### PR DESCRIPTION
## Summary

Fixes #686 - Registration page showing 'Registration is currently disabled'

### Root Cause Analysis

The useNotifications.ts hook imported the server-side Supabase client which uses process.env variables that are NOT available in Vite frontend builds.

### Changes

1. New file: src/client/utils/supabaseClient.ts - Frontend-specific Supabase client using Vite env vars
2. Updated: src/client/hooks/useNotifications.ts - Changed to use frontend client
3. Updated: Tests to match new imports
4. Updated: .env.production documentation

### Verification

- Build succeeds
- TypeScript compiles cleanly
- API endpoint works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the browser initializes Supabase auth/realtime for notifications; misconfiguration of `VITE_SUPABASE_*` will now degrade to a dummy client and could hide failures at runtime.
> 
> **Overview**
> Fixes frontend notifications/auth relying on the server Supabase client by introducing a dedicated `getFrontendSupabaseClient()` that reads Vite `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` and is used by `useNotifications`.
> 
> Updates the `useNotifications` hook test to mock the new client, and adjusts `.env.production` to document that `VITE_SUPABASE_ANON_KEY` must be set (without committing a value).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d9b2db4501ad50e2d6d9881492715c5abcb9716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->