### PR TITLE
[#786] DNS Configuration Fix Guide - alphaarena.app showing 'under construction'

### DIFF
--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
     "digestHash": "spawn_dev_bugfix|bug:786|prs:1|ready:0|complete",
-    "timestamp": 1778843954011,
-    "consecutiveCount": 1
+    "timestamp": 1778845754071,
+    "consecutiveCount": 2
   },
   "highWaterMark": 54,
   "paused": false,

--- a/.virtucorp/scheduler-state.json
+++ b/.virtucorp/scheduler-state.json
@@ -1,8 +1,8 @@
 {
   "lastDispatch": {
-    "digestHash": "spawn_dev_bugfix|bug:786|prs:0|ready:0|complete",
-    "timestamp": 1778843354549,
-    "consecutiveCount": 6
+    "digestHash": "spawn_dev_bugfix|bug:786|prs:1|ready:0|complete",
+    "timestamp": 1778843954011,
+    "consecutiveCount": 1
   },
   "highWaterMark": 54,
   "paused": false,

--- a/docs/deployment/DNS_FIX_GUIDE.md
+++ b/docs/deployment/DNS_FIX_GUIDE.md
@@ -1,0 +1,109 @@
+# DNS Configuration Fix for alphaarena.app
+
+## Problem Summary
+
+**Production URL (alphaarena.app) shows "under construction" page instead of the AlphaArena app.**
+
+This is NOT a code bug - it's a DNS configuration issue.
+
+## Root Cause
+
+The domain `alphaarena.app` is correctly configured in Vercel but has incorrect DNS nameservers:
+
+| Expected (Vercel) | Current (Google Cloud DNS) | Status |
+|-------------------|---------------------------|--------|
+| ns1.vercel-dns.com | ns-cloud-a1.googledomains.com | ❌ Wrong |
+| ns2.vercel-dns.com | ns-cloud-a2.googledomains.com | ❌ Wrong |
+
+Current DNS IPs point to Squarespace servers:
+- 198.185.159.145
+- 198.49.23.145
+- 198.185.159.144
+- 198.49.23.144
+
+These are Squarespace's parking page servers, which display "We're under construction."
+
+## Evidence
+
+```bash
+# HTTP headers show Squarespace server
+curl -I https://alphaarena.app
+# server: Squarespace
+
+# DNS lookup shows Squarespace IPs
+dig alphaarena.app +short
+# 198.185.159.145
+# 198.49.23.145
+# ...
+
+# Vercel domain inspection confirms nameserver mismatch
+vercel domains inspect alphaarena.app
+# WARNING! This Domain is not configured properly.
+```
+
+## Fix Instructions
+
+### Option A: Add A Record (Recommended - Faster)
+
+1. Go to your domain registrar (Google Domains or wherever alphaarena.app was purchased)
+2. Navigate to DNS settings
+3. Add an A record:
+   - **Host**: `@` (or `alphaarena.app`)
+   - **Type**: A
+   - **Value**: `76.76.21.21`
+   - **TTL**: 3600 (or default)
+4. Remove any existing A records pointing to Squarespace IPs
+5. Wait 5-30 minutes for DNS propagation
+
+### Option B: Change Nameservers (More Control)
+
+1. Go to your domain registrar
+2. Navigate to DNS settings
+3. Change nameservers to:
+   - **ns1.vercel-dns.com**
+   - **ns2.vercel-dns.com**
+4. Remove all custom DNS records
+5. Wait up to 48 hours for full propagation
+
+## Verification
+
+After making DNS changes, verify:
+
+```bash
+# Check DNS propagation
+dig alphaarena.app +short
+# Should show: 76.76.21.21
+
+# Check HTTP response
+curl -I https://alphaarena.app
+# Should show: server: Vercel
+
+# Visit the site
+open https://alphaarena.app
+# Should show AlphaArena app, not "under construction"
+```
+
+## Why This Happened
+
+The domain was likely:
+1. Purchased through Squarespace or configured with Squarespace DNS
+2. Squarespace set up their parking page as default
+3. When moved to Vercel, nameservers weren't updated
+
+## Related Files
+
+- `.vercel/project.json` - Vercel project configuration
+- `vercel.json` - Routing and build configuration
+- `.env.production` - Production environment variables
+
+## Status
+
+- **Vercel Project**: ✅ Correctly configured
+- **Vercel Deployment**: ✅ Working (preview URLs work)
+- **Domain Assignment**: ✅ `alphaarena.app` assigned to `alphaarena` project
+- **DNS Nameservers**: ❌ Wrong (pointing to Google/Squarespace)
+
+---
+
+**Last Updated**: 2026-05-15
+**Related Issue**: #786


### PR DESCRIPTION
## Summary

This PR provides comprehensive documentation for resolving the production issue where `alphaarena.app` shows "under construction" page instead of the AlphaArena app.

## Root Cause Analysis

**This is NOT a code bug** - it's a DNS configuration issue.

### Evidence Collected

1. **HTTP Response Shows Squarespace Server**:
   ```
   curl -I https://alphaarena.app
   server: Squarespace
   ```

2. **DNS Lookup Shows Squarespace IPs**:
   ```
   dig alphaarena.app +short
   198.185.159.145
   198.49.23.145
   198.185.159.144
   198.49.23.144
   ```

3. **Vercel Domain Inspection Shows Nameserver Mismatch**:
   ```
   Intended Nameservers    Current Nameservers                   
   ns1.vercel-dns.com      ns-cloud-a1.googledomains.com    ✘    
   ns2.vercel-dns.com      ns-cloud-a2.googledomains.com    ✘    
   ```

4. **Vercel Deployment is Correct**:
   - Project `alphaarena` is configured correctly
   - Domain `alphaarena.app` is assigned to the project
   - Build output contains proper AlphaArena HTML
   - Preview deployments work correctly

### What's Happening

The domain `alphaarena.app` DNS records are pointing to Squarespace's servers instead of Vercel. This causes all traffic to be routed to Squarespace's parking page, which displays "We're under construction. Please check back for an update soon."

### Fix Required

This requires **manual DNS configuration changes** at the domain registrar level:

**Option A (Recommended - Faster)**:
- Add A record: `alphaarena.app → 76.76.21.21`
- Remove existing A records pointing to Squarespace IPs

**Option B (More Control)**:
- Change nameservers to: `ns1.vercel-dns.com`, `ns2.vercel-dns.com`

## Files Changed

- `docs/deployment/DNS_FIX_GUIDE.md` - Comprehensive DNS fix instructions

## Verification After Fix

```bash
# Check DNS propagation
dig alphaarena.app +short
# Should show: 76.76.21.21

# Check HTTP response
curl -I https://alphaarena.app
# Should show: server: Vercel

# Visit the site
open https://alphaarena.app
# Should show AlphaArena app
```

## Why Previous Attempts Failed

Previous attempts likely tried to fix this through code changes, which cannot resolve DNS configuration issues. This documentation provides the correct path to resolution.

---

**Related Issue**: #786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change plus an internal scheduler state update; no runtime code paths or production behavior are modified by this PR.
> 
> **Overview**
> Adds `docs/deployment/DNS_FIX_GUIDE.md` with step-by-step instructions to resolve `alphaarena.app` serving a Squarespace “under construction” page by correcting DNS (A record to `76.76.21.21` or switching nameservers) and includes verification commands.
> 
> Updates `.virtucorp/scheduler-state.json` dispatch metadata (hash/timestamp/counter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78192872ce1ea8102f128deee2394508ee074ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->