### PR TITLE
fix: revert acceptance test URLs to alphaarena-eight.vercel.app

### DIFF
--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -2,7 +2,7 @@ web:
   # Production URL for automated smoke tests
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
   # Network idle configuration for apps with WebSocket connections
   # The production site has WebSocket connections (Supabase Realtime) for real-time market data
   # These keep the network active, so we need a longer timeout and continue on network idle errors

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "首页可访问性测试"


### PR DESCRIPTION
## Problem
PR #709 incorrectly changed test URLs from `alphaarena-eight.vercel.app` to `alphaarena.app`.

However, `alphaarena.app` points to a Squarespace placeholder page, not the actual application!

## Root Cause
The scheduler indicates the correct Vercel deployment is at:
- ✅ **Correct**: `https://alphaarena-eight.vercel.app` → Actual Vercel deployment
- ❌ **Wrong**: `https://alphaarena.app` → Squarespace placeholder

## Fix
Reverted all acceptance test YAML files to use the correct Vercel deployment URL.

## Files Changed
- `.virtucorp/acceptance/registration-test-yaml.yaml`
- `.virtucorp/acceptance/smoke-test-full-yaml.yaml`
- `.virtucorp/acceptance/smoke-test.yaml`
- `.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml`
- `.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml`
- `.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml`
- `.virtucorp/acceptance/sprint54-acceptance-yaml.yaml`

## Impact
Tests will now run against the real application deployment instead of the Squarespace placeholder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates test configuration URLs with no production code changes. Main impact is which environment the automated acceptance/smoke tests run against.
> 
> **Overview**
> Updates all `.virtucorp/acceptance/*.yaml` suites to use `https://alphaarena-eight.vercel.app` instead of `https://alphaarena.app` as the base `web.url`, ensuring acceptance and smoke tests run against the actual Vercel-hosted app rather than the placeholder domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea55c113c3cfc4513a3ac2f0117bc5288a2a75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->