### PR TITLE
[vc:scheduler] Auto-sync .virtucorp/ state files

### DIFF
--- a/.tmp/pr-body.md
+++ b/.tmp/pr-body.md
@@ -1,0 +1,48 @@
+## 问题描述
+
+Issue: #771 - 生产环境后端服务不可用 - Network Error
+
+## 根因分析
+
+1. **DNS 配置错误**: `alphaarena.app` 指向 Squarespace 停放页面，而非 Vercel
+   - 需要 investor 在 Google Domains 修改 DNS 配置
+   - A 记录应指向: `76.76.21.21`
+
+2. **WebSocket URL 无效**: `VITE_WS_URL` 配置指向已下线的 Railway 服务
+   - Railway WebSocket 服务返回 404 "Application not found"
+   - WebSocket 功能已迁移至 Supabase Realtime
+
+## 本次修复
+
+虽然主要问题是 DNS 配置，但本次修复清理了过时的配置：
+
+1. **移除无效 WebSocket URL**
+   - 从 `.env.production` 移除 `VITE_WS_URL`
+   - 从 Vercel 环境变量移除 `VITE_WS_URL`
+
+2. **更新 CORS 配置**
+   - 更新 `src/api/server.ts` 的 ALLOWED_ORIGINS
+   - 更新 `src/server-start.ts` 的 corsOrigin 数组
+   - 添加正确的生产域名
+
+3. **更新文档**
+   - `DEPLOYMENT.md`: 移除 WebSocket URL 配置说明
+   - `DEPLOYMENT_CHECKLIST.md`: 替换 Railway WebSocket 检查为 Supabase Realtime
+   - `docs/sdk/alphaarena-sdk.ts`: 更新默认 baseUrl
+
+## 测试验证
+
+- 客户端构建成功 (`npm run build:client`)
+- 配置测试通过 (22 tests)
+
+## 后续操作
+
+DNS 修复需要 investor 在 Google Domains 执行：
+- A 记录: `alphaarena.app` -> `76.76.21.21`
+- CNAME: `www` -> `cname.vercel-dns.com`
+
+临时访问: `https://alphaarena.vercel.app`（DNS 生效前）
+
+## 相关 Issue
+
+Fixes #771

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev_bugfix|bug:773|prs:0|ready:0|complete",
-    "timestamp": 1778547796850,
-    "consecutiveCount": 2
+    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
+    "timestamp": 1778548396820,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778539996692,
-    "consecutiveCount": 4
+    "timestamp": 1778540596760,
+    "consecutiveCount": 5
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778536396680,
-    "consecutiveCount": 2
+    "timestamp": 1778538796623,
+    "consecutiveCount": 3
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778586197185,
-    "consecutiveCount": 6
+    "timestamp": 1778593397310,
+    "consecutiveCount": 7
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778564596812,
-    "consecutiveCount": 3
+    "timestamp": 1778571796929,
+    "consecutiveCount": 4
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778544796892,
+    "digestHash": "spawn_dev_bugfix|bug:773|prs:0|ready:0|complete",
+    "timestamp": 1778545396804,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778534596575,
-    "consecutiveCount": 1
+    "timestamp": 1778536396680,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa|prs:1|ready:1|complete",
-    "timestamp": 1778593997548,
-    "consecutiveCount": 1
+    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
+    "timestamp": 1778524997017,
+    "consecutiveCount": 4
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778548396820,
-    "consecutiveCount": 1
+    "timestamp": 1778557396688,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:773|prs:0|ready:0|complete",
-    "timestamp": 1778545396804,
-    "consecutiveCount": 1
+    "timestamp": 1778547796850,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778538796623,
-    "consecutiveCount": 3
+    "timestamp": 1778539996692,
+    "consecutiveCount": 4
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778524997017,
-    "consecutiveCount": 4
+    "timestamp": 1778533997089,
+    "consecutiveCount": 5
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778540596760,
-    "consecutiveCount": 5
+    "timestamp": 1778541797105,
+    "consecutiveCount": 6
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778571796929,
-    "consecutiveCount": 4
+    "timestamp": 1778578997096,
+    "consecutiveCount": 5
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778557396688,
-    "consecutiveCount": 2
+    "timestamp": 1778564596812,
+    "consecutiveCount": 3
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778541797105,
-    "consecutiveCount": 6
+    "timestamp": 1778542996793,
+    "consecutiveCount": 7
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778593397310,
-    "consecutiveCount": 7
+    "digestHash": "spawn_dev|prs:0|ready:1|complete",
+    "timestamp": 1778594597145,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,7 +1,7 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev|prs:0|ready:1|complete",
-    "timestamp": 1778594597145,
+    "digestHash": "spawn_qa|prs:1|ready:0|complete",
+    "timestamp": 1778595197658,
     "consecutiveCount": 1
   },
   "highWaterMark": 54,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
-    "timestamp": 1778542996793,
-    "consecutiveCount": 7
+    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
+    "timestamp": 1778544796892,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778533997089,
-    "consecutiveCount": 5
+    "digestHash": "spawn_dev_bugfix|bug:771|prs:0|ready:1|complete",
+    "timestamp": 1778534596575,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_qa_smoke|prs:0|ready:0|complete",
-    "timestamp": 1778578997096,
-    "consecutiveCount": 5
+    "timestamp": 1778586197185,
+    "consecutiveCount": 6
   },
   "highWaterMark": 54,
   "paused": false,

--- a/public/sitemap-en-us.xml
+++ b/public/sitemap-en-us.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=en-US</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-ja-jp.xml
+++ b/public/sitemap-ja-jp.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=ja-JP</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-ko-kr.xml
+++ b/public/sitemap-ko-kr.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace?lang=ko-KR</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap-zh-cn.xml
+++ b/public/sitemap-zh-cn.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://alphaarena.app/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/landing</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/register</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/login</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/subscription</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://alphaarena.app/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/"/>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/landing</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/landing"/>
@@ -25,7 +25,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/register</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/register"/>
@@ -36,7 +36,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/login</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/login"/>
@@ -47,7 +47,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/leaderboard</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/leaderboard"/>
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/subscription</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/subscription"/>
@@ -69,7 +69,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/docs/api</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/docs/api"/>
@@ -80,7 +80,7 @@
   </url>
   <url>
     <loc>https://alphaarena.app/marketplace</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://alphaarena.app/marketplace"/>

--- a/src/client/utils/realtime.ts
+++ b/src/client/utils/realtime.ts
@@ -977,7 +977,23 @@ export class RealtimeClient {
         },
       });
 
-      if (response.ok) {
+      // Read response body to detect Cloudflare errors (can be HTTP 200 with error body)
+      const responseText = await response.text().catch(() => '');
+      
+      // Check for Cloudflare/infrastructure error patterns in response body
+      // Cloudflare errors like "error code: 1101" can be returned with HTTP 200
+      const isInfraErrorInBody = responseText.includes('error code: 1101') ||
+                                  responseText.includes('Worker threw exception') ||
+                                  responseText.includes('Cloudflare') ||
+                                  responseText.includes('Error 1101') ||
+                                  responseText.includes('Error 522') ||
+                                  responseText.includes('Error 524') ||
+                                  responseText.includes('520') ||
+                                  responseText.includes('521') ||
+                                  responseText.includes('523') ||
+                                  responseText.includes('524');
+      
+      if (response.ok && !isInfraErrorInBody) {
         this.serviceHealth.status = 'healthy';
         this.serviceHealth.errorMessage = null;
         this.notifyHealthListeners();
@@ -987,10 +1003,9 @@ export class RealtimeClient {
           message: 'Realtime service is healthy',
         };
       } else {
-        // Check if it's a Cloudflare/infrastructure error
-        const responseText = await response.text().catch(() => '');
-        const isInfraError = responseText.includes('Cloudflare') || 
-                            responseText.includes('Worker threw exception') ||
+        // It's an infrastructure error (either HTTP error or error in body)
+        const isInfraError = isInfraErrorInBody || 
+                            responseText.includes('Cloudflare') || 
                             response.status >= 520;
         
         const message = isInfraError
@@ -1002,6 +1017,11 @@ export class RealtimeClient {
         this.serviceHealth.status = 'down';
         this.serviceHealth.errorMessage = message;
         this.notifyHealthListeners();
+        
+        console.warn('[RealtimeClient] Realtime health check failed:', message);
+        if (isInfraErrorInBody) {
+          console.warn('[RealtimeClient] Response body:', responseText.trim());
+        }
         
         return {
           healthy: false,

--- a/src/client/utils/realtime.ts
+++ b/src/client/utils/realtime.ts
@@ -982,16 +982,21 @@ export class RealtimeClient {
       
       // Check for Cloudflare/infrastructure error patterns in response body
       // Cloudflare errors like "error code: 1101" can be returned with HTTP 200
+      // Use precise patterns to avoid false positives (e.g., timestamps, JSON numbers)
       const isInfraErrorInBody = responseText.includes('error code: 1101') ||
                                   responseText.includes('Worker threw exception') ||
                                   responseText.includes('Cloudflare') ||
                                   responseText.includes('Error 1101') ||
+                                  responseText.includes('Error 520') ||
+                                  responseText.includes('Error 521') ||
                                   responseText.includes('Error 522') ||
+                                  responseText.includes('Error 523') ||
                                   responseText.includes('Error 524') ||
-                                  responseText.includes('520') ||
-                                  responseText.includes('521') ||
-                                  responseText.includes('523') ||
-                                  responseText.includes('524');
+                                  responseText.includes('520 Web server') ||
+                                  responseText.includes('521 Web server') ||
+                                  responseText.includes('522 Connection timed out') ||
+                                  responseText.includes('523 Origin is unreachable') ||
+                                  responseText.includes('524 A timeout');
       
       if (response.ok && !isInfraErrorInBody) {
         this.serviceHealth.status = 'healthy';
@@ -1004,8 +1009,7 @@ export class RealtimeClient {
         };
       } else {
         // It's an infrastructure error (either HTTP error or error in body)
-        const isInfraError = isInfraErrorInBody || 
-                            responseText.includes('Cloudflare') || 
+        const isInfraError = isInfraErrorInBody ||
                             response.status >= 520;
         
         const message = isInfraError


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates client-side Realtime health checking logic, which can change when the app marks Supabase Realtime as down and falls back to polling; misclassification could degrade live updates. Other changes are mostly operational metadata (sitemaps, scheduler state, PR notes).
> 
> **Overview**
> Improves `RealtimeClient.checkServiceHealth()` to treat Cloudflare/infrastructure failures as unhealthy even when the health endpoint returns HTTP 200, by scanning the response body for specific error patterns and adding targeted warning logs.
> 
> Also updates generated/operational artifacts: bumps `public/sitemap*.xml` `lastmod` dates, syncs `.virtucorp/scheduler-state.json`, and adds a PR body note documenting the production outage root cause and follow-up DNS actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b372847f2823979c6bc3096083fb65a05a6a121f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->