### PR TITLE
fix(auth): correct JWT signature generation for registration/login

### DIFF
--- a/supabase/functions/auth/index.ts
+++ b/supabase/functions/auth/index.ts
@@ -39,7 +39,7 @@ function base64UrlEncode(str: string): string {
   return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 
-function generateJWT(payload: any, secret: string, expiresIn: string): string {
+async function generateJWT(payload: any, secret: string, expiresIn: string): Promise<string> {
   const header = { alg: 'HS256', typ: 'JWT' };
   const now = Math.floor(Date.now() / 1000);
   const exp = now + parseExpiresIn(expiresIn);
@@ -49,7 +49,7 @@ function generateJWT(payload: any, secret: string, expiresIn: string): string {
   const encodedHeader = base64UrlEncode(JSON.stringify(header));
   const encodedPayload = base64UrlEncode(JSON.stringify(jwtPayload));
   
-  const signature = hmacSha256(`${encodedHeader}.${encodedPayload}`, secret);
+  const signature = await hmacSha256(`${encodedHeader}.${encodedPayload}`, secret);
   
   return `${encodedHeader}.${encodedPayload}.${signature}`;
 }
@@ -264,7 +264,7 @@ Deno.serve(async (req: Request) => {
       console.log(`User registered: ${user.email}`);
 
       // Generate tokens
-      const accessToken = generateJWT(
+      const accessToken = await generateJWT(
         { userId: user.id, email: user.email, role: user.role },
         JWT_SECRET,
         JWT_EXPIRES_IN
@@ -399,7 +399,7 @@ Deno.serve(async (req: Request) => {
         .eq('id', user.id);
 
       // Generate tokens
-      const accessToken = generateJWT(
+      const accessToken = await generateJWT(
         { userId: user.id, email: user.email, role: user.role },
         JWT_SECRET,
         JWT_EXPIRES_IN
@@ -498,7 +498,7 @@ Deno.serve(async (req: Request) => {
       }
 
       // Generate new access token
-      const accessToken = generateJWT(
+      const accessToken = await generateJWT(
         { userId: user.id, email: user.email, role: user.role },
         JWT_SECRET,
         JWT_EXPIRES_IN


### PR DESCRIPTION
## Problem
Registration flow was broken - after form submission, users remained on the registration page and could not be redirected to the trading interface.

## Root Cause
The `generateJWT` function in Supabase Edge Function was calling `hmacSha256` without `await`. Since `hmacSha256` is an async function that returns `Promise<string>`, the JWT signature became `[object Promise]` instead of an actual signature string.

Example of broken JWT:
```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ...}.[object Promise]
```

This invalid JWT caused authentication to fail silently.

## Fix
1. Made `generateJWT` async (returns `Promise<string>`)
2. Added `await` when calling `hmacSha256`
3. Added `await` at all three call sites:
   - Register endpoint
   - Login endpoint
   - Refresh token endpoint

## Testing
Local testing shows JWT is now properly generated with a valid hex signature.

## Impact
- Fixes #746
- Users can now complete registration and be redirected to the trading page
- Login and token refresh also benefit from this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JWT creation in the auth edge function; while the change is small, mistakes here would break login/registration or produce invalid tokens.
> 
> **Overview**
> Fixes invalid JWTs being issued by making `generateJWT` async and awaiting `hmacSha256`, so the signature is a real digest instead of a Promise string.
> 
> Updates the register, login, and refresh-token handlers to `await generateJWT` when issuing access tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7dff16a66908b8c59d55f7ad213a28abd3dc4ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->