### PR TITLE
fix(auth): use React Router Navigate for protected route redirects (Issue #748)

### DIFF
--- a/src/client/hooks/useAuth.tsx
+++ b/src/client/hooks/useAuth.tsx
@@ -5,6 +5,7 @@
 
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { Spin } from '@arco-design/web-react';
+import { Navigate, useLocation } from 'react-router-dom';
 
 // Types
 interface User {
@@ -343,6 +344,7 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
 
   if (isLoading) {
     return (
@@ -353,24 +355,12 @@ export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   }
 
   if (!isAuthenticated) {
-    return <>{fallback || <NavigateToLogin />}</>;
+    // Use React Router's Navigate component for smooth redirection
+    // Pass the current path as redirect param so user returns after login
+    return fallback ? <>{fallback}</> : <Navigate to="/login" state={{ from: location.pathname }} replace />;
   }
 
   return <>{children}</>;
-}
-
-// Helper component to navigate to login
-function NavigateToLogin() {
-  const [navigated, setNavigated] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!navigated) {
-      setNavigated(true);
-      window.location.href = '/login';
-    }
-  }, [navigated]);
-
-  return null;
 }
 
 export default useAuth;

--- a/src/client/pages/LoginPage.tsx
+++ b/src/client/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect } from 'react';
 import { Form, Input, Button, Message, Typography, Space, Link, Grid } from '@arco-design/web-react';
 import { IconUser, IconLock } from '@arco-design/web-react/icon';
 import { useAuth } from '../hooks/useAuth';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import { useSEO, PAGE_SEO_CONFIGS } from '../hooks/useSEO';
 import { useTranslation } from 'react-i18next';
 import { Logo } from '../components/brand/Logo';
@@ -24,11 +24,15 @@ interface LoginFormValues {
 const LoginPage: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation('auth');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [remainingAttempts, setRemainingAttempts] = useState<number | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+
+  // Get the redirect path from location state (set by ProtectedRoute)
+  const redirectPath = (location.state as any)?.from || '/dashboard';
 
   // SEO: Update meta tags for login page
   useSEO(PAGE_SEO_CONFIGS.login);
@@ -51,7 +55,8 @@ const LoginPage: React.FC = () => {
 
     try {
       await login(values);
-      navigate('/dashboard');
+      // Navigate to the originally intended page or dashboard
+      navigate(redirectPath, { replace: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : t('login.error');
       setError(message);
@@ -76,6 +81,13 @@ const LoginPage: React.FC = () => {
             </Title>
             <Text type="secondary">{t('login.loginSubtitle')}</Text>
           </div>
+
+          {/* Show message if redirected from a protected page */}
+          {redirectPath !== '/dashboard' && (
+            <Message type="warning">
+              请登录以访问您请求的页面
+            </Message>
+          )}
 
           {error && (
             <Message type="error">


### PR DESCRIPTION
**Problem:**
- The strategy list page (/strategies) was crashing or causing Protocol errors
- Unauthenticated users were redirected with `window.location.href` which caused page crashes
- No clear login prompt when user was redirected

**Root Cause:**
The `NavigateToLogin` component in `useAuth.tsx` used `window.location.href` for hard redirects. This caused:
1. Page crashes during navigation (Protocol errors in UI tests)
2. No state preservation - user couldn't return to original page after login
3. Poor UX - no explanation of why user was redirected

**Fix:**
1. Replace `window.location.href` with React Router's `Navigate` component
2. Pass the original path via `location.state` so user returns after login
3. Add warning message on login page: "请登录以访问您请求的页面" (Please login to access requested page)
4. Use `replace` option to avoid creating extra history entry

**Testing:**
- `npm run build` succeeds with no errors
- TypeScript compilation passes (`npx tsc --noEmit`)
- Code changes are minimal and targeted

**Impact:**
- Unauthenticated users now see a clear login prompt
- Login redirect is smooth and doesn't cause page crashes
- After login, user is redirected back to the originally requested page
- Fixes #748

**Related:**
- This is the third P0 bug fix (#746, #747, #748)
- All three bugs were related to authentication and URL configuration issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, frontend-only change to routing behavior, but it affects the unauthenticated access flow for all protected pages and could impact redirect destinations if mis-set.
> 
> **Overview**
> Fixes protected-route redirection by replacing the hard `window.location.href` login redirect with React Router’s `Navigate`, using `replace` and passing the originally requested path via `location.state`.
> 
> Updates `LoginPage` to redirect to the stored `from` path after successful login (defaulting to `/dashboard`) and to show a warning message when the user was bounced from a protected page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6e1acb9fe70acf0bdf01d40983226760f81656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->