### PR TITLE
fix(p0): Add error handling for StrategiesPage API failures

### DIFF
--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -1,7 +1,8 @@
 web:
   # NOTE: alphaarena.com and alphaarena.app domains are not configured to point to Vercel
   # Using Vercel project URL for testing. Network connectivity issues in China may cause failures.
-  url: "https://alphaarena.vercel.app"
+  # Updated to correct production URL (verified via vercel project ls)
+  url: "https://alphaarena-gxcsoccer-s-team.vercel.app"
 
 tasks:
   - name: "首页验证"

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev_bugfix|bug:755|prs:0|ready:1|complete",
-    "timestamp": 1778017712682,
+    "digestHash": "spawn_dev_bugfix|bug:755|prs:1|ready:1|complete",
+    "timestamp": 1778018312680,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:755|prs:1|ready:1|complete",
-    "timestamp": 1778018312680,
-    "consecutiveCount": 1
+    "timestamp": 1778020112701,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/public/locales/en-US/strategy.json
+++ b/public/locales/en-US/strategy.json
@@ -6,7 +6,8 @@
     "create": "Create Strategy",
     "search": "Search strategies",
     "filter": "Filter",
-    "noResults": "No strategies found"
+    "noResults": "No strategies found",
+    "loadError": "Failed to load"
   },
   "detail": {
     "title": "Strategy Detail",

--- a/public/locales/ja-JP/strategy.json
+++ b/public/locales/ja-JP/strategy.json
@@ -6,7 +6,8 @@
     "create": "ストラテジー作成",
     "search": "ストラテジーを検索",
     "filter": "フィルター",
-    "noResults": "ストラテジーが見つかりません"
+    "noResults": "ストラテジーが見つかりません",
+    "loadError": "読み込みエラー"
   },
   "detail": {
     "title": "ストラテジー詳細",

--- a/public/locales/ko-KR/strategy.json
+++ b/public/locales/ko-KR/strategy.json
@@ -6,7 +6,8 @@
     "create": "전략 생성",
     "search": "전략 검색",
     "filter": "필터",
-    "noResults": "전략을 찾을 수 없습니다"
+    "noResults": "전략을 찾을 수 없습니다",
+    "loadError": "로드 실패"
   },
   "detail": {
     "title": "전략 상세",

--- a/public/locales/zh-CN/strategy.json
+++ b/public/locales/zh-CN/strategy.json
@@ -6,7 +6,8 @@
     "create": "创建策略",
     "search": "搜索策略",
     "filter": "筛选",
-    "noResults": "暂无策略"
+    "noResults": "暂无策略",
+    "loadError": "加载失败"
   },
   "detail": {
     "title": "策略详情",

--- a/src/client/pages/StrategiesPage.tsx
+++ b/src/client/pages/StrategiesPage.tsx
@@ -24,7 +24,7 @@ interface StrategyFormValues {
 }
 
 const StrategiesPage: React.FC = () => {
-  const { strategies, loading, refresh } = useStrategies();
+  const { strategies, loading, error, refresh } = useStrategies();
   const [selectedStrategy, setSelectedStrategy] = useState<Strategy | null>(null);
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
@@ -258,6 +258,19 @@ const StrategiesPage: React.FC = () => {
             {loading ? (
               <Card style={{ textAlign: 'center', padding: 24 }} className="chart-card">
                 <Text type="secondary">{t('common:button.loading')}</Text>
+              </Card>
+            ) : error ? (
+              <Card style={{ textAlign: 'center', padding: 24 }} className="chart-card">
+                <Text type="error">{t('list.loadError')}: {error}</Text>
+                <Button 
+                  type="primary" 
+                  icon={<IconRefresh />} 
+                  onClick={refresh}
+                  size="small"
+                  style={{ marginTop: 12 }}
+                >
+                  {t('common:button.retry')}
+                </Button>
               </Card>
             ) : filteredStrategies.length === 0 ? (
               <Card style={{ textAlign: 'center', padding: 24 }} className="chart-card">
@@ -498,16 +511,31 @@ const StrategiesPage: React.FC = () => {
           bodyStyle={isTablet ? { padding: 12 } : undefined}
           className="chart-card"
         >
-          <div className={isTablet ? 'mobile-table-container' : ''}>
-            <Table
-              columns={strategyColumns}
-              dataSource={filteredStrategies}
-              rowKey="id"
-              loading={loading}
-              pagination={{ pageSize: isTablet ? 10 : 20 }}
-              scroll={isTablet ? { x: 1000 } : undefined}
-            />
-          </div>
+          {error ? (
+            <div style={{ textAlign: 'center', padding: 24 }}>
+              <Text type="error">{t('list.loadError')}: {error}</Text>
+              <Button 
+                type="primary" 
+                icon={<IconRefresh />} 
+                onClick={refresh}
+                size="small"
+                style={{ marginTop: 12 }}
+              >
+                {t('common:button.retry')}
+              </Button>
+            </div>
+          ) : (
+            <div className={isTablet ? 'mobile-table-container' : ''}>
+              <Table
+                columns={strategyColumns}
+                dataSource={filteredStrategies}
+                rowKey="id"
+                loading={loading}
+                pagination={{ pageSize: isTablet ? 10 : 20 }}
+                scroll={isTablet ? { x: 1000 } : undefined}
+              />
+            </div>
+          )}
         </Card>
 
         {/* Strategy Details Drawer */}


### PR DESCRIPTION
## Summary

This PR addresses P0 bug #755 where the /strategies page could crash when API requests failed.

### Root Cause Analysis

1. Network Issue: Vercel URLs were unreachable causing connection timeouts
2. Code Issue: StrategiesPage did not handle API errors properly - error state from useStrategies hook was unused

### Changes

1. Added error handling in StrategiesPage - shows error message with retry button
2. Fixed acceptance test URL configuration
3. Added translations for loadError message

### Testing

Build succeeded with no errors.

Fixes #755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n change that surfaces existing `useStrategies` error state and adds a retry path; main risk is minor UX/regression in strategies list rendering.
> 
> **Overview**
> Prevents the `/strategies` page from failing silently/crashing on API errors by wiring `useStrategies`'s `error` into `StrategiesPage` and rendering a **load error state** (message + Retry button calling `refresh`) for both mobile cards and desktop/tablet table views.
> 
> Adds `list.loadError` translations across `en-US`, `ja-JP`, `ko-KR`, and `zh-CN`, and updates VirtuCorp acceptance config to use the correct Vercel URL (plus an updated `.virtucorp/scheduler-state.json` dispatch record).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea60a001055dd6ff6cd06d31824fc97008423e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->