### PR TITLE
fix: update acceptance test URLs to stable production deployment

### DIFF
--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -2,7 +2,7 @@ web:
   # Production URL for automated smoke tests
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
   # Network idle configuration for apps with WebSocket connections
   # The production site has WebSocket connections (Supabase Realtime) for real-time market data
   # These keep the network active, so we need a longer timeout and continue on network idle errors

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -2,7 +2,7 @@ web:
   # Production URL for automated smoke tests
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
   # Network idle configuration for apps with WebSocket connections
   # The production site has WebSocket connections (Supabase Realtime) for real-time market data
   # These keep the network active, so we need a longer timeout and continue on network idle errors

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
+  url: "https://alphaarena-eight.vercel.app"
 
 tasks:
   - name: "首页可访问性测试"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena.app"
+  url: "https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "首页可访问性测试"

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775853467060,
+    "timestamp": 1775860667131,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775860667131,
+    "timestamp": 1775869666607,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775869666607,
+    "timestamp": 1775876866673,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1775876866673,
+    "digestHash": "spawn_dev|prs:0|ready:1|complete",
+    "timestamp": 1775878666653,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,


### PR DESCRIPTION
## Problem
The previous URL `https://alphaarena-kzzp6nxq1-gxcsoccer-s-team.vercel.app` was a temporary Vercel preview that expired.

## Solution
Updated to the stable production URL: `https://alphaarena-eight.vercel.app`

This URL is:
- Set as the GitHub repository homepage
- Verified to be working with the actual AlphaArena app
- Stable (won't expire after each deployment)

## Files Updated
- registration-test-yaml.yaml
- smoke-test-full-yaml.yaml
- smoke-test.yaml
- sprint-51-acceptance-yaml.yaml
- sprint-51-full-acceptance-yaml.yaml
- sprint-54-acceptance-yaml.yaml
- sprint54-acceptance-yaml.yaml

## Verification
All 7 acceptance test YAML files now point to the stable production URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change affecting where automated acceptance/smoke tests run; main risk is unintended testing against the wrong environment if the target URL is incorrect.
> 
> **Overview**
> Updates all Virtucorp acceptance/smoke test YAML configs to use the stable production deployment URL (`https://alphaarena-eight.vercel.app`) instead of an expired Vercel preview URL.
> 
> Also refreshes `.virtucorp/scheduler-state.json` `lastDispatch` metadata (digest hash/timestamp) to reflect the latest scheduler run state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5285714f0c418e4a2ca34642627969b498c3b70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->