### PR TITLE
fix(p0): Remove dead Railway WebSocket URL and update CORS configuration

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -15,7 +15,10 @@
 VITE_API_URL=https://plnylmnckssnfpwznpwf.supabase.co/functions/v1
 
 # WebSocket Configuration
-VITE_WS_URL=wss://alphaarena-production.up.railway.app
+# Note: WebSocket URL is optional - the app uses Supabase Realtime for real-time features
+# The legacy Railway WebSocket service has been decommissioned.
+# If needed in the future, configure a new WebSocket endpoint.
+# VITE_WS_URL=wss://your-websocket-server.example.com
 
 # Supabase Configuration
 VITE_SUPABASE_URL=https://plnylmnckssnfpwznpwf.supabase.co

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778539996692,
-    "consecutiveCount": 4
+    "timestamp": 1778540596760,
+    "consecutiveCount": 5
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778536396680,
-    "consecutiveCount": 2
+    "timestamp": 1778538796623,
+    "consecutiveCount": 3
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778534596575,
-    "consecutiveCount": 1
+    "timestamp": 1778536396680,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778515996638,
-    "consecutiveCount": 3
+    "timestamp": 1778524997017,
+    "consecutiveCount": 4
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778538796623,
-    "consecutiveCount": 3
+    "timestamp": 1778539996692,
+    "consecutiveCount": 4
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778524997017,
-    "consecutiveCount": 4
+    "timestamp": 1778533997089,
+    "consecutiveCount": 5
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778540596760,
-    "consecutiveCount": 5
+    "timestamp": 1778541797105,
+    "consecutiveCount": 6
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778541797105,
-    "consecutiveCount": 6
+    "timestamp": 1778542996793,
+    "consecutiveCount": 7
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778533997089,
-    "consecutiveCount": 5
+    "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
+    "timestamp": 1778534596575,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -35,7 +35,10 @@ Supabase Edge Functions 基于 Deno，不支持长时间运行的 Node.js 服务
 | Variable Name | Development | Production |
 |--------------|-------------|------------|
 | `VITE_API_URL` | `http://localhost:3001` | `https://plnylmnckssnfpwznpwf.supabase.co/functions/v1` |
-| `VITE_WS_URL` | `ws://localhost:3001` | `wss://alphaarena-production.up.railway.app` |
+| `VITE_SUPABASE_URL` | `https://plnylmnckssnfpwznpwf.supabase.co` | `https://plnylmnckssnfpwznpwf.supabase.co` |
+| `VITE_SUPABASE_ANON_KEY` | (从 Supabase Dashboard) | (从 Supabase Dashboard) |
+
+**注意**：WebSocket 功能已迁移至 Supabase Realtime，无需配置独立的 WebSocket URL。
 
 ### Supabase 环境变量
 

--- a/docs/deployment/DEPLOYMENT_CHECKLIST.md
+++ b/docs/deployment/DEPLOYMENT_CHECKLIST.md
@@ -12,11 +12,12 @@
 在 Vercel Dashboard → Settings → Environment Variables 中确认：
 
 - [ ] `VITE_API_URL` = `https://plnylmnckssnfpwznpwf.supabase.co/functions/v1`
-- [ ] `VITE_WS_URL` = `wss://alphaarena-production.up.railway.app`
 - [ ] `VITE_SUPABASE_URL` = `https://plnylmnckssnfpwznpwf.supabase.co`
 - [ ] `VITE_SUPABASE_ANON_KEY` = (从 Supabase Dashboard 获取)
 
 **重要**：确保这些变量在 **Production** 环境中设置，并且标记为 **Build** 变量。
+
+**注意**：WebSocket 功能已迁移至 Supabase Realtime，不再需要独立的 WebSocket 服务器。
 
 ### 3. Supabase 服务状态
 - [ ] Supabase 项目状态正常
@@ -24,10 +25,10 @@
 - [ ] 数据库迁移已应用
 - [ ] RLS (Row Level Security) 策略已配置
 
-### 4. Railway WebSocket 服务
-- [ ] WebSocket 服务正在运行
-- [ ] 健康检查端点响应正常
-- [ ] 连接数和资源使用在正常范围
+### 4. Supabase Realtime 服务
+- [ ] Supabase Realtime 正常工作
+- [ ] Broadcast channels 配置正确
+- [ ] Presence 功能正常
 
 ### 5. 依赖项检查
 - [ ] `package-lock.json` 已更新

--- a/docs/sdk/alphaarena-sdk.ts
+++ b/docs/sdk/alphaarena-sdk.ts
@@ -11,7 +11,7 @@
  *   
  *   const client = new AlphaArenaClient({
  *     apiKey: 'aa_live_xxxxx',
- *     baseUrl: 'https://alphaarena-production.up.railway.app'
+ *     baseUrl: 'https://plnylmnckssnfpwznpwf.supabase.co/functions/v1'
  *   });
  *   
  *   // Get account info
@@ -262,7 +262,7 @@ export class AlphaArenaClient {
     this.apiKey = config.apiKey;
     
     const axiosConfig: AxiosRequestConfig = {
-      baseURL: config.baseUrl || 'https://alphaarena-production.up.railway.app',
+      baseURL: config.baseUrl || 'https://plnylmnckssnfpwznpwf.supabase.co/functions/v1',
       timeout: config.timeout || 30000,
       headers: {
         'X-API-Key': this.apiKey,

--- a/public/sitemap-en-us.xml
+++ b/public/sitemap-en-us.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=en-US</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-ja-jp.xml
+++ b/public/sitemap-ja-jp.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=ja-JP</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-ko-kr.xml
+++ b/public/sitemap-ko-kr.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=ko-KR</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-zh-cn.xml
+++ b/public/sitemap-zh-cn.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://alphaarena.app/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/"/>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/landing</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/landing"/>
@@ -25,7 +25,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/register</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/register"/>
@@ -36,7 +36,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/login</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/login"/>
@@ -47,7 +47,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/leaderboard"/>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/subscription</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/subscription"/>
@@ -69,7 +69,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/docs/api"/>
@@ -80,7 +80,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-11</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/marketplace"/>

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -125,15 +125,18 @@ export interface APIServerConfig {
 }
 
 // Allowed origins for CORS
+// Note: Railway backend has been decommissioned - using Vercel + Supabase Edge Functions
 const ALLOWED_ORIGINS = [
-  'https://alphaarena-production.up.railway.app', // Backend itself
+  'https://alphaarena.app', // Production domain (when DNS is fixed)
+  'https://alphaarena.com', // Alternative production domain
+  'https://www.alphaarena.com', // Production domain with www
   'https://alphaarena.vercel.app', // Vercel production
   'https://alphaarena-eight.vercel.app', // Vercel production deployment
-  'https://alphaarena-hymr9xflt-gxcsoccer-s-team.vercel.app', // Vercel preview deployments
+  'https://alphaarena-gxcsoccer-s-team.vercel.app', // Vercel team deployment
+  'https://alphaarena-git-main-gxcsoccer-s-team.vercel.app', // Vercel main branch deployment
   'http://localhost:3000', // Local development
   'http://localhost:5173', // Vite dev server
   'https://*.vercel.app', // Wildcard for all Vercel deployments
-  'https://alpha-arena-*.vercel.app', // Wildcard for alpha-arena-* Vercel deployments
 ];
 
 /**

--- a/src/api/swaggerConfig.ts
+++ b/src/api/swaggerConfig.ts
@@ -77,8 +77,8 @@ All errors follow a consistent format:
         description: 'Current server (relative path)',
       },
       {
-        url: 'https://alphaarena-production.up.railway.app/api',
-        description: 'Production server',
+        url: 'https://plnylmnckssnfpwznpwf.supabase.co/functions/v1',
+        description: 'Production server (Supabase Edge Functions)',
       },
       {
         url: 'http://localhost:3001/api',

--- a/src/server-start.ts
+++ b/src/server-start.ts
@@ -18,13 +18,16 @@ console.log(`[Startup] Starting AlphaArena API server on port ${PORT}...`);
 const server = new APIServer({
   port: PORT,
   corsOrigin: [
-    'https://alphaarena-production.up.railway.app',
-    'https://alphaarena.vercel.app',
-    'https://alphaarena-eight.vercel.app',
-    'https://alphaarena-hymr9xflt-gxcsoccer-s-team.vercel.app',
-    'https://*.vercel.app',
-    'http://localhost:3000',
-    'http://localhost:5173',
+    'https://alphaarena.app', // Production domain (when DNS is fixed)
+    'https://alphaarena.com', // Alternative production domain
+    'https://www.alphaarena.com', // Production domain with www
+    'https://alphaarena.vercel.app', // Vercel production
+    'https://alphaarena-eight.vercel.app', // Vercel production deployment
+    'https://alphaarena-gxcsoccer-s-team.vercel.app', // Vercel team deployment
+    'https://alphaarena-git-main-gxcsoccer-s-team.vercel.app', // Vercel main branch deployment
+    'https://*.vercel.app', // Wildcard for all Vercel deployments
+    'http://localhost:3000', // Local development
+    'http://localhost:5173', // Vite dev server
   ],
 });
 


### PR DESCRIPTION
## 问题描述

Issue: #771 - 生产环境后端服务不可用 - Network Error

## 根因分析

1. **DNS 配置错误**: `alphaarena.app` 指向 Squarespace 停放页面，而非 Vercel
   - 需要 investor 在 Google Domains 修改 DNS 配置
   - A 记录应指向: `76.76.21.21`

2. **WebSocket URL 无效**: `VITE_WS_URL` 配置指向已下线的 Railway 服务
   - Railway WebSocket 服务返回 404 "Application not found"
   - WebSocket 功能已迁移至 Supabase Realtime

## 本次修复

虽然主要问题是 DNS 配置，但本次修复清理了过时的配置：

1. **移除无效 WebSocket URL**
   - 从 `.env.production` 移除 `VITE_WS_URL`
   - 从 Vercel 环境变量移除 `VITE_WS_URL`

2. **更新 CORS 配置**
   - 更新 `src/api/server.ts` 的 ALLOWED_ORIGINS
   - 更新 `src/server-start.ts` 的 corsOrigin 数组
   - 添加正确的生产域名

3. **更新文档**
   - `DEPLOYMENT.md`: 移除 WebSocket URL 配置说明
   - `DEPLOYMENT_CHECKLIST.md`: 替换 Railway WebSocket 检查为 Supabase Realtime
   - `docs/sdk/alphaarena-sdk.ts`: 更新默认 baseUrl

## 测试验证

- 客户端构建成功 (`npm run build:client`)
- 配置测试通过 (22 tests)

## 后续操作

DNS 修复需要 investor 在 Google Domains 执行：
- A 记录: `alphaarena.app` -> `76.76.21.21`
- CNAME: `www` -> `cname.vercel-dns.com`

临时访问: `https://alphaarena.vercel.app`（DNS 生效前）

## 相关 Issue

Fixes #771

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CORS allowlists and documented/default API endpoints, which can inadvertently block/allow origins or point clients to the wrong backend if misconfigured.
> 
> **Overview**
> Removes the legacy Railway WebSocket configuration from production env/docs and clarifies that real-time features now rely on Supabase Realtime.
> 
> Updates production endpoint references to Supabase Edge Functions (Swagger `servers`, public SDK default `baseUrl`) and refreshes the API server CORS allowlists to drop the decommissioned Railway origin and add current `alphaarena.*` and Vercel deployment domains. Also bumps sitemap `lastmod` dates and updates the internal scheduler state JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c7394aa39c367139765fb0224af9d96614b6675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->