### PR TITLE
fix: prevent static assets from being rewritten to index.html (Issue #691)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -80,7 +80,7 @@
       "destination": "/socket.io/$1"
     },
     {
-      "source": "/:path*",
+      "source": "/((?!api|socket.io|assets|docs|public).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## Summary

Fixes #691 - Production /strategies route crashes server with ERR_CONNECTION_CLOSED

## Root Cause

The rewrite rule `/:path*" -> "/index.html" was matching ALL paths, including static assets like `/assets/index-xxx.js`. This caused all static files (JS, CSS, images) to return `index.html` instead of the actual file content, breaking the application.

When the browser tried to load JavaScript files, it received HTML content instead, which caused:
- JavaScript parsing errors
- Application failed to initialize
- Server connection appeared to "crash" (actually the app just failed to load)

## Fix

Changed the SPA fallback rewrite to use a negative lookahead pattern that excludes static asset paths:
- `/api/*` - API routes (handled by other rewrites)
- `/socket.io/*` - WebSocket routes
- `/assets/*` - Static assets (JS, CSS, images)
- `/docs/*` - API documentation
- `/public/*` - Public resources

The new pattern `/((?!api|socket.io|assets|docs|public).*)` ensures:
- SPA routes like `/strategies` -> `/index.html` (correct)
- Static files like `/assets/index.js` -> actual file (fixed)
- API routes -> Supabase Edge Functions (unchanged)

## Verification

- Local build: ✅ Passed
- Local preview: ✅ `/strategies` returns correct `index.html`
- Static assets: ✅ `/assets/index.js` returns correct JS file

## Impact

- **P0 Critical Fix**: This resolves a production-blocking issue
- **No Breaking Changes**: Only modifies Vercel routing configuration
- **All Routes Fixed**: The fix applies to all SPA routes, not just `/strategies`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it affects routing: an incorrect regex could break SPA navigation or unexpectedly bypass the `index.html` fallback for some paths.
> 
> **Overview**
> Updates the Vercel SPA fallback rewrite to stop rewriting *all* routes to `index.html`.
> 
> Replaces the catch-all `/:path*` rule with a negative-lookahead pattern (`/((?!api|socket.io|assets|docs|public).*)`) so static assets and non-SPA endpoints (e.g., `/assets/*`, `/api/*`, `/socket.io/*`) are served directly while client-side routes still fall back to `index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d52eaefe1b355d2de6bcf0d28d4bdedc4c9b551d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->