### PR TITLE
fix: update acceptance test URLs to correct production deployment

### DIFF
--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -2,7 +2,7 @@ web:
   # Production URL for automated smoke tests
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
   # Network idle configuration for apps with WebSocket connections
   # The production site has WebSocket connections (Supabase Realtime) for real-time market data
   # These keep the network active, so we need a longer timeout and continue on network idle errors

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "首页可访问性测试"

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775853467060,
+    "timestamp": 1775860667131,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775876866673,
+    "digestHash": "spawn_qa|prs:1|ready:0|complete",
+    "timestamp": 1775877466620,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775860667131,
+    "timestamp": 1775869666607,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775869666607,
+    "timestamp": 1775876866673,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,


### PR DESCRIPTION
## Summary
- Updated all 7 acceptance test YAML files to use the correct production deployment URL
- Changed from `https://alphaarena.app` to `https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app`
- This is the latest production deployment from commit fd73aad

## Files Updated
- smoke-test.yaml
- smoke-test-full-yaml.yaml
- registration-test-yaml.yaml
- sprint-51-acceptance-yaml.yaml
- sprint-51-full-acceptance-yaml.yaml
- sprint-54-acceptance-yaml.yaml
- sprint54-acceptance-yaml.yaml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test configuration (base URLs) and scheduler state metadata, with no production code or data-path modifications.
> 
> **Overview**
> Updates Virtucorp acceptance/smoke test configs to run against a new production Vercel deployment by changing the `web.url` in seven YAML suites from `alphaarena-eight.vercel.app` to `alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app`.
> 
> Refreshes `.virtucorp/scheduler-state.json` `lastDispatch` metadata (new `digestHash` and `timestamp`) to reflect the latest scheduler run state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064ccf2bf58a5a0846549c76115bef6c0235d20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->