### PR TITLE
Fix #768: Add LocaleProvider to App component for language switcher

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,6 +31,7 @@ import ThemeToggle from './components/ThemeToggle';
 import SettingsPanel from './components/SettingsPanel';
 import NotificationCenter from './components/NotificationCenter';
 import { LanguageSwitcher } from './components/LanguageSwitcher'; // Issue #586
+import { LocaleProvider } from './i18n/LocaleProvider'; // Issue #768: P0 fix - wrap app with LocaleProvider
 import OfflineIndicator from './components/OfflineIndicator';
 import InstallPrompt from './components/InstallPrompt'; // Issue #628: PWA 安装提示
 import MobileBottomNav from './components/MobileBottomNav';
@@ -698,22 +699,25 @@ function App() {
     <SettingsProvider>
       <ConnectionProvider>
         <RealtimeConnectionSync />
-        <BrowserRouter>
-          <RouteRestorer />
-          <AppLayout>
-            <AppRoutes />
-          </AppLayout>
-          {/* Error reporter panel - shown when errors are captured */}
-          {hasErrors && (
-            <Suspense fallback={null}>
-              <ErrorReporterPanel
-                errors={errors}
-                onClear={clearErrors}
-                visible={process.env.NODE_ENV === 'development'}
-              />
-            </Suspense>
-          )}
-        </BrowserRouter>
+        {/* Issue #768: P0 fix - LocaleProvider wraps the entire app so LanguageSwitcher works on all pages */}
+        <LocaleProvider>
+          <BrowserRouter>
+            <RouteRestorer />
+            <AppLayout>
+              <AppRoutes />
+            </AppLayout>
+            {/* Error reporter panel - shown when errors are captured */}
+            {hasErrors && (
+              <Suspense fallback={null}>
+                <ErrorReporterPanel
+                  errors={errors}
+                  onClear={clearErrors}
+                  visible={process.env.NODE_ENV === 'development'}
+                />
+              </Suspense>
+            )}
+          </BrowserRouter>
+        </LocaleProvider>
       </ConnectionProvider>
     </SettingsProvider>
     </SubscriptionProvider>

--- a/tests/client/language-switcher-context.test.tsx
+++ b/tests/client/language-switcher-context.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Language Switcher Context Test (Issue #768)
+ * 
+ * P0 Bug: Language switch button not found on homepage
+ * Root cause: LocaleProvider was not wrapping the app, causing
+ * LanguageSwitcher component to fail when calling useLocaleContext()
+ * 
+ * This test verifies that LanguageSwitcher can render when LocaleProvider
+ * is properly provided in the component tree.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { LocaleProvider } from '../../src/client/i18n/LocaleProvider';
+import { LanguageSwitcher } from '../../src/client/components/LanguageSwitcher';
+import i18n from '../../src/client/i18n/index';
+import { act } from 'react-dom/test-utils';
+
+// Mock useAuth hook
+jest.mock('../../src/client/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({
+    isAuthenticated: false,
+    user: null,
+  })),
+}));
+
+describe('LanguageSwitcher Context (Issue #768)', () => {
+  beforeEach(async () => {
+    // Reset language to default before each test
+    await act(async () => {
+      await i18n.changeLanguage('zh-CN');
+    });
+  });
+
+  it('should fail to render without LocaleProvider (reproducing the bug)', async () => {
+    // This test reproduces the P0 bug - LanguageSwitcher crashes without LocaleProvider
+    // We expect it to throw an error
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    
+    expect(() => {
+      render(
+        <MemoryRouter>
+          <LanguageSwitcher />
+        </MemoryRouter>
+      );
+    }).toThrow('useLocaleContext must be used within a LocaleProvider');
+    
+    consoleError.mockRestore();
+  });
+
+  it('should render successfully with LocaleProvider', async () => {
+    // This test verifies the fix - LanguageSwitcher works when LocaleProvider wraps it
+    render(
+      <MemoryRouter>
+        <LocaleProvider>
+          <LanguageSwitcher />
+        </LocaleProvider>
+      </MemoryRouter>
+    );
+    
+    // Wait for i18n to initialize
+    await waitFor(() => {
+      // Should show a button with language icon
+      const button = screen.getByRole('button', { name: /切换语言/i });
+      expect(button).toBeInTheDocument();
+    }, { timeout: 10000 });
+  });
+
+  it('should render with data-testid for automated testing', async () => {
+    // Smoke tests use data-testid to find elements
+    render(
+      <MemoryRouter>
+        <LocaleProvider>
+          <LanguageSwitcher />
+        </LocaleProvider>
+      </MemoryRouter>
+    );
+    
+    await waitFor(() => {
+      // The button should have data-testid="language-selector"
+      const button = screen.getByTestId('language-selector');
+      expect(button).toBeInTheDocument();
+    }, { timeout: 10000 });
+  });
+
+  it('should render on landing page when LocaleProvider is present', async () => {
+    // Simulate landing page context - compact mode
+    render(
+      <MemoryRouter>
+        <LocaleProvider>
+          <LanguageSwitcher compact={true} />
+        </LocaleProvider>
+      </MemoryRouter>
+    );
+    
+    await waitFor(() => {
+      const button = screen.getByTestId('language-selector');
+      expect(button).toBeInTheDocument();
+    }, { timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #768 - P0 Bug: Language switch button not found on homepage

## Root Cause Analysis
- **Bug**: QA smoke test failed - language switch button could not be found on homepage
- **Investigation**: 
  1. Checked `LanguageSwitcher.tsx` - component uses `useLocaleContext()` hook
  2. Checked `App.tsx` - found that `LocaleProvider` was NOT wrapping the app
  3. Checked `LandingPage.tsx` - uses `LanguageSwitcher` but without provider context
  4. Reproduced locally: Without `LocaleProvider`, `useLocaleContext()` throws error
  5. Error message: `"useLocaleContext must be used within a LocaleProvider"`
  6. Component crash → button invisible → smoke test failed

## Fix
Added `LocaleProvider` to `App.tsx` provider chain:
- Import `LocaleProvider` from `./i18n/LocaleProvider`
- Wrap `<BrowserRouter>` and children with `<LocaleProvider>`
- Now `LanguageSwitcher` works on ALL pages (public + protected routes)

## Test Evidence
Added `language-switcher-context.test.tsx` with 4 tests:
1. **Bug reproduction**: Confirms `LanguageSwitcher` throws without `LocaleProvider`
2. **Fix verification**: Confirms `LanguageSwitcher` renders with `LocaleProvider`
3. **Test ID check**: Confirms `data-testid="language-selector"` is present (smoke test requirement)
4. **Compact mode**: Confirms works in landing page context

All tests pass ✅:
```
PASS tests/client/language-switcher-context.test.tsx
PASS tests/client/language-switcher.test.tsx  
PASS tests/client/LandingPage.test.tsx
```

## Files Changed
- `src/client/App.tsx`: Added LocaleProvider import and wrapper
- `tests/client/language-switcher-context.test.tsx`: New test file

## Impact
- **Before**: Language switcher crashed on homepage → P0 production bug
- **After**: Language switcher works on all pages → smoke tests should pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrapping the entire app in `LocaleProvider` changes initial render behavior (including potential full-screen i18n loading state) and affects all routes, so regressions would be broadly visible but the change is small and localized.
> 
> **Overview**
> Fixes Issue #768 by wrapping the `BrowserRouter` tree in `LocaleProvider` in `App.tsx`, ensuring `useLocaleContext()` is available everywhere and preventing the `LanguageSwitcher` from crashing/vanishing on pages like the homepage.
> 
> Adds `language-switcher-context.test.tsx` to both reproduce the failure without `LocaleProvider` and verify successful rendering (including `data-testid="language-selector"` and compact mode) when the provider is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c81bf4ab84f43668c77c867f452002066b0d718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->