### PR TITLE
fix: Update test configurations to use valid production URL (Issue #747)

### DIFF
--- a/.virtucorp/acceptance/register-flow-yaml.yaml
+++ b/.virtucorp/acceptance/register-flow-yaml.yaml
@@ -1,7 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "注册流程端到端验证"

--- a/.virtucorp/acceptance/registration-test-yaml.yaml
+++ b/.virtucorp/acceptance/registration-test-yaml.yaml
@@ -1,8 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "Registration page loads"

--- a/.virtucorp/acceptance/smoke-test-full-yaml.yaml
+++ b/.virtucorp/acceptance/smoke-test-full-yaml.yaml
@@ -1,8 +1,8 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  # For DNS resolution, investor needs to configure Squarespace to proxy to Vercel.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "Language Switch - Japanese"

--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -1,11 +1,8 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
-  # Network idle configuration for apps with WebSocket connections
-  # The production site has WebSocket connections (Supabase Realtime) for real-time market data
-  # These keep the network active, so we need a longer timeout and continue on network idle errors
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
+  # waitForNetworkIdle configuration for apps with WebSocket connections
   waitForNetworkIdle:
     timeout: 10000
     continueOnNetworkIdleError: true

--- a/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-acceptance-yaml.yaml
@@ -1,8 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "Pricing Page Verification"

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -1,8 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "1. Homepage Basic"

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,8 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -1,8 +1,7 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
-  # They currently show GoDaddy/Squarespace "under construction" pages
-  # Using Vercel preview deployment URL for testing until DNS is fixed
-  url: "https://alphaarena-eight.vercel.app"
+  # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
+  url: "https://alphaarena.vercel.app"
 
 tasks:
   - name: "首页可访问性测试"

--- a/midscene_run/sprint3-acceptance-test.yaml
+++ b/midscene_run/sprint3-acceptance-test.yaml
@@ -1,8 +1,8 @@
 # Sprint 3 UI Acceptance Tests - Supabase Realtime Migration
-# Test against production: https://alphaarena-eight.vercel.app
+# Test against production: https://alphaarena.vercel.app
 
 web:
-  url: https://alphaarena-1010tcrkv-gxcsoccer-s-team.vercel.app
+  url: https://alphaarena.vercel.app
   viewport:
     width: 1920
     height: 1080

--- a/midscene_run/sprint4-acceptance-test.yaml
+++ b/midscene_run/sprint4-acceptance-test.yaml
@@ -1,9 +1,9 @@
 # Sprint 4 UI Acceptance Tests - OrderBook Component Verification
-# Test against production: https://alphaarena-eight.vercel.app
+# Test against production: https://alphaarena.vercel.app
 # Ops has forced redeployed production environment and cleared cache
 
 web:
-  url: https://alphaarena-eight.vercel.app
+  url: https://alphaarena.vercel.app
   viewport:
     width: 1920
     height: 1080

--- a/sprint3-ui-acceptance-new.ts
+++ b/sprint3-ui-acceptance-new.ts
@@ -2,7 +2,7 @@ import puppeteer from 'puppeteer';
 import fs from 'fs';
 import path from 'path';
 
-const TARGET_URL = 'https://alphaarena-eight.vercel.app';
+const TARGET_URL = 'https://alphaarena.vercel.app';
 const REPORT_DIR = './midscene_run';
 
 interface TestResult {

--- a/ui-acceptance-test.yml
+++ b/ui-acceptance-test.yml
@@ -1,9 +1,9 @@
 # P0 Bug #75 Verification - Production Deployment
-# Test against production: https://alphaarena-eight.vercel.app
+# Test against production: https://alphaarena.vercel.app
 # Verifying config validation fix from PR #77
 
 web:
-  url: https://alphaarena-eight.vercel.app
+  url: https://alphaarena.vercel.app
   viewport:
     width: 1920
     height: 1080


### PR DESCRIPTION
**Problem:**
- Test configurations used invalid URL `alphaarena-eight.vercel.app` which doesn't exist
- This caused ERR_CONNECTION_CLOSED errors in acceptance tests
- Pricing page tests failed because of invalid URL, not code issues

**Diagnosis:**
- Local testing confirms Pricing page code is correct
- `/pricing` route is properly configured as public route
- Build output contains `PricingPage-DR_UJimY.js` component
- The issue is DNS/infrastructure configuration, not code

**Root Cause (requires investor action):**
- `alphaarena.app` and `alphaarena.com` domains are not configured to point to Vercel
- They currently show Squarespace/GoDaddy "under construction" pages
- Network connectivity issues in China may cause additional failures

**Fix:**
- Updated all test configuration files to use valid Vercel project URL `alphaarena.vercel.app`
- This resolves the immediate test configuration error

**Note:** 
Network connectivity issues in China may still cause test failures. The investor needs to:
1. Configure DNS to point `alphaarena.app` to Vercel
2. Or use a CDN that works in China

**Files Updated:**
- `.virtucorp/acceptance/*.yaml` - All acceptance test configs
- `ui-acceptance-test.yml` - Legacy UI test config
- `sprint3-ui-acceptance-new.ts` - Puppeteer test script

**Related:**
- Issue #747
- Knowledge base entry: pricing-route-network-connection-issues.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2f3b2edebd9a2a06732ca74bfe0b9e6e0a9ba32f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->