### PR TITLE
fix(test): Update acceptance test brand assertions to match APL

### DIFF
--- a/.virtucorp/acceptance/smoke-test.yaml
+++ b/.virtucorp/acceptance/smoke-test.yaml
@@ -11,7 +11,7 @@ tasks:
   - name: "Landing Page - Basic Checks"
     flow:
       - sleep: 2000
-      - aiAssert: "页面标题包含 AlphaArena 或专业级算法交易相关文字"
+      - aiAssert: "页面标题包含 APL 或专业级算法交易相关文字"
       - aiAssert: "页面有'免费注册'或 'Sign Up' 按钮"
       - aiAssert: "页面没有显示红色错误弹窗或白屏"
 

--- a/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-51-full-acceptance-yaml.yaml
@@ -7,7 +7,7 @@ tasks:
   - name: "1. Homepage Basic"
     flow:
       - sleep: 2000
-      - aiAssert: "Homepage shows AlphaArena logo and navigation"
+      - aiAssert: "Homepage shows APL logo and navigation"
   - name: "2. i18n Switch to English"
     flow:
       - sleep: 2000

--- a/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint-54-acceptance-yaml.yaml
@@ -7,7 +7,7 @@ web:
 tasks:
   - name: "首页验证"
     flow:
-      - aiAssert: "页面显示了 AlphaArena 品牌名称或 logo"
+      - aiAssert: "页面显示了 APL 品牌名称或 logo"
   - name: "策略列表页面验证"
     flow:
       - ai: "导航到 /strategies 页面"

--- a/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
+++ b/.virtucorp/acceptance/sprint54-acceptance-yaml.yaml
@@ -8,7 +8,7 @@ tasks:
     flow:
       - ai: "打开首页"
       - aiWaitFor: "页面加载完成"
-      - aiAssert: "页面显示了 AlphaArena 的标题或品牌标识"
+      - aiAssert: "页面显示了 APL 的标题或品牌标识"
       - aiAssert: "页面布局正常，没有显示错误信息"
   - name: "策略列表页面测试"
     flow:

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_pm_plan|prs:0|ready:0|complete",
-    "timestamp": 1778452396552,
+    "digestHash": "spawn_dev|prs:0|ready:1|complete",
+    "timestamp": 1778452996106,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,


### PR DESCRIPTION
## Summary
- Update brand assertions in acceptance tests from "AlphaArena" to "APL"
- Files modified:
  - smoke-test.yaml
  - sprint-51-full-acceptance-yaml.yaml
  - sprint-54-acceptance-yaml.yaml
  - sprint54-acceptance-yaml.yaml

## Test Plan
- Run acceptance tests against production URL to verify assertions pass

Closes #764

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only acceptance-test string assertions and a scheduler state snapshot, with no production code or data-flow changes.
> 
> **Overview**
> Updates Virtucorp acceptance test YAMLs to assert the **new brand name/logo** by replacing `AlphaArena` with `APL` in homepage/landing-page checks.
> 
> Also refreshes `.virtucorp/scheduler-state.json` `lastDispatch` metadata (`digestHash` and `timestamp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e9b47e147756f094bf0a10d87bfd7b4685431a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->