### PR TITLE
fix: update smoke test URLs to valid production URL

### DIFF
--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -2,7 +2,7 @@ web:
   # Production URL for automated smoke tests
   # For local testing, run: npm run build && npm run preview
   # Then override with: url: "http://localhost:4173"
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
   # Network idle configuration for apps with WebSocket connections
   # The production site has WebSocket connections (Supabase Realtime) for real-time market data
   # These keep the network active, so we need a longer timeout and continue on network idle errors

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,5 +1,5 @@
 web:
-  url: "https://alphaarena-eight.vercel.app"
+  url: "https://alphaarena.app"
 
 tasks:
   - name: "首页可访问性测试"


### PR DESCRIPTION
## Summary
- Fix Issue #721
- Updated all acceptance test yaml files to use `https://alphaarena.app` instead of the invalid `https://alphaarena-eight.vercel.app`

## Files Updated (7 files)
- `smoke-test.yaml`
- `smoke-test-full-yaml.yaml`
- `registration-test-yaml.yaml`
- `sprint-51-acceptance-yaml.yaml`
- `sprint-51-full-acceptance-yaml.yaml`
- `sprint-54-acceptance-yaml.yaml`
- `sprint54-acceptance-yaml.yaml`

## Testing
This is a simple configuration fix. Once alphaarena.app DNS is properly configured, smoke tests will work correctly.

Fixes #721

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a pure test configuration change, only altering the base URL used by automated acceptance runs.
> 
> **Overview**
> Updates all `.virtucorp/acceptance/*.yaml` suites (smoke, registration, and sprint acceptance) to use `https://alphaarena.app` instead of the old `https://alphaarena-eight.vercel.app` base URL, ensuring automated runs target the valid production site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac52e040526794b7e60738fdf0c633bfc32cbc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->